### PR TITLE
suite2p wrapper and mocked test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: |
             pip install flake8
             # `|| true` to force exit code 0 even if no files found
-            CHANGED_PYFILES=$(git diff --name-only origin/master | grep .py || true)
+            CHANGED_PYFILES=$(git diff --diff-filter=AMR --name-only origin/master | grep .py || true)
             echo "List of changed files:"
             echo ${CHANGED_PYFILES}
             echo ${CHANGED_PYFILES} | xargs -r flake8 --count

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             pip install .
             # pytest would be a dep in requirements.txt
-            python -m pytest --cov ophys_etl_pipelines --cov-report xml
+            python -m pytest --cov ophys_etl --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
           name: Test
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: |
             pip install flake8
             # `|| true` to force exit code 0 even if no files found
-            CHANGED_PYFILES=$(git diff --diff-filter=AMR --name-only origin/master | grep .py || true)
+            CHANGED_PYFILES=$(git diff --diff-filter AMR --name-only origin/master | grep .py || true)
             echo "List of changed files:"
             echo ${CHANGED_PYFILES}
             echo ${CHANGED_PYFILES} | xargs -r flake8 --count

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - python/save-cache
       - run:
           command: |
+            pip install .
             # pytest would be a dep in requirements.txt
             python -m pytest --cov ophys_etl_pipelines --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy
 scipy
 pytest
 pytest-cov
+argschema==2.0.1
+h5py

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -149,10 +149,14 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
         return data
 
 
+class ExistingFile(argschema.fields.InputFile):
+    pass
+
+
 class Suite2PWrapperOutputSchema(argschema.schemas.DefaultSchema):
     output_files = argschema.fields.Dict(
         keys=argschema.fields.Str,
-        values=argschema.fields.InputFile,
+        values=ExistingFile,
         required=True,
         description="retained output files from Suite2P")
 

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -123,7 +123,7 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
             argschema.fields.Str,
             cli_as_single_argument=True,
             required=True,
-            default=['stat.npy'],
+            default=['stat.npy', 'F.npy'],
             description=("only Suite2P output files with basenames in this "
                          "list will be retained. If 'all', a complete list "
                          "will be retained."))

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -14,29 +14,39 @@ class Suite2PWrapperException(Exception):
 
 
 class Suite2PWrapperSchema(argschema.ArgSchema):
-    # Options for running s2p. One list can be found at:
-    # https://github.com/MouseLand/suite2p/blob/master/suite2p/run_s2p.py
+    """
+    s2p parameter names are copied from:
+    https://github.com/MouseLand/suite2p/blob/master/suite2p/run_s2p.py
+    descriptions here should indicate why certain default setting
+    choices have been made for Allen production.
+    """
 
     # s2p IO settings (file paths)
     h5py = argschema.fields.InputFile(
             required=True,
-            description="Path to 2P motion corrected hdf5 data path.")
+            description=("Path to input video. In Allen production case, "
+                         "assumed to be motion-corrected."))
     h5py_key = argschema.fields.Str(
             required=False,
             missing="data",
             default="data",
-            description="hdf5 file key for motion corrected dataset.")
+            description="key in h5py where data array is stored")
     # s2p registration settings
     do_registration = argschema.fields.Int(
             default=0,
-            description="0 skips registration, as we are doing our own.")
+            description=("0 skips registration (not well-documented). In "
+                         "Allen production case, we are providing motion-"
+                         "corrected videos, so we skip Suite2P's own "
+                         "registration."))
     # s2p cell detection settings
     roidetect = argschema.fields.Bool(
             default=True,
-            description="Whether or not to run ROI extraction.")
+            description=("Whether or not to run ROI extraction. This is the "
+                         "main role of Suite2P in Allen production."))
     sparse_mode = argschema.fields.Bool(
             default=True,
-            description="Whether or not to run 'sparse mode'.")
+            description=("From conversation with authors, True is the "
+                         "preferred mode."))
     diameter = argschema.fields.Int(
             default=12,
             description=("If not sparse_mode, use diameter (presumably "
@@ -44,52 +54,68 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
     spatial_scale = argschema.fields.Int(
             default=0,
             description=("0: multi-scale; 1: 6 pix; 2: 12 pix;"
-                         "3: 24 pix; 4: 48 pix"))
+                         "3: 24 pix; 4: 48 pix. From conversation with "
+                         "authors, 0 is the preferred mode."))
     connected = argschema.fields.Bool(
             default=True,
-            description="Whether to keep ROIs fully connected.")
+            description=("Whether to keep ROIs fully connected. This is "
+                         "Suite2P default."))
     nbinned = argschema.fields.Int(
             required=False,
-            description="Max num of binned frames for cell detection.")
+            description=("Max num of binned frames for cell detection. Below "
+                         "is an Allen-specific parameter `bin_size` from "
+                         "which this setting is derived, if not provided."))
     max_iterations = argschema.fields.Int(
             default=20,
-            description="Max num iterations to detect cells.")
+            description="Max num iterations to detect cells. Suite2P default")
     threshold_scaling = argschema.fields.Float(
             default=0.75,
             description=("Adjust automatically determined threshold by this "
-                         "scalar multiplier"))
+                         "scalar multiplier. From an extensive validation "
+                         "effort, we found that 0.75 segmented expected cells "
+                         "but higher values tended to miss some. A fair "
+                         "number of non-cells also are segmented, and need "
+                         "to be filtered by a classifier."))
     max_overlap = argschema.fields.Float(
             default=0.75,
             description=("Cells with more overlap than this get removed "
-                         "during triage, before refinement"))
+                         "during triage, before refinement. Suite2P default."))
     high_pass = argschema.fields.Int(
             default=100,
             description=("Running mean subtraction with window of "
-                         "size 'high_pass'"))
+                         "size 'high_pass'. Suite2P default."))
     smooth_masks = argschema.fields.Bool(
             default=True,
             description=("Whether to smooth masks in final pass of cell "
                          "detection. Especially useful if one is in a high "
-                         "noise regime."))
+                         "noise regime. It appears this is only applicable "
+                         "with sparse_mode=False, which is not our default."))
     # s2p ROI extraction parameters
     inner_neuropil_radius = argschema.fields.Int(
             default=2,
             description=("Number of pixels to keep between ROI and neuropil "
-                         "donut."))
+                         "donut. "
+                         "Allen production will run it's own neuropil "
+                         "subtraction routine."))
     min_neuropil_pixels = argschema.fields.Int(
             default=350,
-            description=("Minimum number of pixels in the neuropil."))
+            description=("Minimum number of pixels in the neuropil."
+                         "Allen production will run it's own neuropil "
+                         "subtraction routine."))
     allow_overlap = argschema.fields.Bool(
             # NOTE: changing this from extraction validation and labeling
             # will be untangled downstream in demixing.
             default=True,
             description=("Pixels that are overlapping are thrown out (False) "
-                         "or added to both ROIs (True)"))
+                         "or added to both ROIs (True). Allen production will "
+                         "run a demixing step that should allow both ROIs "
+                         "to share pixels."))
     # Allen-specific options
     bin_size = argschema.fields.Int(
             required=False,
             description=("If nbinned not provided, will calculate nbinned as "
-                         "nframes / bin_size"))
+                         "nframes / bin_size. This allows consistent temporal "
+                         "downsampling across movies of different lengths."))
     output_dir = argschema.fields.OutputDir(
             required=True,
             description="for minimal and cleaner output, specifies output dir")
@@ -104,7 +130,8 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
     timestamp = argschema.fields.Bool(
             default=True,
             description=("if true, will add a timestamp to the output file "
-                         "names"))
+                         "names. "
+                         "<basename>.<ext> -> <basename>_<timestamp>.<ext>"))
 
     @mm.post_load
     def check_args(self, data, **kwargs):

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -4,7 +4,7 @@ import pathlib
 import marshmallow as mm
 import h5py
 import tempfile
-from typing import List
+from typing import List, Optional
 import datetime
 import shutil
 
@@ -157,8 +157,9 @@ class Suite2PWrapperOutputSchema(argschema.schemas.DefaultSchema):
         description="retained output files from Suite2P")
 
 
-def copy_and_add_uid(srcdir: pathlib.Path, dstdir: pathlib.Path,
-                     basenames: List[str], uid: str = None) -> List[str]:
+def copy_and_add_uid(
+        srcdir: pathlib.Path, dstdir: pathlib.Path,
+        basenames: List[str], uid: Optional[str] = None) -> List[str]:
     """copy files matching basenames from a tree search of srcdir to
     dstdir with an optional unique id inserted into the basename.
 

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -125,7 +125,7 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
 class Suite2PWrapperOutputSchema(argschema.schemas.DefaultSchema):
     output_files = argschema.fields.Dict(
         keys=argschema.fields.Str,
-        values=argschema.fields.OutputFile,
+        values=argschema.fields.InputFile,
         required=True,
         description="retained output files from Suite2P")
 

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -219,8 +219,11 @@ class Suite2PWrapper(argschema.ArgSchemaParser):
         # make a tempdir for Suite2P's output
         with tempfile.TemporaryDirectory() as tdir:
             self.args['save_path0'] = tdir
+            self.logger.info(f"Running Suite2P with output going to {tdir}")
             suite2p.run_s2p.run_s2p(self.args)
 
+            self.logger.info(f"Suite2P complete. Copying output from {tdir} "
+                             f"to {self.args['output_dir']}")
             # copy over specified retained files to the output dir
             odir = pathlib.Path(self.args['output_dir'])
             odir.mkdir(parents=True, exist_ok=True)

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -1,0 +1,220 @@
+import argschema
+import suite2p
+import logging
+import pathlib
+import marshmallow as mm
+import h5py
+import tempfile
+from typing import List
+import datetime
+import shutil
+
+
+class Suite2PWrapperException(Exception):
+    pass
+
+
+class Suite2PWrapperSchema(argschema.ArgSchema):
+    # Options for running s2p. One list can be found at:
+    # https://github.com/MouseLand/suite2p/blob/master/suite2p/run_s2p.py
+
+    # s2p IO settings (file paths)
+    h5py = argschema.fields.InputFile(
+            required=True,
+            description="Path to 2P motion corrected hdf5 data path.")
+    h5py_key = argschema.fields.Str(
+            required=False,
+            missing="data",
+            default="data",
+            description="hdf5 file key for motion corrected dataset.")
+    # s2p registration settings
+    do_registration = argschema.fields.Int(
+            default=0,
+            description="0 skips registration, as we are doing our own.")
+    # s2p cell detection settings
+    roidetect = argschema.fields.Bool(
+            default=True,
+            description="Whether or not to run ROI extraction.")
+    sparse_mode = argschema.fields.Bool(
+            default=True,
+            description="Whether or not to run 'sparse mode'.")
+    diameter = argschema.fields.Int(
+            default=12,
+            description=("If not sparse_mode, use diameter (presumably "
+                         "in pixels) for filtering and extracting."))
+    spatial_scale = argschema.fields.Int(
+            default=0,
+            description=("0: multi-scale; 1: 6 pix; 2: 12 pix;"
+                         "3: 24 pix; 4: 48 pix"))
+    connected = argschema.fields.Bool(
+            default=True,
+            description="Whether to keep ROIs fully connected.")
+    nbinned = argschema.fields.Int(
+            required=False,
+            description="Max num of binned frames for cell detection.")
+    max_iterations = argschema.fields.Int(
+            default=20,
+            description="Max num iterations to detect cells.")
+    threshold_scaling = argschema.fields.Float(
+            default=0.75,
+            description=("Adjust automatically determined threshold by this "
+                         "scalar multiplier"))
+    max_overlap = argschema.fields.Float(
+            default=0.75,
+            description=("Cells with more overlap than this get removed "
+                         "during triage, before refinement"))
+    high_pass = argschema.fields.Int(
+            default=100,
+            description=("Running mean subtraction with window of "
+                         "size 'high_pass'"))
+    smooth_masks = argschema.fields.Bool(
+            default=True,
+            description=("Whether to smooth masks in final pass of cell "
+                         "detection. Especially useful if one is in a high "
+                         "noise regime."))
+    # s2p ROI extraction parameters
+    inner_neuropil_radius = argschema.fields.Int(
+            default=2,
+            description=("Number of pixels to keep between ROI and neuropil "
+                         "donut."))
+    min_neuropil_pixels = argschema.fields.Int(
+            default=350,
+            description=("Minimum number of pixels in the neuropil."))
+    allow_overlap = argschema.fields.Bool(
+            # NOTE: changing this from extraction validation and labeling
+            # will be untangled downstream in demixing.
+            default=True,
+            description=("Pixels that are overlapping are thrown out (False) "
+                         "or added to both ROIs (True)"))
+    # Allen-specific options
+    bin_size = argschema.fields.Int(
+            required=False,
+            description=("If nbinned not provided, will calculate nbinned as "
+                         "nframes / bin_size"))
+    output_dir = argschema.fields.OutputDir(
+            required=True,
+            description="for minimal and cleaner output, specifies output dir")
+    retain_files = argschema.fields.List(
+            argschema.fields.Str,
+            cli_as_single_argument=True,
+            required=True,
+            default=['stat.npy'],
+            description=("only Suite2P output files with basenames in this "
+                         "list will be retained. If 'all', a complete list "
+                         "will be retained."))
+    timestamp = argschema.fields.Bool(
+            default=True,
+            description=("if true, will add a timestamp to the output file "
+                         "names"))
+
+    @mm.post_load
+    def check_args(self, data, **kwargs):
+        if ('nbinned' not in data) & ('bin_size' not in data):
+            raise Suite2PWrapperException(
+                    "must provide either `nbinned` or `bin_size`")
+        return data
+
+    @mm.post_load
+    def check_retain_files(self, data, **kwargs):
+        if 'all' in data['retain_files']:
+            data['retain_files'] = [
+                    'ops1.npy', 'data.bin', 'Fneu.npy', 'F.npy', 'iscell.npy',
+                    'ops.npy', 'spks.npy', 'stat.npy']
+        return data
+
+
+class Suite2PWrapperOutputSchema(argschema.schemas.DefaultSchema):
+    output_files = argschema.fields.Dict(
+        keys=argschema.fields.Str,
+        values=argschema.fields.OutputFile,
+        required=True,
+        description="retained output files from Suite2P")
+
+
+def copy_and_add_uid(srcdir: pathlib.Path, dstdir: pathlib.Path,
+                       basenames: List[str], uid: str = None) -> List[str]:
+    """copy files matching basenames from a tree search of srcdir to
+    dstdir with an optional unique id inserted into the basename.
+
+    Parameters
+    ----------
+    srcdir : pathlib.Path
+       source directory
+    dstdir : pathlib.Path
+       destination directory
+    basenames : list
+        list of basenames to copy
+    uid : str
+        uid to insert into basename (example a timestamp string)
+
+    Returns
+    -------
+    copied_files : dict
+        keys are basenames and vaues are output paths as strings
+
+    """
+
+    copied_files = {}
+
+    for basename in basenames:
+        result = list(srcdir.rglob(basename))
+        if len(result) != 1:
+            raise ValueError(f"{len(result)} matches found in {srcdir} "
+                             f"for {basename}. Expected 1 match.")
+        dstbasename = result[0].name
+        if uid is not None:
+            dstbasename = result[0].stem + f"_{uid}" + result[0].suffix
+
+        dstfile = dstdir / dstbasename
+
+        shutil.copyfile(result[0], dstfile)
+
+        copied_files[basename] = str(dstfile)
+
+    return copied_files
+
+
+class Suite2PWrapper(argschema.ArgSchemaParser):
+    default_schema = Suite2PWrapperSchema
+    default_output_schema = Suite2PWrapperOutputSchema
+
+    def run(self):
+        self.logger.name = type(self).__name__
+        self.logger.setLevel(self.args.pop('log_level'))
+
+        # determine nbinned from bin_size
+        if 'nbinned' not in self.args:
+            with h5py.File(self.args['h5py'], 'r') as f:
+                nframes = f['data'].shape[0]
+            self.args['nbinned'] = int(nframes / self.args['bin_size'])
+            self.logger.info(f"movie has {nframes} frames. Setting nbinned "
+                             f"to {self.args['nbinned']}")
+
+        # make a tempdir for Suite2P's output
+        with tempfile.TemporaryDirectory() as tdir:
+            self.args['save_path0'] = tdir
+            suite2p.run_s2p.run_s2p(self.args)
+
+            # copy over specified retained files to the output dir
+            odir = pathlib.Path(self.args['output_dir'])
+            odir.mkdir(parents=True, exist_ok=True)
+            self.now = None
+            if self.args['timestamp']:
+                self.now = datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')
+            output_files = copy_and_add_uid(
+                    pathlib.Path(tdir),
+                    odir,
+                    self.args['retain_files'],
+                    self.now)
+            for k, v in output_files.items():
+                self.logger.info(f"wrote {k} to {v}")
+
+        outdict = {
+                'output_files': output_files
+                }
+        self.output(outdict, indent=2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    s2pw = Suite2PWrapper()
+    s2pw.run()

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -1,6 +1,5 @@
 import argschema
 import suite2p
-import logging
 import pathlib
 import marshmallow as mm
 import h5py
@@ -132,7 +131,7 @@ class Suite2PWrapperOutputSchema(argschema.schemas.DefaultSchema):
 
 
 def copy_and_add_uid(srcdir: pathlib.Path, dstdir: pathlib.Path,
-                       basenames: List[str], uid: str = None) -> List[str]:
+                     basenames: List[str], uid: str = None) -> List[str]:
     """copy files matching basenames from a tree search of srcdir to
     dstdir with an optional unique id inserted into the basename.
 

--- a/tests/pipelines/test_dummy_1.py
+++ b/tests/pipelines/test_dummy_1.py
@@ -1,2 +1,0 @@
-def test_dummy_1():
-    assert True

--- a/tests/transforms/test_dummy_2.py
+++ b/tests/transforms/test_dummy_2.py
@@ -1,2 +1,0 @@
-def test_dummy_2():
-    assert True

--- a/tests/transforms/test_suite2p_wrapper.py
+++ b/tests/transforms/test_suite2p_wrapper.py
@@ -1,0 +1,137 @@
+import pytest
+from unittest.mock import MagicMock, Mock
+from pathlib import Path
+from functools import partial
+import os
+import numpy as np
+import h5py
+import json
+import filecmp
+import random
+
+import sys
+sys.modules['suite2p'] = Mock()
+from ophys_etl.transforms import suite2p_wrapper # noqa
+
+suite2p_basenames = ['ops1.npy', 'data.bin', 'Fneu.npy', 'F.npy', 'iscell.npy',
+                     'ops.npy', 'spks.npy', 'stat.npy']
+
+
+@pytest.mark.parametrize(
+        "basenames, dstsubdir, exception",
+        [
+            (['tmp.txt'], "other", False),
+            (['tmp.txt', "tmp2.txt"], "other", False),
+            (['tmp.txt', "tmp.txt"], "other", True),
+            ])
+def test_copy_and_add_uid(tmp_path, basenames, dstsubdir, exception):
+    srcfiles = {}
+    for i, bname in enumerate(basenames):
+        if i == 0:
+            tfile = tmp_path / bname
+        else:
+            spath = tmp_path / "sub_dir"
+            spath.mkdir(exist_ok=True)
+            tfile = spath / bname
+        with open(tfile, "w") as f:
+            f.write("%032x" % random.getrandbits(128))
+        srcfiles[bname] = str(tfile)
+
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    uid = "extra"
+    if exception:
+        with pytest.raises(ValueError):
+            dstfiles = suite2p_wrapper.copy_and_add_uid(
+                    tmp_path,
+                    other_dir,
+                    basenames,
+                    uid)
+    else:
+        dstfiles = suite2p_wrapper.copy_and_add_uid(
+                tmp_path,
+                other_dir,
+                basenames,
+                uid)
+
+        for bname in basenames:
+            src = Path(srcfiles[bname])
+            dst = Path(dstfiles[bname])
+            assert filecmp.cmp(src, dst)
+            assert dst.name == src.stem + f"_{uid}" + src.suffix
+
+
+def suite2p_side_effect(args):
+    """write the suite2p files at various depths
+    """
+
+    basedir = Path(args['save_path0'])
+    nest1 = basedir / "nest1"
+    nest2 = nest1 / "nest2"
+    nest2.mkdir(parents=True)
+
+    for bdir, flims in zip([basedir, nest1, nest2], [(0, 2), (2, 6), (6, 8)]):
+        for i in range(flims[0], flims[1]):
+            outfile = bdir / suite2p_basenames[i]
+            with open(outfile, "w") as f:
+                f.write('content')
+
+
+@pytest.mark.parametrize(
+        "retain_files, nbinned, bin_size, exception",
+        [
+            ([['stat.npy'], 10, None, False]),
+            ([['stat.npy'], None, 10, False]),
+            ([['stat.npy'], None, None, True]),
+            ([['stat.npy', 'F.npy'], None, None, True]),
+            ([['all'], 10, None, False]),
+            ])
+def test_suite2p_wrapper(
+        tmp_path, monkeypatch, retain_files, nbinned, bin_size, exception):
+    nframes = 100
+    input_file = tmp_path / "input.h5py"
+    with h5py.File(input_file, "w") as f:
+        f.create_dataset('data', data=np.zeros((nframes, 34, 45)))
+
+    args = {
+            'h5py': str(input_file),
+            'output_dir': str(tmp_path / "output"),
+            'output_json': str(tmp_path / "output.json"),
+            'retain_files': retain_files
+            }
+
+    if nbinned is not None:
+        args['nbinned'] = nbinned
+    if bin_size is not None:
+        args['bin_size'] = bin_size
+
+    mock_suite2p = MagicMock()
+    mock_suite2p.run_s2p.run_s2p = MagicMock()
+    mock_suite2p.run_s2p.run_s2p.side_effect = suite2p_side_effect
+
+    mpatcher = partial(monkeypatch.setattr, target=suite2p_wrapper)
+    mpatcher(name="suite2p", value=mock_suite2p)
+    if exception:
+        with pytest.raises(suite2p_wrapper.Suite2PWrapperException):
+            s = suite2p_wrapper.Suite2PWrapper(input_data=args, args=[])
+        return
+
+    s = suite2p_wrapper.Suite2PWrapper(input_data=args, args=[])
+    s.run()
+
+    if bin_size is not None:
+        assert s.args['nbinned'] == int(nframes / bin_size)
+
+    assert os.path.isfile(args['output_json'])
+    with open(args['output_json'], 'r') as f:
+        outj = json.load(f)
+
+    file_list = retain_files
+    if 'all' in retain_files:
+        file_list = suite2p_basenames
+
+    for fname in file_list:
+        assert fname in list(outj['output_files'].keys())
+        assert os.path.isfile(outj['output_files'][fname])
+        assert s.now in outj['output_files'][fname]

--- a/tests/transforms/test_suite2p_wrapper.py
+++ b/tests/transforms/test_suite2p_wrapper.py
@@ -42,7 +42,7 @@ def test_copy_and_add_uid(tmp_path, basenames, dstsubdir, exception):
 
     uid = "extra"
     if exception:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r".* Expected 1 match."):
             dstfiles = suite2p_wrapper.copy_and_add_uid(
                     tmp_path,
                     other_dir,
@@ -113,7 +113,8 @@ def test_suite2p_wrapper(
     mpatcher = partial(monkeypatch.setattr, target=suite2p_wrapper)
     mpatcher(name="suite2p", value=mock_suite2p)
     if exception:
-        with pytest.raises(suite2p_wrapper.Suite2PWrapperException):
+        with pytest.raises(suite2p_wrapper.Suite2PWrapperException,
+                           match=r".*`nbinned`.*"):
             s = suite2p_wrapper.Suite2PWrapper(input_data=args, args=[])
         return
 


### PR DESCRIPTION
## Summary
This PR establishes a wrapper of Suite2P. This repo does not have a Suite2P dependency, we plan to run containers that have Suite2P installed (upcoming work). Suite2P is mocked for the test of this wrapper.

## Not covered by this PR:
* dockerfile and/or singularity def file for installed Suite2P
* handling the hard-coded classifier_path in Suite2P (will be done in-container or via a PR to Suite2P)

## Functionality from wrapper
* argschema-validated inputs and outputs
* additional Allen-specific args:
    1. `bin_size`: we found that specifying `bin_size` rather than `nbinned` was good for our data. We calculate nbinned from `bin_size` and the number of frames in a video.
    2. `output_dir` : Suite2P likes to save files to `save_path0` which has nested structure. This implementation copies the output files to a flat directory. The output_json is a dictionary for the full path of the ouputs based on the established Suite2P basenames of their output files. This should be flexible enough if we want to introduce nested structure or multiple destination sinks in the future.
    3. `retain_files` is a list of files to keep. The rest are thrown away with the temporary directory sent to Suite2P as `save_path0`. This lets us keep just what we want on disk.
    4. `timestamp` all the suite2p basenames `<basename>.<suffix>` are renamed optionally as `<basename>_<timestamp>.<suffix>`.

## Example for running
In an environment with Suite2P installed, with this repo installed on top of it:
```
python -m ophys_etl.transforms.suite2p_wrapper \
    --h5py /allen/aibs/informatics/labeling_artifacts/truncated_ophys_experiment_840460366.h5 \
    --output_dir $PWD/tmp3 \
    --bin_size 115 \
    --output_json output.json \
    --retain_files "['stat.npy', 'F.npy']" \
    --log_level INFO
```
Some wrapper specific logging results:
```
INFO:Suite2PWrapper:movie has 2000 frames. Setting nbinned to 17

<snipped Suite2P output>

INFO:Suite2PWrapper:wrote stat.npy to /home/danielk/ophys_etl_pipelines/tmp3/stat_20200623171313366779.npy
INFO:Suite2PWrapper:wrote F.npy to /home/danielk/ophys_etl_pipelines/tmp3/F_20200623171313366779.npy
```
and the contents of `output.json` are:
```
  "output_files": {
    "stat.npy": "/home/danielk/ophys_etl_pipelines/tmp3/stat_20200623171313366779.npy",
    "F.npy": "/home/danielk/ophys_etl_pipelines/tmp3/F_20200623171313366779.npy"
  }
}
```