### PR TITLE
Filter modifications

### DIFF
--- a/src/ophys_etl/filters.py
+++ b/src/ophys_etl/filters.py
@@ -3,33 +3,29 @@ from typing import List
 from scipy.sparse import coo_matrix
 
 
-def filter_longest_edge_length(coo_matrices: List[coo_matrix],
-                               edge_threshold: int) -> List[coo_matrix]:
+def filter_by_aspect_ratio(coo_matrices: List[coo_matrix],
+                           aspect_threshold: float) -> List[coo_matrix]:
     """
-    Low pass filters list of coo_matrices by the longest distance in the
-    height or width (whichever is greater) against a user defined threshold.
-    Matrix dimensions must be lower than edge_threshold, not equal to, to pass
-    through the filter.
+    Returns a list where ROIs with aspect ratio < aspect_threshold are
+    removed. Aspect ratio is min(heigh/width, width/height)
     Parameters
     ----------
     coo_matrices:
         The list of coo_matrices to low pass filter in both height and width
-    edge_threshold:
-        The threshold that both height and width of the coo_matrix must be
-        under
+    aspect_threshold:
+        The inclusive threshold below which ROIs will be removed
 
     Returns
     -------
     List[coo_matrix]:
-        The coo_matrices that had both length and width lower than the
-        specified edge_threshold
+        The coo_matrices that are not removed by this filter
 
     """
     filtered_rois = []
     for coo_roi in coo_matrices:
-        max_row_or_col = max(coo_roi.col.ptp(),
-                             coo_roi.row.ptp())
-        # peak to peak gets actual length - 1
-        if (max_row_or_col + 1) < edge_threshold:
+        height = coo_roi.row.ptp() + 1
+        width = coo_roi.col.ptp() + 1
+        ratio = min(height/width, width/height)
+        if ratio > aspect_threshold:
             filtered_rois.append(coo_roi)
     return filtered_rois

--- a/src/ophys_etl/transforms/convert_rois.py
+++ b/src/ophys_etl/transforms/convert_rois.py
@@ -63,7 +63,7 @@ class BinarizeAndCreateROIsInputSchema(ArgSchema):
         description=("The quantile against which an ROI is binarized. If not "
                      "provided will use default function value of 0.1."))
     npixel_threshold = Int(
-        default=100,
+        default=85,
         required=False,
         description=("ROIs with fewer pixels than this will be labeled as "
                      "invalid and small size."))

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -2,118 +2,29 @@ import pytest
 import numpy as np
 from scipy.sparse import coo_matrix
 
-from ophys_etl.filters import filter_longest_edge_length
+from ophys_etl.filters import filter_by_aspect_ratio
 
 
-@pytest.mark.parametrize("coo_rois, longest_edge_thrsh, expected_rois",
-                         [([coo_matrix(np.array([[0, 0, 0, 0, 0],
-                                                 [0, 0.7, 0.85, 0.98, 0.67],
-                                                 [0, 0.85, 0.79, 0.82, 0.78],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0]]))], 3, []),
-                          ([coo_matrix(np.array([[0, 0.76, 0.85, 0, 0],
-                                                 [0, 0.88, 0.65, 0, 0],
-                                                 [0, 0.95, 0.78, 0, 0],
-                                                 [0, 0.98, 0.88, 0, 0],
-                                                 [0, 0, 0, 0, 0]]))], 3, []),
-                          ([coo_matrix(np.array([[0, 1, 1, 1, 1],
-                                                 [0, 1, 1, 1, 1],
-                                                 [0, 1, 1, 1, 1],
-                                                 [0, 1, 1, 1, 1],
-                                                 [0, 0, 0, 0, 0]]))], 3, []),
-                          ([coo_matrix(np.array([[0, 0, 0, 0, 0],
-                                                 [0.67, 0.89, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0.87],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0]]))], 3, []),
-                          ([coo_matrix(np.array([[0.89, 0, 0, 0, 0],
-                                                 [0.79, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0.85, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0]]))], 3, []),
-                          ([coo_matrix(np.array([[0.89, 0.54, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0.74]]))], 3,
-                           []),
-                          ([coo_matrix(np.array([[0, 0, 0, 0, 0],
-                                                 [0, 1, 0.96, 0, 0],
-                                                 [0, 0.67, 0.87, 0, 0],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0]]))], 3,
-                           [coo_matrix(np.array([[0, 0, 0, 0, 0],
-                                                 [0, 1, 0.96, 0, 0],
-                                                 [0, 0.67, 0.87, 0, 0],
-                                                 [0, 0, 0, 0, 0],
-                                                 [0, 0, 0, 0, 0]]))]),
-                          ([coo_matrix(
-                              np.array([[0, 0, 0, 0, 0],
-                                        [0, 1, 0, 0, 0],
-                                        [0, 0, 1, 0, 0],
-                                        [0, 0, 0, 0, 0],
-                                        [0, 0, 0, 0, 0]]))],
-                           3, [coo_matrix(np.array(
-                              [[0, 0, 0, 0, 0],
-                               [0, 1, 0, 0, 0],
-                               [0, 0, 1, 0, 0],
-                               [0, 0, 0, 0, 0],
-                               [0, 0, 0, 0, 0]]))]),
-                          ([], 3, []),
-                          ([coo_matrix(
-                              np.array([[0, 0, 0, 0, 0],
-                                        [0, 1, 0, 0, 0],
-                                        [0, 0, 1, 0, 0],
-                                        [0, 0, 0, 0, 0],
-                                        [0, 0, 0, 0, 0]])),
-                            coo_matrix(
-                              np.array([[0, 0, 0, 0, 0],
-                                        [0, 1, 0.96, 0, 0],
-                                        [0, 0.67, 0.87, 0, 0],
-                                        [0, 0, 0, 0, 0],
-                                        [0, 0, 0, 0, 0]])),
-                            coo_matrix(
-                              np.array([[0, 1, 1, 1, 1],
-                                        [0, 1, 1, 1, 1],
-                                        [0, 1, 1, 1, 1],
-                                        [0, 1, 1, 1, 1],
-                                        [0, 0, 0, 0, 0]]))],
-                           3, [coo_matrix(
-                              np.array([[0, 0, 0, 0, 0],
-                                        [0, 1, 0, 0, 0],
-                                        [0, 0, 1, 0, 0],
-                                        [0, 0, 0, 0, 0],
-                                        [0, 0, 0, 0, 0]])),
-                               coo_matrix(
-                                   np.array([[0, 0, 0, 0, 0],
-                                             [0, 1, 0.96, 0, 0],
-                                             [0, 0.67, 0.87, 0, 0],
-                                             [0, 0, 0, 0, 0],
-                                             [0, 0, 0, 0, 0]]))]),
-                          ([coo_matrix(np.array([[1, 1, 1]]))], 3, []),
-                          ([coo_matrix(np.array([[0, 1, 1]]))], 3,
-                           [coo_matrix(np.array([[0, 1, 1]]))])])
-def test_filter_rois_by_longest_edge_length(coo_rois, longest_edge_thrsh,
-                                            expected_rois):
-    """
-    Test Cases (Included in the list of coo_matrices):
-    1. Larger than longest edge thrsh in x direction, contiguous
-    2. Larger than longest edge thrsh in y direction, contiguous
-    3. Larger than longest edge thrsh in x and y, contiguous
-    4. Larger than longest edge thrsh in x, non contiguous
-    5. Larger than longest edge thrsh in y, non contiguous
-    6. Larger than longest edge thrsh in x and y, non contiguous
-    7. Smaller than longest edge thrsh in x and y, contiguous
-    8. Smaller than longest edge thrsh in x and y, non contiguous
-    9. Empty list
-    10. List with more than one element two trues and one false
-    11. Singleton roi with ptp 2 and length equal to filter
-    12. Singleton roi with ptp 1 and length less than filter
-    """
-    filtered_rois = filter_longest_edge_length(coo_rois,
-                                               longest_edge_thrsh)
-    # assume that test is true and the indices line up between calculated and
-    # expected
-    for i in range(len(filtered_rois)):
-        assert np.allclose(filtered_rois[i].toarray(),
-                           expected_rois[i].toarray())
+def coos_by_aspect(threshold):
+    width = 100
+    height = int(width * threshold)
+    while (height/width) <= threshold:
+        height += 1
+    mdense = np.ones((height, width))
+    aspect_larger = [coo_matrix(mdense), coo_matrix(mdense.T)]
+
+    height = int(width * threshold)
+    while (height/width) >= threshold:
+        height -= 1
+    mdense = np.ones((height, width))
+    aspect_smaller = [coo_matrix(mdense), coo_matrix(mdense.T)]
+    return aspect_smaller, aspect_larger
+
+
+@pytest.mark.parametrize("threshold", [0.1, 0.2, 0.3])
+def test_filter_rois_by_aspect_ratio(threshold):
+    csmaller, clarger = coos_by_aspect(threshold)
+    filtered = filter_by_aspect_ratio(csmaller + clarger, threshold)
+    assert len(clarger) == len(filtered)
+    for i, j in zip(clarger, filtered):
+        np.testing.assert_array_equal(i.toarray(), j.toarray())

--- a/tests/transforms/test_convert_rois.py
+++ b/tests/transforms/test_convert_rois.py
@@ -38,7 +38,7 @@ def test_output_schema_element():
 
 @pytest.mark.parametrize("s2p_stat_fixture, ophys_movie_fixture, "
                          "motion_correction_fixture, "
-                         "longest_edge_threshold, expected_rois",
+                         "aspect_threshold, expected_rois",
                          [({'frame_shape': (5, 5),
                             'masks': [
                                 np.array([[0.67, 0.87, 0.98, 0, 0],
@@ -55,12 +55,19 @@ def test_output_schema_element():
                                           [0, 0, 0.55, 0.43, 0],
                                           [0, 0, 0.68, 0.40, 0],
                                           [0, 0, 0.79, 0, 0],
-                                          [0, 0, 0, 0, 0]])
+                                          [0, 0, 0, 0, 0]]),
+                                # should get filtered out by aspect threshold
+                                np.array([[0, 0, 0, 0, 0],
+                                          [0, 0, 0, 0, 0],
+                                          [1, 1, 1, 1, 1],
+                                          [0, 0, 0, 0, 0],
+                                          [0, 0, 0, 0, 0]]),
                             ]},
                            {'movie_shape': (10, 5, 5)},
                            {'abs_value_bound': 0.25,
                             'required_x_values': [-0.3, 0.3],
-                            'required_y_values': [-0.3, 0.3]}, 10,
+                            'required_y_values': [-0.3, 0.3]},
+                           0.2,
                            [
                                {'id': 0,
                                 'x': 0,
@@ -113,89 +120,13 @@ def test_output_schema_element():
                                    'mask_image_plane': 0,
                                    'exclusion_labels': []
                                }
-                           ]),
-                          ({'frame_shape': (5, 5),
-                            'masks': [
-                                np.array([[0, 0, 0, 0, 0],
-                                          [0, 0.7, 0.85, 0.98, 0.67],
-                                          [0, 0.85, 0.79, 0.82, 0.78],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0]]),
-                                np.array([[0, 0.76, 0.85, 0, 0],
-                                          [0, 0.88, 0.65, 0, 0],
-                                          [0, 0.95, 0.78, 0, 0],
-                                          [0, 0.98, 0.88, 0, 0],
-                                          [0, 0, 0, 0, 0]]),
-                                np.array([[0, 1, 1, 1, 1],
-                                          [0, 1, 1, 0.83, 1],
-                                          [0, 1, 0.78, 0.85, 1],
-                                          [0, 1, 1, 1, 1],
-                                          [0, 0, 0, 0, 0]]),
-                                np.array([[0, 0, 0, 0, 0],
-                                          [0.67, 0.89, 0, 0, 0],
-                                          [0, 0, 0, 0, 0.87],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0]]),
-                                np.array([[0.89, 0, 0, 0, 0],
-                                          [0.79, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0.85, 0, 0, 0],
-                                          [0, 0, 0, 0, 0]]),
-                                np.array([[0.89, 0.54, 0, 0, 0],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0.74]]),
-                                np.array([[0, 0, 0, 0, 0],
-                                          [0, 1, 0.96, 0, 0],
-                                          [0, 0.67, 0.87, 0, 0],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0]]),
-                                np.array([[0, 0, 0, 0, 0],
-                                          [0, 1, 0.85, 0, 0],
-                                          [0, 0, 1, 0, 0],
-                                          [0, 0, 0, 0, 0],
-                                          [0, 0, 0, 0, 0]])]},
-                           {'movie_shape': (10, 5, 5)},
-                           {'abs_value_bound': 0,
-                            'required_x_values': [-0.1, 0.1],
-                            'required_y_values': [-0.1, 0.1]}, 3,
-                           [
-                               {'exclusion_labels': [],
-                                'height': 2,
-                                'id': 0,
-                                'mask_image_plane': 0,
-                                'mask_matrix': [[True, True],
-                                                [False, True]],
-                                'max_correction_down': 0.1,
-                                'max_correction_up': 0.1,
-                                'max_correction_left': 0.1,
-                                'max_correction_right': 0.1,
-                                'valid_roi': True,
-                                'width': 2,
-                                'x': 1,
-                                'y': 1},
-                               {'exclusion_labels': [],
-                                'height': 2,
-                                'id': 1,
-                                'mask_image_plane': 0,
-                                'mask_matrix': [[True, False],
-                                                [False, True]],
-                                'max_correction_down': 0.1,
-                                'max_correction_up': 0.1,
-                                'max_correction_left': 0.1,
-                                'max_correction_right': 0.1,
-                                'valid_roi': True,
-                                'width': 2,
-                                'x': 1,
-                                'y': 1}
                            ])],
                          indirect=["s2p_stat_fixture",
                                    "ophys_movie_fixture",
                                    "motion_correction_fixture"])
 def test_binarize_and_convert_rois(s2p_stat_fixture, ophys_movie_fixture,
                                    motion_correction_fixture,
-                                   longest_edge_threshold,
+                                   aspect_threshold,
                                    expected_rois, tmp_path):
     stat_path, stat_fixure_params = s2p_stat_fixture
     movie_path, movie_fixture_params = ophys_movie_fixture
@@ -208,7 +139,7 @@ def test_binarize_and_convert_rois(s2p_stat_fixture, ophys_movie_fixture,
         'motion_correction_values': str(motion_path),
         'output_json': str(output_path),
         'npixel_threshold': 1,
-        'longest_edge_threshold': longest_edge_threshold
+        'aspect_ratio_threshold': aspect_threshold
     }
 
     converter = BinarizerAndROICreator(input_data=args,
@@ -221,4 +152,5 @@ def test_binarize_and_convert_rois(s2p_stat_fixture, ophys_movie_fixture,
     with open(output_path) as open_output:
         rois = json.load(open_output)
 
-        assert expected_rois == rois
+    assert len(expected_rois) == len(rois)
+    assert expected_rois == rois


### PR DESCRIPTION
related to investigations in #45

### Modifications
- loosen npixel_threshold filter default from 100 to 85. 100 was established during labeling on un-binarized ROIs. This filter is now applied after binarization, which drops some pixels from a mask.
- replace longest edge filter with aspect filter. We found that longest edge filter was catching some obvious soma with dendrites.