### PR TITLE
skips over empty ROIs

### DIFF
--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -117,15 +117,16 @@ def roi_bounds(roi_mask: coo_matrix) -> Tuple[int, int, int, int]:
         (min_row, max_row, min_col, max_col)
     """
 
-    if roi_mask.row.size > 0 and roi_mask.col.size > 0:
-        min_row = roi_mask.row.min()
-        min_col = roi_mask.col.min()
-        # Need to add 1 to max indices to get correct slicing upper bound
-        max_row = roi_mask.row.max() + 1
-        max_col = roi_mask.col.max() + 1
-        return (min_row, max_row, min_col, max_col)
-    else:
-        return (0, 0, 0, 0)
+    if roi_mask.row.size == 0 | roi_mask.col.size == 0:
+        return None
+
+    min_row = roi_mask.row.min()
+    min_col = roi_mask.col.min()
+    # Need to add 1 to max indices to get correct slicing upper bound
+    max_row = roi_mask.row.max() + 1
+    max_col = roi_mask.col.max() + 1
+
+    return (min_row, max_row, min_col, max_col)
 
 
 def crop_roi_mask(roi_mask: coo_matrix) -> coo_matrix:
@@ -190,6 +191,9 @@ def coo_rois_to_lims_compatible(coo_masks: List[coo_matrix],
     compatible_rois = []
     for temp_id, coo_mask in enumerate(coo_masks):
         compatible_roi = _coo_mask_to_LIMS_compatible_format(coo_mask)
+        if compatible_roi is None:
+            continue
+
         compatible_roi['id'] = temp_id  # popped off when writing to LIMs
         compatible_roi['max_correction_up'] = max_correction_vals.up
         compatible_roi['max_correction_down'] = max_correction_vals.down
@@ -222,6 +226,9 @@ def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> DenseROI:
 
     """
     bounds = roi_bounds(coo_mask)
+    if bounds is None:
+        return None
+
     height = bounds[1] - bounds[0]
     width = bounds[3] - bounds[2]
     mask_matrix = crop_roi_mask(coo_mask).toarray()

--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -115,6 +115,7 @@ def roi_bounds(roi_mask: coo_matrix) -> Tuple[int, int, int, int]:
     Tuple[int, int, int, int]
         Slicing bounds to extract an ROI in the following order:
         (min_row, max_row, min_col, max_col)
+        or None if mask is empty
     """
 
     if roi_mask.row.size == 0 | roi_mask.col.size == 0:
@@ -139,21 +140,16 @@ def crop_roi_mask(roi_mask: coo_matrix) -> coo_matrix:
     Returns
     -------
     coo_matrix
-        A cropped ROI mask
+        A cropped ROI mask or None if coo_matrix is empty
 
-    Raises
-    ------
-    ValueError
-        Raised if an empty ROI mask is provided
     """
-    if roi_mask.row.size > 0 and roi_mask.col.size > 0:
-        min_row, max_row, min_col, max_col = roi_bounds(roi_mask)
-    else:
-        raise ValueError("Cannot crop an empty ROI mask (or mask where all "
-                         "elements are zero)")
+
+    bounds = roi_bounds(roi_mask)
+    if bounds is None:
+        return None
 
     # Convert coo to csr matrix so we can take advantage of indexing
-    cropped_mask = roi_mask.tocsr()[min_row:max_row, min_col:max_col]
+    cropped_mask = roi_mask.tocsr()[bounds[0]:bounds[1], bounds[2]:bounds[3]]
 
     return cropped_mask.tocoo()
 
@@ -223,6 +219,7 @@ def _coo_mask_to_LIMS_compatible_format(coo_mask: coo_matrix) -> DenseROI:
     Returns
     -------
     DenseROI
+       or None if the coo_mask is empty
 
     """
     bounds = roi_bounds(coo_mask)

--- a/tests/transforms/test_roi_transforms.py
+++ b/tests/transforms/test_roi_transforms.py
@@ -92,7 +92,7 @@ def test_binarize_roi_mask(mask, expected, absolute_threshold, quantile):
                [0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0]]),
-     (0, 0, 0, 0)),
+     None),
 
     (np.array([[1, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0],
@@ -296,7 +296,9 @@ def test_small_size_exclusion(dense_mask, npixel_threshold, expected):
             coo_matrix(([1, 1, 1, 1], ([0, 1, 0, 1], [0, 0, 1, 1])),
                        shape=(20, 20)),
             coo_matrix(([1, 1, 1, 0], ([12, 13, 12, 13], [12, 12, 13, 13])),
-                       shape=(20, 20))
+                       shape=(20, 20)),
+            # this empty one should get filtered away
+            coo_matrix([[]])
            ],
           MotionBorder(2.5, 2.5, 2.5, 2.5), 3,
           [{'id': 0,

--- a/tests/transforms/test_roi_transforms.py
+++ b/tests/transforms/test_roi_transforms.py
@@ -130,7 +130,7 @@ def test_roi_bounds(mask, expected):
     assert obtained == expected
 
 
-@pytest.mark.parametrize("mask, expected, raises_error", [
+@pytest.mark.parametrize("mask, expected", [
     (np.array([[0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0],
                [0, 0, 1, 1, 0, 0],
@@ -138,9 +138,7 @@ def test_roi_bounds(mask, expected):
                [0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0]]),
      np.array([[1, 1],
-               [1, 1]]),
-     False),
-
+               [1, 1]])),
     (np.array([[0., 0., 0., 0., 0., 0.],
                [0., 1., 0., 0., 0., 0.],
                [0., 0., 2., 1., 0., 0.],
@@ -149,28 +147,22 @@ def test_roi_bounds(mask, expected):
                [0., 0., 0., 0., 0., 0.]]),
      np.array([[1., 0., 0.],
                [0., 2., 1.],
-               [0., 1., 1.]]),
-     False),
-
+               [0., 1., 1.]])),
     (np.array([[1.]]),
-     np.array([[1.]]),
-     False),
-
+     np.array([[1.]])),
     (np.array([[0., 0., 0., 0.],
                [0., 0., 0., 0.],
                [0., 0., 0., 0.]]),
-     None,  # Doesn't matter what this is
-     True)
+     None)
 ])
-def test_crop_roi_mask(mask, expected, raises_error):
+def test_crop_roi_mask(mask, expected):
     coo_mask = coo_matrix(mask)
 
-    if not raises_error:
-        obtained = roi_transforms.crop_roi_mask(coo_mask)
-        assert np.allclose(obtained.toarray(), expected)
+    obtained = roi_transforms.crop_roi_mask(coo_mask)
+    if expected is None:
+        assert obtained is None
     else:
-        with pytest.raises(ValueError, match="Cannot crop an empty ROI mask"):
-            obtained = roi_transforms.crop_roi_mask(coo_mask)
+        assert np.allclose(obtained.toarray(), expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When running 126 ophys experiments, 5 failed with an empty coo matrix. This PR implements a skipping-over of these ROIs.

### Validation
These 5 runs failed with the current master image:
```
[
{
  "MotionCorrectedImageStack": "/allen/programs/braintv/production/visualbehavior/prod2/specimen_887264964/ophys_session_960593969/ophys_experiment_960960480/processed//motion_corrected_video.h5",
  "OphysMotionXyOffsetData": "/allen/programs/braintv/production/visualbehavior/prod2/specimen_887264964/ophys_session_960593969/ophys_experiment_960960480/processed//960960480_rigid_motion_transform.csv",
  "id": 960960480
}
{
  "MotionCorrectedImageStack": "/allen/programs/braintv/production/visualbehavior/prod2/specimen_887264964/ophys_session_957189583/ophys_experiment_957652800/processed//motion_corrected_video.h5",
  "OphysMotionXyOffsetData": "/allen/programs/braintv/production/visualbehavior/prod2/specimen_887264964/ophys_session_957189583/ophys_experiment_957652800/processed//957652800_rigid_motion_transform.csv",
  "id": 957652800
}
{
  "MotionCorrectedImageStack": "/allen/programs/braintv/production/visualbehavior/prod3/specimen_910267443/ophys_session_995560574/ophys_experiment_995622557/processed//motion_corrected_video.h5",
  "OphysMotionXyOffsetData": "/allen/programs/braintv/production/visualbehavior/prod3/specimen_910267443/ophys_session_995560574/ophys_experiment_995622557/processed//995622557_rigid_motion_transform.csv",
  "id": 995622557
}
{
  "MotionCorrectedImageStack": "/allen/programs/braintv/production/visualbehavior/prod5/specimen_989489224/ophys_session_1012635881/ophys_experiment_1012746738/processed//motion_corrected_video.h5",
  "OphysMotionXyOffsetData": "/allen/programs/braintv/production/visualbehavior/prod5/specimen_989489224/ophys_session_1012635881/ophys_experiment_1012746738/processed//1012746738_rigid_motion_transform.csv",
  "id": 1012746738
}
{
  "MotionCorrectedImageStack": "/allen/programs/braintv/production/visualbehavior/prod3/specimen_916452082/ophys_session_990144181/ophys_experiment_990381322/processed//motion_corrected_video.h5",
  "OphysMotionXyOffsetData": "/allen/programs/braintv/production/visualbehavior/prod3/specimen_916452082/ophys_session_990144181/ophys_experiment_990381322/processed//990381322_rigid_motion_transform.csv",
  "id": 990381322
}
]
```
with this change, these no longer fail and go through extract traces.