### PR TITLE
Model registry table and connection API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,7 @@ dmypy.json
 cython_debug/
 
 # VS code
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/deploy/registry-template.yml
+++ b/deploy/registry-template.yml
@@ -1,0 +1,26 @@
+# Creates a DynamoDB table to store active classifier models
+
+AWSTemplateFormatVersion: "2010-09-09"
+
+Resources: 
+  modelRegistryTable: 
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - 
+          AttributeName: "model_name"
+          AttributeType: "S"
+        - 
+          AttributeName: "timestamp"
+          AttributeType: "N"
+      BillingMode: "PAY_PER_REQUEST"
+      KeySchema:
+        - 
+          AttributeName: "model_name"
+          KeyType: "HASH"
+        - 
+          AttributeName: "timestamp"
+          KeyType: "RANGE"
+      PointInTimeRecoverySpecification: 
+        PointInTimeRecoveryEnabled: true
+      TableName: "ROIClassifierRegistry"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ argschema==2.0.1
 h5py
 matplotlib
 pandas
+moto
+boto3

--- a/src/ophys_etl/transforms/registry.py
+++ b/src/ophys_etl/transforms/registry.py
@@ -1,0 +1,218 @@
+import boto3
+from typing import Optional, Union
+import time
+
+
+class RegistryConnection(object):
+    def __init__(
+            self,
+            table_name: str,
+            aws_access_key_id: Optional[str] = None,
+            aws_secret_access_key: Optional[str] = None,
+            aws_session_token: Optional[str] = None):
+        """
+        Instantiate a connection to the dynamoDB table used as a model
+        registry.
+        
+        Parameters
+        ----------
+        table_name: str
+            The name of the DynamoDB table containing the registry
+        aws_access_key_id: Optional[str]
+            Access key id for AWS account. If not used, will discover
+            credentials according to the discovery order in boto3 (e.g. 
+            environment variables, ~/.aws/credentials file)
+            https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html    # noqa
+        aws_secret_access_key: Optional[str]
+            Secret access key for AWS account. See `aws_access_key_id`.
+        aws_session_token: Optional[str]
+            Session key for AWS account. Only needed when using temporary
+            credentials.
+
+        Methods
+        -------
+
+        """
+        self._client = boto3.client(
+            "dynamodb",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token
+        )
+        self._table_name = table_name
+
+    def get_active_model(self, env: str = "prod") -> str:
+        """
+        Get the active model's artifact location for a particularly
+        environment ('dev', 'stage', or 'prod'). This is the entry
+        point that the classification/segmentation module should use
+        to get the location of the trained model for classifying ROIs.
+
+        Parameters
+        ----------
+        env: str ("dev|stage|prod")
+            The environment to retrieve the model from.
+
+        Returns
+        -------
+        str
+            The location of the model artifact (either an S3 URI or a
+            filepath on the isilon)
+
+        Raises
+        ------
+        KeyError
+            If there is not an active model for the environment `env`.
+        """
+        response = self._client.get_item(
+            TableName=self._table_name,
+            Key={"model_name": {"S": env},
+                 "timestamp": {"N": "0"}},
+            ProjectionExpression="artifact_location",
+            ConsistentRead=True
+        )
+        if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+            raise RuntimeError(
+                "Accessing record in DynamoDB was unsuccessful. "
+                "Most likely your credentials are incorrect or do not "
+                "allow access to the table. Please try again. "
+                f"Response: \n {response}")
+        elif response.get("Item") is None:
+            raise KeyError(f"No active model was found in {env} environment.")
+        return response["Item"]["artifact_location"]["S"]
+
+    def register_active_model(
+            self, model_name: str, env: str, mlflow_run_id: str,
+            artifact_location: str):
+        """
+        Create a record for a new active model in the registry for
+        a specific environment.
+
+        Parameters
+        ----------
+        model_name: str
+            The name of the model to register as active in the database.
+        env: str ("dev|stage|prod")
+            The environment to register the active model
+        artifact_location: str
+            The location of the model artifact. Can be an s3 URI or a
+            filepath on the isilon.
+        mlflow_run_id: str
+            The ID of the mlflow run used to train the model, for
+            linking with the mlflow database
+
+        Returns
+        -------
+        List of put_item responses from DynamoDB.
+
+        Raises
+        ------
+        ValueError
+            If a user tries to register a model with the
+            `model_name` in the list: ["dev", "stage", "prod"].
+            These values must be reserved to point to the currently
+             active model.
+        ValueError
+            If `env` is not one of "dev", "stage", or "prod".
+        RuntimeError
+            If a non-200 (OK) status code is returned when
+            trying to put items in the table.
+        """
+        if model_name.lower() in ["dev", "stage", "prod"]:
+            raise ValueError(f"Cannot use protected name '{model_name}'.")
+        if env not in ["dev", "stage", "prod"]:
+            raise ValueError(f"Value for `env` must be one of 'dev', 'stage', "
+                             f"or 'prod' (got '{env}'.")
+        # Add the new record first
+        response = self._client.put_item(
+            TableName=self._table_name,
+            Item={
+                "model_name": {"S": model_name},
+                "timestamp": {"N": str(int(time.time()))},
+                "artifact_location": {"S": artifact_location},
+                "mlflow_run_id": {"S": mlflow_run_id}
+            }
+        )
+        if response["ResponseMetadata"]["HTTPStatusCode"] != 200:    # error
+            raise RuntimeError(
+                "Putting new record in DynamoDB was unsuccessful. "
+                "Most likely your credentials are incorrect or do not "
+                "allow access to the table. Please try again. "
+                f"Response: \n {response}")
+        # Replace the active record
+        active_response = self._client.put_item(
+            TableName=self._table_name,
+            Item={
+                "model_name": {"S": env},
+                "timestamp": {"N": "0"},
+                "artifact_location": {"S": artifact_location},
+                "mlflow_run_id": {"S": mlflow_run_id}
+            }
+        )
+        # if status not OK
+        if active_response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+            raise RuntimeError(
+                "Putting new active model in DynamoDB was unsuccessful. "
+                "Most likely your credentials are incorrect or do not "
+                "allow access to the table. Please try again. "
+                f"Response: \n {active_response}")
+        return [response, active_response]
+
+    def activate_model(
+            self, model_name: str, env: str, timestamp: Union[str, int]):
+        """
+        Reactivate a model in the registry by name and timestamp.
+        Only one model can be active per environment, so the previously
+         active model is replaced.
+
+        Parameters
+        ----------
+        model_name: str
+            The model's name
+        env: str ("dev|stage|prod")
+            The environment for which to activate the model
+        timestamp: int
+            The model's timestamp in seconds from epoch (either str
+            or int). This is the sort key in the table.
+
+        Returns
+        -------
+        Response from DynamoDB put operation.
+
+        Raises
+        ------
+        KeyError
+            If no value is returned from the table (did not exist)
+        RuntimeError
+            If the DynamoDB response was not 200 (OK)
+        """
+        model_response = self._client.get_item(
+            TableName=self._table_name,
+            Key={"model_name": {"S": model_name},
+                 "timestamp": {"N": str(timestamp)}},
+            ProjectionExpression="artifact_location,mlflow_run_id"
+        )
+        if model_response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+            raise RuntimeError(
+                "Unable to get response from DynamoDB table. "
+                "Most likely your credentials are incorrect or do not "
+                "allow access to the table. Please try again. "
+                f"Response: \n {model_response}")
+        elif model_response.get("Item") is None:
+            raise KeyError(f"No model with name {model_name} and timestamp "
+                           f"{timestamp} was found in the table.")
+
+        model = model_response["Item"]
+        active_response = self._client.put_item(
+            TableName=self._table_name,
+            Item={"model_name": {"S": env},
+                  "timestamp": {"N": "0"},
+                  "artifact_location": {"S": model["artifact_location"]},
+                  "mlflow_run_id": {"S": model["mlflow_run_id"]}})
+        if active_response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+            raise RuntimeError(
+                "Putting new active model in DynamoDB was unsuccessful. "
+                "Most likely your credentials are incorrect or do not "
+                "allow access to the table. Please try again. "
+                f"Response: \n {active_response}")
+        return active_response

--- a/src/ophys_etl/transforms/registry.py
+++ b/src/ophys_etl/transforms/registry.py
@@ -7,6 +7,7 @@ class RegistryConnection(object):
     def __init__(
             self,
             table_name: str,
+            region: Optional[str] = "us-west-2",
             aws_access_key_id: Optional[str] = None,
             aws_secret_access_key: Optional[str] = None,
             aws_session_token: Optional[str] = None):
@@ -35,6 +36,7 @@ class RegistryConnection(object):
         """
         self._client = boto3.client(
             "dynamodb",
+            region_name=region,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token

--- a/src/ophys_etl/transforms/registry.py
+++ b/src/ophys_etl/transforms/registry.py
@@ -209,8 +209,8 @@ class RegistryConnection(object):
             TableName=self._table_name,
             Item={"model_name": {"S": env},
                   "timestamp": {"N": "0"},
-                  "artifact_location": {"S": model["artifact_location"]},
-                  "mlflow_run_id": {"S": model["mlflow_run_id"]}})
+                  "artifact_location": model["artifact_location"],
+                  "mlflow_run_id": model["mlflow_run_id"]})
         if active_response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise RuntimeError(
                 "Putting new active model in DynamoDB was unsuccessful. "

--- a/src/ophys_etl/transforms/registry.py
+++ b/src/ophys_etl/transforms/registry.py
@@ -32,6 +32,9 @@ class RegistryConnection(object):
 
         Methods
         -------
+        * get_active_model
+        * register_active_model
+        * activate_model
 
         """
         self._client = boto3.client(

--- a/tests/transforms/test_registry.py
+++ b/tests/transforms/test_registry.py
@@ -1,0 +1,136 @@
+from moto import mock_dynamodb2
+import boto3
+import pytest
+
+from ophys_etl.transforms.registry import RegistryConnection
+
+
+@pytest.fixture
+def connection(scope="function"):
+    mock_dynamo = mock_dynamodb2()
+    mock_dynamo.start()
+    table_name = "test-table"
+    client = boto3.client("dynamodb")
+    client.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {
+                "AttributeName": "model_name",
+                "KeyType": "HASH"
+            },
+            {
+                "AttributeName": "timestamp",
+                "KeyType": "RANGE"
+            }
+        ],
+        AttributeDefinitions=[
+            {
+                "AttributeName": "model_name",
+                "AttributeType": "S"
+            },
+            {
+                "AttributeName": "timestamp",
+                "AttributeType": "N"
+            }
+        ]
+    )
+    yield RegistryConnection(table_name)
+    mock_dynamo.stop()
+
+
+def test_register_active_model_roundtrip(connection, monkeypatch):
+    """Register an active model and query for it to check."""
+    monkeypatch.setattr("ophys_etl.transforms.registry.time.time", lambda: 123)
+    connection.register_active_model("twiggy", "prod", "abc999", "s3://path")
+    record = connection._client.get_item(
+        TableName=connection._table_name,
+        Key={"model_name": {"S": "twiggy"},
+             "timestamp": {"N": "123"}},
+        ProjectionExpression="model_name,timestamp,artifact_location,mlflow_run_id"    # noqa
+    )
+    # Roundtrip get the records that were put
+    assert record["Item"] == {
+        "model_name": {"S": "twiggy"}, "timestamp": {"N": "123"},
+        "mlflow_run_id": {"S": "abc999"},
+        "artifact_location": {"S": "s3://path"}}
+    active = connection._client.get_item(
+        TableName=connection._table_name,
+        Key={"model_name": {"S": "prod"}, "timestamp": {"N": "0"}},
+        ProjectionExpression="artifact_location,mlflow_run_id"
+    )
+    assert active["Item"] == {
+        "mlflow_run_id": {"S": "abc999"},
+        "artifact_location": {"S": "s3://path"}}
+
+
+@pytest.mark.parametrize(
+    "env,path", [
+        ("prod", "s3://path/prod"),
+        ("stage", "s3://path/stage"),
+        ("dev", "/allen/aibs/")
+    ]
+)
+def test_register_get_model_integration(env, path, connection):
+    connection.register_active_model("twiggy", env, "abc999", path)
+    assert path == connection.get_active_model(env)
+
+
+@pytest.mark.parametrize(
+    "name", ["prod", "PROD", "stage", "dev"]
+)
+def test_register_active_model_raises_error_protected_name(name, connection):
+    with pytest.raises(ValueError):
+        connection.register_active_model(name, "prod", 123, "s3://model/path")
+
+
+@pytest.mark.parametrize(
+    "env", ["prod", "stage", "dev"]
+)
+def test_get_active_fails_http_status(env, monkeypatch, connection):
+    """Force non-200 status."""
+    monkeypatch.setattr(
+        connection._client, "get_item",
+        lambda **x: {"ResponseMetadata": {"HTTPStatusCode": 0}})
+    with pytest.raises(RuntimeError):
+        connection.get_active_model(env)
+
+
+def test_get_active_fails_not_exist(connection):
+    with pytest.raises(KeyError):
+        connection.get_active_model("prod")
+
+
+def test_register_active_fails_http_status(connection, monkeypatch):
+    monkeypatch.setattr(
+        connection._client, "put_item",
+        lambda **x: {"ResponseMetadata": {"HTTPStatusCode": 0}})
+    with pytest.raises(RuntimeError):
+        connection.register_active_model(
+            "tyra", "stage", "aaa999", "s3://path")
+
+
+def test_activate_model_fails_http_status_get(connection, monkeypatch):
+    monkeypatch.setattr(
+        connection._client, "get_item",
+        lambda **x: {"ResponseMetadata": {"HTTPStatusCode": 0}})
+    with pytest.raises(RuntimeError):
+        connection.activate_model("tyra", "stage", "123")
+
+
+def test_activate_model_fails_http_status_put(connection, monkeypatch):
+    connection._client.put_item(
+        TableName=connection._table_name,
+        Item={"model_name": {"S": "tyra"}, "timestamp": {"N": "123"},
+              "artifact_location": {"S": "s3://path"},
+              "mlflow_run_id": {"S": "aaa000"}}
+    )
+    monkeypatch.setattr(
+        connection._client, "put_item",
+        lambda **x: {"ResponseMetadata": {"HTTPStatusCode": 0}})
+    with pytest.raises(RuntimeError):
+        connection.activate_model("tyra", "stage", "123")
+
+
+def test_activate_model_fails_no_model_exists(connection, monkeypatch):
+    with pytest.raises(KeyError):
+        connection.activate_model("tyra", "stage", "123")

--- a/tests/transforms/test_registry.py
+++ b/tests/transforms/test_registry.py
@@ -10,7 +10,7 @@ def connection(scope="function"):
     mock_dynamo = mock_dynamodb2()
     mock_dynamo.start()
     table_name = "test-table"
-    client = boto3.client("dynamodb")
+    client = boto3.client("dynamodb", region_name="us-west-2")
     client.create_table(
         TableName=table_name,
         KeySchema=[


### PR DESCRIPTION
Resolves #15 

Creates a connection object for LIMS to use for the registry, and a template for making the registry table.
I haven't created the IAM role for LIMS. Need to reconnect with Wayne to figure out how to store these credentials.

**Validation**
* Unit tests
* DynamoDB table exists: [link](https://us-west-2.console.aws.amazon.com/dynamodb/home?region=us-west-2#tables:selected=ROIClassifierRegistry;tab=items)