### PR TITLE
adds bridging module from binarize to extract, for non-production run…

### DIFF
--- a/src/ophys_etl/extractors/motion_correction.py
+++ b/src/ophys_etl/extractors/motion_correction.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 import numpy as np
 import pandas as pd
+from pathlib import Path
 
 MotionBorder = namedtuple('MotionBorder', ['left', 'right', 'up', 'down'])
 
@@ -57,3 +58,35 @@ def get_max_correction_values(x_series: pd.Series, y_series: pd.Series,
                          f"{max_border}, with max_shift {max_shift}")
 
     return max_border
+
+
+def get_max_correction_from_file(
+        input_csv: Path, max_shift: float = 30.0) -> MotionBorder:
+    """
+
+    Parameters
+    ----------
+    input_csv: Path
+        Path to motion correction values for each frame stored in .csv format.
+        This .csv file is expected to have a header row of either:
+        ['framenumber','x','y','correlation','kalman_x', 'kalman_y'] or
+        ['framenumber','x','y','correlation','input_x','input_y','kalman_x',
+         'kalman_y','algorithm','type']
+    max_shift: float
+        Maximum shift to allow when considering motion correction. Any
+        larger shifts are considered outliers.
+
+    Returns
+    -------
+    motion_border
+        A named tuple containing the maximum correction values found during
+        motion correction workflow step. Saved with the following direction
+        order [left, right, up, down].
+
+    """
+    motion_correction_df = pd.read_csv(input_csv)
+    motion_border = get_max_correction_values(
+        x_series=motion_correction_df['x'],
+        y_series=motion_correction_df['y'],
+        max_shift=max_shift)
+    return motion_border

--- a/src/ophys_etl/schemas/__init__.py
+++ b/src/ophys_etl/schemas/__init__.py
@@ -1,1 +1,2 @@
-from ophys_etl.schemas._dense_roi_schema import DenseROISchema  # noqa: F401
+from ophys_etl.schemas._roi_schema import (  # noqa: F401
+        DenseROISchema, ExtractROISchema)

--- a/src/ophys_etl/schemas/_roi_schema.py
+++ b/src/ophys_etl/schemas/_roi_schema.py
@@ -2,6 +2,30 @@ from marshmallow import Schema
 from marshmallow.fields import (List, Str, Float, Int, Bool)
 
 
+class ExtractROISchema(Schema):
+    """This ROI format is the expected input of AllenSDK's extract_traces
+    'rois' field
+    """
+
+    id = Int(required=True,
+             description=("Unique ID of the ROI, get's overwritten writting "
+                          "to LIMS"))
+    x = Int(required=True,
+            description="X location of top left corner of ROI in pixels")
+    y = Int(required=True,
+            description="Y location of top left corner of ROI in pixels")
+    width = Int(required=True,
+                description="Width of the ROI in pixels")
+    height = Int(required=True,
+                 description="Height of the ROI in pixels")
+    valid = Bool(required=True,
+                 description=("Boolean indicating if the ROI is a valid "
+                              "cell or not"))
+    mask = List(List(Bool), required=True,
+                description=("Bool nested list describing which pixels "
+                             "in the ROI area are part of the cell"))
+
+
 class DenseROISchema(Schema):
     """This ROI format is the expected output of Segmentation/Binarization
     and the expected input of Feature_extraction/Classification.

--- a/src/ophys_etl/transforms/binarize_extract_bridge.py
+++ b/src/ophys_etl/transforms/binarize_extract_bridge.py
@@ -1,0 +1,120 @@
+import argschema
+import json
+from pathlib import Path
+from marshmallow import ValidationError
+
+from ophys_etl.schemas import DenseROISchema, ExtractROISchema
+from ophys_etl.extractors.motion_correction import MotionBorder
+from ophys_etl.transforms.roi_transforms import dense_to_extract
+
+
+class BridgeInputSchema(argschema.ArgSchema):
+    input_file = argschema.fields.InputFile(
+        required=True,
+        description=("an output from BinarizerAndROICreator in "
+                     "convert_rois.py"))
+    storage_directory = argschema.fields.OutputDir(
+        required=True,
+        description="the intended destination directory for the traces")
+    # NOTE these schema field names match convert_rois and not AllenSDK
+    motion_corrected_video = argschema.fields.Str(
+        required=True,
+        validate=lambda x: Path(x).exists(),
+        description=("Path to motion corrected video file *.h5"))
+    motion_correction_values = argschema.fields.InputFile(
+        required=True,
+        description=("Path to motion correction values for each frame "
+                     "stored in .csv format. This .csv file is expected to"
+                     "have a header row of either:\n"
+                     "['framenumber','x','y','correlation','kalman_x',"
+                     "'kalman_y']\n['framenumber','x','y','correlation',"
+                     "'input_x','input_y','kalman_x',"
+                     "'kalman_y','algorithm','type']"))
+
+
+class MotionBorderSchema(argschema.schemas.DefaultSchema):
+    x0 = argschema.fields.Float()
+    x1 = argschema.fields.Float()
+    y0 = argschema.fields.Float()
+    y1 = argschema.fields.Float()
+
+
+class BridgeOutputSchema(argschema.schemas.DefaultSchema):
+    # NOTE these schema field names match AllenSDK and not convert_rois
+    motion_border = argschema.fields.Nested(
+            MotionBorderSchema,
+            required=True)
+    storage_directory = argschema.fields.OutputDir(
+            required=True)
+    motion_corrected_stack = argschema.fields.Str(
+            validate=lambda x: Path(x).exists(),
+            required=True)
+    rois = argschema.fields.Nested(
+            ExtractROISchema,
+            required=True,
+            many=True)
+    log_0 = argschema.fields.InputFile(
+            required=True)
+
+
+class BinarizeToExtractBridge(argschema.ArgSchemaParser):
+    """
+    This module can bridge the output of
+    'ophys_etl_pipelines/src/ophys_etl/transforms/convert_rois.py'
+    to the input of
+    https://github.com/AllenInstitute/AllenSDK/blob/7e60bc5a811f76750d22a507f449621a0784e6bd/allensdk/brain_observatory/ophys/trace_extraction/_schemas.py#L33-L41  # noqa
+    In production, this purpose is served by a LIMS strategy. This python
+    bridge is here as a helper for running the pipeline manually outside
+    of production
+    """
+    default_schema = BridgeInputSchema
+    default_output_schema = BridgeOutputSchema
+
+    def run(self):
+        self.logger.name = type(self).__name__
+
+        with open(self.args['input_file'], "r") as f:
+            compatible_rois = json.load(f)
+
+        # validate ROIs
+        errors = DenseROISchema(many=True).validate(compatible_rois)
+        if any(errors):
+            raise ValidationError(f"Schema validation errors: {errors}")
+
+        # read the motion border and check they are all the same
+        for i, roi in enumerate(compatible_rois):
+            iborder = MotionBorder(
+                up=roi['max_correction_up'],
+                down=roi['max_correction_down'],
+                left=roi['max_correction_left'],
+                right=roi['max_correction_right'])
+            if i == 0:
+                border = iborder
+            else:
+                assert iborder == border
+
+        border_dict = {
+                'y1': border.up,
+                'y0': border.down,
+                'x0': border.right,
+                'x1': border.left
+                }
+
+        converted_rois = [dense_to_extract(roi) for roi in compatible_rois]
+
+        output = {
+                'log_0': self.args['motion_correction_values'],
+                'motion_corrected_stack': self.args['motion_corrected_video'],
+                'storage_directory': self.args['storage_directory'],
+                'rois': converted_rois,
+                'motion_border': border_dict
+                }
+
+        self.output(output, indent=2)
+        self.logger.info(f"transformed {self.args['input_file']} to "
+                         f"{self.args['output_json']}")
+
+
+if __name__ == "__main__":  # pragma: nocover
+    bridge = BinarizeToExtractBridge()
+    bridge.run()

--- a/src/ophys_etl/transforms/convert_rois.py
+++ b/src/ophys_etl/transforms/convert_rois.py
@@ -3,13 +3,13 @@ from pathlib import Path
 
 import h5py
 import numpy as np
-import pandas as pd
 from argschema import ArgSchema, ArgSchemaParser
 from argschema.fields import Float, InputFile, Int, OutputFile, Str
 from marshmallow import ValidationError
 from marshmallow.validate import Range
 
-from ophys_etl.extractors.motion_correction import get_max_correction_values
+from ophys_etl.extractors.motion_correction import \
+        get_max_correction_from_file
 from ophys_etl.schemas import DenseROISchema
 from ophys_etl.transforms.roi_transforms import (binarize_roi_mask,
                                                  coo_rois_to_lims_compatible,
@@ -123,12 +123,9 @@ class BinarizerAndROICreator(ArgSchemaParser):
         # load the motion correction values
         self.logger.info("Loading motion correction border values from "
                          f" {self.args['motion_correction_values']}")
-        motion_correction_df = pd.read_csv(
-            self.args['motion_correction_values'])
-        motion_border = get_max_correction_values(
-            x_series=motion_correction_df['x'],
-            y_series=motion_correction_df['y'],
-            max_shift=self.args['maximum_motion_shift'])
+        motion_border = get_max_correction_from_file(
+            self.args['motion_correction_values'],
+            self.args['maximum_motion_shift'])
 
         # create the rois
         self.logger.info("Transforming ROIs to LIMS compatible style.")

--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -3,7 +3,33 @@ from typing import List, Optional, Tuple
 import numpy as np
 from scipy.sparse import coo_matrix
 from ophys_etl.extractors.motion_correction import MotionBorder
-from ophys_etl.types import DenseROI
+from ophys_etl.types import DenseROI, ExtractROI
+
+
+def dense_to_extract(roi: DenseROI) -> ExtractROI:
+    """reformat from expected output format from binarization
+    to expected input format of extract_traces
+
+    Parameters
+    ----------
+    roi: DenseROI
+        an ROI in the output format of binarization
+
+    Returns
+    -------
+    exroi: ExtractROI
+        an ROI in the input format for extract_traces
+
+    """
+    exroi = ExtractROI(
+            id=roi['id'],
+            x=roi['x'],
+            y=roi['y'],
+            width=roi['width'],
+            height=roi['height'],
+            valid=roi['valid_roi'],
+            mask=roi['mask_matrix'])
+    return exroi
 
 
 def suite2p_rois_to_coo(suite2p_stats: np.ndarray,

--- a/src/ophys_etl/types/__init__.py
+++ b/src/ophys_etl/types/__init__.py
@@ -1,1 +1,1 @@
-from ophys_etl.types._dense_roi import DenseROI  # noqa: F401
+from ophys_etl.types._roi import DenseROI, ExtractROI  # noqa: F401

--- a/src/ophys_etl/types/_roi.py
+++ b/src/ophys_etl/types/_roi.py
@@ -21,3 +21,15 @@ class DenseROI(TypedDict):
     max_correction_right: float
     mask_image_plane: int
     exclusion_labels: List[str]
+
+
+class ExtractROI(TypedDict):
+    """AllenSDK extract_traces expects this format
+    """
+    id: int
+    x: int
+    y: int
+    width: int
+    height: int
+    valid: bool
+    mask: List[List[bool]]

--- a/tests/transforms/test_binarize_extract_bridge.py
+++ b/tests/transforms/test_binarize_extract_bridge.py
@@ -1,0 +1,72 @@
+import json
+import pytest
+
+from ophys_etl.types import DenseROI
+from ophys_etl.transforms.binarize_extract_bridge import \
+        BinarizeToExtractBridge
+
+
+@pytest.fixture
+def mock_movie_path(tmp_path):
+    mpath = tmp_path / "mock_movie.h5"
+    with open(mpath, "w") as f:
+        f.write("content")
+    yield mpath
+
+
+@pytest.fixture
+def mock_compatible_path(tmp_path):
+    cpath = tmp_path / "myrois.json"
+    rois = []
+    for i in range(10):
+        rois.append(DenseROI(
+            id=i+1,
+            x=23,
+            y=34,
+            width=128,
+            height=128,
+            valid_roi=True,
+            mask_matrix=[[True, True], [False, True]],
+            max_correction_up=12,
+            max_correction_down=12,
+            max_correction_left=12,
+            max_correction_right=12,
+            mask_image_plane=0,
+            exclusion_labels=['small_size', 'motion_border']))
+
+    with open(cpath, "w") as f:
+        json.dump(rois, f)
+    yield cpath
+
+
+@pytest.fixture
+def mock_motion_csv(tmp_path):
+    mpath = tmp_path / "m.csv"
+    with open(mpath, "w") as fp:
+        fp.write("content")
+    yield mpath
+
+
+def test_binarize_extract(mock_compatible_path, mock_motion_csv,
+                          mock_movie_path, tmp_path):
+    outpath = tmp_path / "myoutput.json"
+    args = {
+            'input_file': str(mock_compatible_path),
+            'storage_directory': str(tmp_path),
+            'motion_corrected_video': str(mock_movie_path),
+            'motion_correction_values': str(mock_motion_csv),
+            'output_json': str(outpath)
+            }
+    bridge = BinarizeToExtractBridge(input_data=args, args=[])
+    bridge.run()
+
+    with open(outpath, 'r') as f:
+        outj = json.load(f)
+
+    assert outj['log_0'] == str(mock_motion_csv)
+    assert outj['motion_corrected_stack'] == str(mock_movie_path)
+    assert outj['storage_directory'] == str(tmp_path)
+    with open(mock_compatible_path, 'r') as f:
+        nroi = len(json.load(f))
+    assert len(outj['rois']) == nroi
+    assert 'motion_border' in outj

--- a/tests/transforms/test_roi_transforms.py
+++ b/tests/transforms/test_roi_transforms.py
@@ -5,6 +5,29 @@ from scipy.sparse import coo_matrix
 
 from ophys_etl.extractors.motion_correction import MotionBorder
 from ophys_etl.transforms import roi_transforms
+from ophys_etl.types import DenseROI
+
+
+def test_dense_to_extract():
+    d = DenseROI(
+            id=1,
+            x=23,
+            y=34,
+            width=128,
+            height=128,
+            valid_roi=True,
+            mask_matrix=[[True, True], [False, True]],
+            max_correction_up=12,
+            max_correction_down=12,
+            max_correction_left=12,
+            max_correction_right=12,
+            mask_image_plane=0,
+            exclusion_labels=['small_size', 'motion_border'])
+    e = roi_transforms.dense_to_extract(d)
+    for k in ['id', 'x', 'y', 'width', 'height']:
+        assert e[k] == d[k]
+    assert e['mask'] == d['mask_matrix']
+    assert e['valid'] == d['valid_roi']
 
 
 @pytest.mark.parametrize("s2p_stat_fixture", [


### PR DESCRIPTION
In production a [LIMS strategy](http://stash.corp.alleninstitute.org/projects/TECH/repos/lims/browse/app/strategies/ophys_extract_traces_v2_strategy.rb#20) transforms the output of segment/binarize to the input for `extract_traces`. This PR adds a python module that performs that transformation also, for ease-of-use in development environments. With this module, the following script can run segementation, binarization, and trace extraction with no LIMS connections:
```
#!/bin/bash
#PBS -q braintv
#PBS -l nodes=1:ppn=10
#PBS -l mem=100g
#PBS -l walltime=02:00:00
#PBS -N prod_seg_example
#PBS -j oe
#PBS -o /allen/aibs/informatics/danielk/dev_LIMS/logs
#PBS -t 0

ename=/allen/aibs/informatics/danielk/dev_LIMS/experiments.json
read -r eid vid mot <<< $(python -c "import json; fp=open('${ename}', 'r'); j=json.load(fp)[${PBS_ARRAYID}];fp.close();print j['id'], j['MotionCorrectedImageStack'], j['OphysMotionXyOffsetData']")

outdir=/allen/aibs/informatics/danielk/dev_LIMS/slapp_reruns/${eid}
segout=${outdir}/binarize_output.json
extractin=${outdir}/extract_input.json
mkdir -p ${outdir}

image=/allen/aibs/informatics/danielk/dev_LIMS/suite2p_container.img_latest.sif
#image=library://allen_institute_pika/ophys_etl_pipelines/suite2p_container.img:latest

# segment and binarize
singularity run \
        --bind /allen:/allen,/scratch/capacity/${PBS_JOBID}:/tmp \
        ${image} \
        python -m ophys_etl.pipelines.segment_binarize_pipeline \
        --motion_corrected_video ${vid} \
       --motion_correction_values ${mot} \
        --log_level INFO \
        --output_json ${segout}

# bridge to extract
singularity run \
        --bind /allen:/allen,/scratch/capacity/${PBS_JOBID}:/tmp \
        ${image} \
        python -m ophys_etl.transforms.binarize_extract_bridge \
        --input_file ${segout} \
        --storage_directory ${outdir} \
        --motion_corrected_video ${vid} \
        --motion_correction_values ${mot} \
        --log_level INFO \
        --output_json ${extractin}

# extract traces
/allen/aibs/technology/conda/run_miniconda.sh \
        /allen/aibs/technology/conda/production/allensdk_py36 \
        python -m allensdk.brain_observatory.ophys.trace_extraction \
        --input_json ${extractin} \
        --log_level INFO \
        --output_json ${outdir}/extract_traces_output.json
```
The `json` read at the start enables running many of these at once in a PBS job array. The first entry is:
```
[
  {
    "MotionCorrectedImageStack": "/allen/programs/braintv/production/neuralcoding/prod0/specimen_813702151/ophys_session_849304162/ophys_experiment_850517344/processed//motion_corrected_video.h5",
    "OphysMotionXyOffsetData": "/allen/programs/braintv/production/neuralcoding/prod0/specimen_813702151/ophys_session_849304162/ophys_experiment_850517344/processed//850517344_rigid_motion_transform.csv",
    "id": 850517344
  },
...
]
```
This script created and filled this directory:
```
$ ls -R slapp_reruns/
slapp_reruns/:
850517344

slapp_reruns/850517344:
binarize_output.json  extract_traces_output.json  roi_traces.h5
extract_input.json    neuropil_traces.h5
```