### PR TITLE
adds chained transform pipeline for single LIMS call

### DIFF
--- a/src/ophys_etl/pipelines/segment_binarize_pipeline.py
+++ b/src/ophys_etl/pipelines/segment_binarize_pipeline.py
@@ -1,0 +1,53 @@
+import argschema
+from ophys_etl.transforms.suite2p_wrapper import Suite2PWrapper
+from ophys_etl.transforms.convert_rois import BinarizerAndROICreator
+import tempfile
+import pathlib
+import json
+
+
+class SegmentBinarizeSchema(argschema.ArgSchema):
+    motion_corrected_video = argschema.fields.InputFile(
+        required=True,
+        description="hdf5 motion-correced video")
+    motion_correction_values = argschema.fields.InputFile(
+        required=True,
+        description="motion correction values in a csv")
+
+
+class SegmentBinarize(argschema.ArgSchemaParser):
+    default_schema = SegmentBinarizeSchema
+
+    def run(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        Suite2P_output = pathlib.Path(tmpdir.name) / "Suite2P_output.json"
+
+        # segment with Suite2P, almost all default args
+        segment_args = {
+                "h5py": self.args['motion_corrected_video'],
+                "output_dir": tmpdir.name,
+                "output_json": str(Suite2P_output),
+                "retain_files": ["stat.npy"],
+                "bin_size": 115
+                }
+        segment = Suite2PWrapper(input_data=segment_args, args=[])
+        segment.run()
+
+        # binarize and output LIMS format
+        with open(Suite2P_output, "r") as f:
+            stat = json.load(f)['output_files']['stat.npy']
+
+        binarize_args = {"suite2p_stat_path": stat}
+
+        for k in ['output_json', 'motion_corrected_video',
+                  'motion_correction_values']:
+            binarize_args[k] = self.args[k]
+
+        binarize = BinarizerAndROICreator(input_data=binarize_args, args=[])
+        binarize.binarize_and_create()
+        tmpdir.cleanup()
+
+
+if __name__ == "__main__":  # pragma: nocover
+    sbmod = SegmentBinarize()
+    sbmod.run()

--- a/src/ophys_etl/pipelines/segment_binarize_pipeline.py
+++ b/src/ophys_etl/pipelines/segment_binarize_pipeline.py
@@ -28,7 +28,8 @@ class SegmentBinarize(argschema.ArgSchemaParser):
                 "output_dir": tmpdir.name,
                 "output_json": str(Suite2P_output),
                 "retain_files": ["stat.npy"],
-                "bin_size": 115
+                "bin_size": 115,
+                "log_level": self.args['log_level'],
                 }
         segment = Suite2PWrapper(input_data=segment_args, args=[])
         segment.run()
@@ -40,7 +41,7 @@ class SegmentBinarize(argschema.ArgSchemaParser):
         binarize_args = {"suite2p_stat_path": stat}
 
         for k in ['output_json', 'motion_corrected_video',
-                  'motion_correction_values']:
+                  'motion_correction_values', 'log_level']:
             binarize_args[k] = self.args[k]
 
         binarize = BinarizerAndROICreator(input_data=binarize_args, args=[])

--- a/src/ophys_etl/pipelines/segment_binarize_pipeline.py
+++ b/src/ophys_etl/pipelines/segment_binarize_pipeline.py
@@ -1,13 +1,15 @@
 import argschema
 from ophys_etl.transforms.suite2p_wrapper import Suite2PWrapper
 from ophys_etl.transforms.convert_rois import BinarizerAndROICreator
+from ophys_etl.schemas.fields import H5InputFile
+
 import tempfile
 import pathlib
 import json
 
 
 class SegmentBinarizeSchema(argschema.ArgSchema):
-    motion_corrected_video = argschema.fields.InputFile(
+    motion_corrected_video = H5InputFile(
         required=True,
         description="hdf5 motion-correced video")
     motion_correction_values = argschema.fields.InputFile(

--- a/tests/pipelines/test_segment_binarize_pipeline.py
+++ b/tests/pipelines/test_segment_binarize_pipeline.py
@@ -1,0 +1,76 @@
+import h5py
+import numpy as np
+from unittest.mock import patch, Mock
+import pathlib
+import argschema
+import json
+import ophys_etl.transforms.convert_rois as crois
+
+import sys
+sys.modules['suite2p'] = Mock()
+import ophys_etl.transforms.suite2p_wrapper as s2pw  # noqa
+import ophys_etl.pipelines.segment_binarize_pipeline as sbpipe  # noqa
+
+
+class MockSuite2PWrapper(argschema.ArgSchemaParser):
+    default_schema = s2pw.Suite2PWrapperSchema
+    default_output_schema = s2pw.Suite2PWrapperOutputSchema
+
+    def run(self):
+        stat = pathlib.Path(self.args['output_dir']) / "stat.npy"
+        with open(stat, "w") as f:
+            f.write("content")
+        outj = {
+                'output_files': {
+                    'stat.npy': str(stat)
+                    }
+                }
+        self.output(outj)
+
+
+class MockOutputSchema(argschema.schemas.DefaultSchema):
+    some_output = argschema.fields.Str(
+        required=True)
+
+
+class MockBinarizer(argschema.ArgSchemaParser):
+    default_schema = crois.BinarizeAndCreateROIsInputSchema
+    default_output_schema = MockOutputSchema
+
+    def binarize_and_create(self):
+        self.output({'some_output': 'junk'})
+
+
+@patch(
+        'ophys_etl.pipelines.segment_binarize_pipeline.Suite2PWrapper',
+        MockSuite2PWrapper)
+@patch(
+        'ophys_etl.pipelines.segment_binarize_pipeline.BinarizerAndROICreator',
+        MockBinarizer)
+def test_segment_binarize_pipeline(tmp_path):
+    """tests that satisfying the pipeline schema satisfies the
+    internal transform schema.
+    """
+    h5path = tmp_path / "mc_video.h5"
+    with h5py.File(str(h5path), "w") as f:
+        f.create_dataset("data", data=np.zeros((20, 100, 100)))
+
+    mcvalues_path = tmp_path / "mc_values.csv"
+    with open(mcvalues_path, "w") as f:
+        f.write("content")
+
+    outj_path = tmp_path / "output.json"
+
+    args = {
+            "motion_corrected_video": str(h5path),
+            "motion_correction_values": str(mcvalues_path),
+            "output_json": str(outj_path)
+            }
+
+    sbp = sbpipe.SegmentBinarize(input_data=args, args=[])
+    sbp.run()
+
+    with open(outj_path, "r") as f:
+        outj = json.load(f)
+
+    assert outj == {'some_output': 'junk'}


### PR DESCRIPTION
chains together Suite2P segmentation and to-LIMS binarization and formatting in a single pipeline.

### Validation
The folllowing PBS script:

```bash
#!/bin/bash
#PBS -q braintv
#PBS -l nodes=1:ppn=10
#PBS -l mem=100g
#PBS -l walltime=02:00:00
#PBS -N prod_seg_example
#PBS -j oe
#PBS -o /allen/aibs/informatics/danielk/prod_segmentation_example/

export TMPDIR=/scratch/capacity/${PBS_JOBID}

singularity run -B /allen:/allen,${TMPDIR}:${TMPDIR} /allen/aibs/informatics/danielk/prod_segmentation_example/suite2p_container.img python -m ophys_etl.pipelines.segment_binarize_pipeline --input_json /allen/aibs/informatics/danielk/prod_segmentation_example/input.json --output_json /allen/aibs/informatics/danielk/prod_segmentation_example/output.json
```

with the following `input_json`

```json
{
        "motion_corrected_video": "/allen/programs/braintv/production/visualbehavior/prod2/specimen_850862430/ophys_session_959458018/ophys_experiment_960410038/processed/motion_corrected_video.h5",
        "motion_correction_values": "/allen/programs/braintv/production/visualbehavior/prod2/specimen_850862430/ophys_session_959458018/ophys_experiment_960410038/processed/960410038_rigid_motion_transform.csv",
        "log_level": "INFO"
}
```
succeeded, with this log output:
<details>
  <summary>prod_seg_example.o24066883</summary>

```
----------------------------------------
Begin PBS Prologue Wed Aug  5 13:06:48 PDT 2020 1596658008
Job ID:         24066883.qmaster2.corp.alleninstitute.org
Username:       danielk
Group:          domain_users
Nodes:          n76
End PBS Prologue Wed Aug  5 13:06:48 PDT 2020 1596658008
----------------------------------------
INFO:Suite2PWrapper:movie has 48389 frames. Setting nbinned to 420
INFO:Suite2PWrapper:Running Suite2P with output going to /scratch/capacity/24066883.qmaster2.corp.alleninstitute.org/tmpzji2a6k3
{}
h5
time 369.96 sec. Wrote h5py to binaries for 1 planes
SKIPPING REGISTRATION FOR ALL PLANES...
NOTE: binary file created, but registration not performed
>>>>>>>>>>>>>>>>>>>>> PLANE 0 <<<<<<<<<<<<<<<<<<<<<<
Registration metrics, 128.30 sec.
----------- ROI DETECTION AND EXTRACTION
Binning movie in chunks of length 115
Binned movie [420,512,512], 74.94 sec.
NOTE: estimated spatial scale ~6 pixels, time epochs 1.00, threshold 3.75
0 ROIs, score=97.74
1000 ROIs, score=3.88
Found 1312 ROIs, 194.64 sec
After removing overlaps, 1080 ROIs remain
Masks made in 20.77 sec.
Extracted fluorescence from 1080 ROIs in 48389 frames, 270.82 sec.
NOTE: applying classifier /opt/conda/envs/suite2p/lib/python3.7/site-packages/suite2p/classifiers/classifier.npy
----------- Total 496.98 sec.
----------- SPIKE DECONVOLUTION
----------- Total 6.21 sec.
Plane 0 processed in 632.15 sec (can open in GUI).
total = 632.15 sec.
TOTAL RUNTIME 632.63 sec
INFO:Suite2PWrapper:Suite2P complete. Copying output from /scratch/capacity/24066883.qmaster2.corp.alleninstitute.org/tmpzji2a6k3 to /scratch/capacity/24066883.qmaster2.corp.alleninstitute.org/tmpuh4_1jxf
INFO:Suite2PWrapper:wrote stat.npy to /scratch/capacity/24066883.qmaster2.corp.alleninstitute.org/tmpuh4_1jxf/stat_20200805132338195905.npy
INFO:BinarizerAndROICreator:Loading suite2p ROIs and video size.
INFO:BinarizerAndROICreator:Binarizing the ROIs created by Suite2p.
INFO:BinarizerAndROICreator:Binarized ROIs from Suite2p, total binarized: 1080
INFO:BinarizerAndROICreator:Loading motion correction border values from  /allen/programs/braintv/production/visualbehavior/prod2/specimen_850862430/ophys_session_959458018/ophys_experiment_960410038/processed/960410038_rigid_motion_transform.csv
INFO:numexpr.utils:Note: NumExpr detected 32 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
INFO:numexpr.utils:NumExpr defaulting to 8 threads.
INFO:BinarizerAndROICreator:Transforming ROIs to LIMS compatible style.
INFO:BinarizerAndROICreator:Writing LIMs compatible ROIs to json file at /allen/aibs/informatics/danielk/prod_segmentation_example/output.json
----------------------------------------
Begin PBS Epilogue Wed Aug  5 13:23:52 PDT 2020 1596659032
Job ID:         24066883.qmaster2.corp.alleninstitute.org
Username:       danielk
Group:          domain_users
Job Name:       prod_seg_example
Session:        1048
Limits:         nodes=1:ppn=10,mem=100gb,walltime=02:00:00,neednodes=1:ppn=10
Resources:      cput=01:13:08,vmem=21088932kb,walltime=00:16:59,mem=45841592kb,energy_used=0
Queue:          braintv
Account:
Exit status:      0
Nodes:  n76
Killing leftovers...
Warning: the RSA host key for 'n76' differs from the key for the IP address '172.20.5.76'
Offending key for IP in /root/.ssh/known_hosts:576
Matching host key in /root/.ssh/known_hosts:251^M
Warning: the RSA host key for 'n76' differs from the key for the IP address '172.20.5.76'
Offending key for IP in /root/.ssh/known_hosts:576
Matching host key in /root/.ssh/known_hosts:251^M

End PBS Epilogue Wed Aug  5 13:24:02 PDT 2020 1596659042
----------------------------------------
```
</details>

The `output_json` was written, indicating that the output schema validation was met. The appropriateness of the output schema should have already been demonstrated in https://github.com/AllenInstitute/ophys_etl_pipelines/pull/14 .