### PR TITLE
Fix classifier module schema issues and standardize schema names

### DIFF
--- a/src/ophys_etl/schemas/dense_roi.py
+++ b/src/ophys_etl/schemas/dense_roi.py
@@ -1,0 +1,51 @@
+from marshmallow import Schema
+from marshmallow.fields import (List, Str, Float, Int, Bool)
+
+
+class DenseROISchema(Schema):
+    """This ROI format is the expected output of Segmentation/Binarization
+    and the expected input of Feature_extraction/Classification.
+    """
+
+    id = Int(required=True,
+             description=("Unique ID of the ROI, get's overwritten writting "
+                          "to LIMS"))
+    x = Int(required=True,
+            description="X location of top left corner of ROI in pixels")
+    y = Int(required=True,
+            description="Y location of top left corner of ROI in pixels")
+    width = Int(required=True,
+                description="Width of the ROI in pixels")
+    height = Int(required=True,
+                 description="Height of the ROI in pixels")
+    valid_roi = Bool(required=True,
+                     description=("Boolean indicating if the ROI is a valid "
+                                  "cell or not"))
+    mask_matrix = List(List(Bool), required=True,
+                       description=("Bool nested list describing which pixels "
+                                    "in the ROI area are part of the cell"))
+    max_correction_up = Float(required=True,
+                              description=("Max correction in pixels in the "
+                                           "up direction"))
+    max_correction_down = Float(required=True,
+                                description=("Max correction in pixels in the "
+                                             "down direction"))
+    max_correction_left = Float(required=True,
+                                description=("Max correction in pixels in the "
+                                             "left direction"))
+    max_correction_right = Float(required=True,
+                                 description="Max correction in the pixels in "
+                                             "the right direction")
+    mask_image_plane = Int(required=True,
+                           description=("The old segmentation pipeline stored "
+                                        "overlapping ROIs on separate image "
+                                        "planes. For compatibility purposes, "
+                                        "this field must be kept, but will "
+                                        "always be set to zero for the new "
+                                        "updated pipeline"))
+    exclusion_labels = List(Str, required=True,
+                            description=("LIMS ExclusionLabel names used to "
+                                         "track why a given ROI is not "
+                                         "considered a valid_roi. (examples: "
+                                         "motion_border, "
+                                         "classified_as_not_cell)"))

--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -1,7 +1,7 @@
+import sys
 from typing import List, Optional, Tuple
 import numpy as np
 from scipy.sparse import coo_matrix
-import sys
 from ophys_etl.extractors.motion_correction import MotionBorder
 
 if sys.version_info >= (3, 8):
@@ -10,7 +10,7 @@ else:
     from typing_extensions import TypedDict
 
 
-class StandardROI(TypedDict):
+class DenseROI(TypedDict):
     id: int
     x: int
     y: int
@@ -155,7 +155,7 @@ def coo_rois_to_lims_compatible(coo_masks: List[coo_matrix],
                                 max_correction_vals: MotionBorder,
                                 movie_shape: Tuple[int, int],
                                 npixel_threshold: int,
-                                ) -> List[StandardROI]:
+                                ) -> List[DenseROI]:
     """
     Converts coo formatted ROIs to lims compatible format.
 
@@ -177,7 +177,7 @@ def coo_rois_to_lims_compatible(coo_masks: List[coo_matrix],
 
     Returns
     -------
-    List[StandardROI]
+    List[DenseROI]
         converted rois into LIMS-standard form
 
     """
@@ -201,7 +201,7 @@ def coo_rois_to_lims_compatible(coo_masks: List[coo_matrix],
     return compatible_rois
 
 
-def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> StandardROI:
+def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> DenseROI:
     """
     This functions transforms ROI mask data from COO format
     to the LIMS expected format.
@@ -212,7 +212,7 @@ def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> StandardROI:
 
     Returns
     -------
-    StandardROI
+    DenseROI
 
     """
     bounds = roi_bounds(coo_mask)
@@ -220,7 +220,7 @@ def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> StandardROI:
     width = bounds[3] - bounds[2]
     mask_matrix = crop_roi_mask(coo_mask).toarray()
     mask_matrix = np.array(mask_matrix, dtype=bool)
-    compatible_roi = StandardROI(
+    compatible_roi = DenseROI(
         x=int(bounds[2]),
         y=int(bounds[0]),
         width=int(width),
@@ -238,11 +238,11 @@ def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> StandardROI:
     return compatible_roi
 
 
-def _motion_exclusion(roi: StandardROI, movie_shape: Tuple[int, int]) -> bool:
+def _motion_exclusion(roi: DenseROI, movie_shape: Tuple[int, int]) -> bool:
     """
     Parameters
     ----------
-    roi: StandardROI
+    roi: DenseROI
         the ROI to check
     movie_shape: Tuple[int, int]
         The frame shape of the movie from which ROIs were extracted in order
@@ -267,11 +267,11 @@ def _motion_exclusion(roi: StandardROI, movie_shape: Tuple[int, int]) -> bool:
     return valid
 
 
-def _small_size_exclusion(roi: StandardROI, npixel_threshold: int) -> bool:
+def _small_size_exclusion(roi: DenseROI, npixel_threshold: int) -> bool:
     """
     Parameters
     ----------
-    roi: StandardROI
+    roi: DenseROI
         the ROI to check
     npixel_threshold: int
         ROIs with fewer pixels than this will be labeled as invalid and small
@@ -288,7 +288,7 @@ def _small_size_exclusion(roi: StandardROI, npixel_threshold: int) -> bool:
     return valid
 
 
-def _check_exclusion(compatible_roi: StandardROI,
+def _check_exclusion(compatible_roi: DenseROI,
                      movie_shape: Tuple[int, int],
                      npixel_threshold: int) -> List[str]:
     """
@@ -296,7 +296,7 @@ def _check_exclusion(compatible_roi: StandardROI,
 
     Parameters
     ----------
-    compatible_roi: StandardROI
+    compatible_roi: DenseROI
         the ROI to check
     movie_shape: Tuple[int, int]
         The frame shape of the movie from which ROIs were extracted in order

--- a/tests/transforms/test_convert_rois.py
+++ b/tests/transforms/test_convert_rois.py
@@ -1,15 +1,16 @@
 import pytest
 import json
 import numpy as np
-from ophys_etl.transforms.convert_rois import (
-        BinarizerAndROICreator, LIMSCompatibleROIFormat)
-from ophys_etl.transforms.roi_transforms import StandardROI
+
+from ophys_etl.transforms.convert_rois import BinarizerAndROICreator
+from ophys_etl.transforms.roi_transforms import DenseROI
+from ophys_etl.schemas.dense_roi import DenseROISchema
 
 
 def test_output_schema_element():
     """test that attempts to keep the TypedDict and subschema element in sync
     """
-    s = StandardROI(
+    s = DenseROI(
             id=1,
             x=23,
             y=34,
@@ -24,13 +25,13 @@ def test_output_schema_element():
             mask_image_plane=0,
             exclusion_labels=['small_size', 'motion_border'])
 
-    # does this example have exactly the keys specified in StandardROI?
-    assert set(list(s.keys())) == set(list(StandardROI.__annotations__.keys()))
+    # does this example have exactly the keys specified in DenseROI?
+    assert set(list(s.keys())) == set(list(DenseROI.__annotations__.keys()))
 
     # can't really validate the above, but we can check against our
     # output schema
     # validate the object with a marshmallow load()
-    subschema = LIMSCompatibleROIFormat()
+    subschema = DenseROISchema()
     subschema.load(s)
     assert subschema.dump(s) == s
 


### PR DESCRIPTION
This commit makes the following changes:

1) Rename binarize LIMSCompatibleROIFormat to DenseROISchema

   Opting for a shorter (but still descriptive) name.
   This schema is also being moved to a shared spot because
   the classifier should be using it as the input schema.

   The new home for the schema is: ophys_etl.schemas.dense_roi

2) Make the classifier's input schema inherit from DenseROISchema

   Because the input to the classifier module is exactly the output
   of the binarization sub-module both should share the same
   schema for ROIs.

   As the classifier's ROI input schema does an additional conversion
   that adds ROIs in sparse format, the new schema will be called
   SparseAndDenseROISchema

3) Rename the StandardROI TypedDict in roi_transforms to DenseROI

Summary: Now instead of juggling 'StandardROI',
         'LIMSCompatibleROIFormat' and 'RoiJsonSchema' we will
         instead only need to consider Sparse or Dense.

TODO

- [x] Change the merge base to `master` after #29 and #34 are merged into `master`