### PR TITLE
Update tagging for uploading singularity images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           command: |
             echo ${SYLABS_TOKEN} | singularity remote login
             singularity push -U suite2p_container.img library://allen_institute_pika/ophys_etl_pipelines/suite2p_container.img:${CIRCLE_BRANCH}
+            singularity push -U suite2p_container.img library://allen_institute_pika/ophys_etl_pipelines/suite2p_container.img:latest
 
   build:
     executor: python/default


### PR DESCRIPTION
When pushing to our singularity library, create a tag `latest`. The image needs to have a stable name to pull properly.