### PR TITLE
Fix lims and module ROI id mismatch

### DIFF
--- a/src/ophys_etl/transforms/classification.py
+++ b/src/ophys_etl/transforms/classification.py
@@ -330,9 +330,9 @@ def _munge_traces(roi_data: List[SparseAndDenseROI], trace_file_path: str,
     traces_data = traces_file[trace_data_key]
 
     # An array of str(int) describing roi names (id) associated with each trace
-    # Example: ['0', '1', '10', '100', ..., '2', '20', '200', ...]
+    # Example: ['10', '100', ..., '2', '20', '200', ..., '3']
     traces_id_order = traces_file[trace_names_key][:].astype(int)
-    traces_id_mapping = np.argsort(traces_id_order)
+    traces_id_mapping = {val: ind for ind, val in enumerate(traces_id_order)}
 
     downsampled_traces = []
     for roi in roi_data:

--- a/tests/transforms/test_classification.py
+++ b/tests/transforms/test_classification.py
@@ -374,29 +374,29 @@ def test_filter_excluded_rois(rois):
 
 
 @pytest.mark.parametrize("roi_data, trace_file_fixture, expected", [
-    # Case: Everything in order
-    ([{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}],  # roi_data
+    # Case: ROI id order in segmentation output matches trace "roi_names" order
+    ([{"id": 10}, {"id": 100}, {"id": 20}, {"id": 200}, {"id": 3}],  # roi_data
      {"trace_data": np.arange(100).reshape((5, 20)),  # trace_file_fixture
-      "trace_names": ['0', '1', '2', '3', '4']},
+      "trace_names": ['10', '100', '20', '200', '3']},
      np.arange(100).reshape((5, 20))),  # expected
 
-    # Case: Trace names are not in numerical order
-    ([{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}],
+    # Case: ROI id order does not match order of trace "roi_names" (variant 1)
+    ([{"id": 10}, {"id": 100}, {"id": 20}, {"id": 200}, {"id": 3}],
      {"trace_data": np.arange(100).reshape((5, 20)),
-      "trace_names": ['1', '2', '0', '4', '3']},
-     np.arange(100).reshape((5, 20))[[2, 0, 1, 4, 3]]),
+      "trace_names": ['100', '20', '10', '200', '3']},
+     np.arange(100).reshape((5, 20))[[2, 0, 1, 3, 4]]),
 
-    # Case: ROIs are not in numerical order
-    ([{"id": 4}, {"id": 2}, {"id": 1}, {"id": 3}, {"id": 0}],
+    # Case: ROI id order does not match order of trace "roi_names" (variant 2)
+    ([{"id": 3}, {"id": 20}, {"id": 10}, {"id": 200}, {"id": 100}],
      {"trace_data": np.arange(100).reshape((5, 20)),
-      "trace_names": ['0', '1', '2', '3', '4']},
-     np.arange(100).reshape((5, 20))[[4, 2, 1, 3, 0]]),
+      "trace_names": ['10', '100', '20', '200', '3']},
+     np.arange(100).reshape((5, 20))[[4, 2, 0, 3, 1]]),
 
-    # Case: Nothing is in order :(
-    ([{"id": 4}, {"id": 2}, {"id": 1}, {"id": 3}, {"id": 0}],
+    # Case: ROI id order does not match order of trace "roi_names" (variant 3)
+    ([{"id": 3}, {"id": 20}, {"id": 10}, {"id": 200}, {"id": 100}],
      {"trace_data": np.arange(100).reshape((5, 20)),
-      "trace_names": ['1', '2', '0', '4', '3']},
-     np.arange(100).reshape((5, 20))[[3, 1, 0, 4, 2]]),
+      "trace_names": ['100', '20', '10', '200', '3']},
+     np.arange(100).reshape((5, 20))[[4, 1, 2, 3, 0]]),
 
 ], indirect=["trace_file_fixture"])
 def test_munge_traces(roi_data, trace_file_fixture, expected):


### PR DESCRIPTION
Previously, the classification _munge_traces() function
was assuming that ROI ids would take on a contiguous range
of values starting at 0. Because ROI id names are now
being obtained from LIMS, it is no longer the case that
ROI ids will start from 0. It is also very likely that
the expectation that ROI ids be contiguous is also no
longer the case.

This commit fixes the lookup mapping that is used to match up
the index which a trace is stored with an ROI id.