### PR TITLE
GH-67 Replace `bin_size` with `bin_duration` and `movie_frame_rate` args

### DIFF
--- a/src/ophys_etl/pipelines/segment_binarize_pipeline.py
+++ b/src/ophys_etl/pipelines/segment_binarize_pipeline.py
@@ -48,9 +48,6 @@ class SegmentBinarizeSchema(argschema.ArgSchema):
                               / "Suite2P_output.json")
             data["suite2p_args"]["output_json"] = str(Suite2p_output)
 
-        if "bin_size" not in data["suite2p_args"]:
-            data["suite2p_args"]["bin_size"] = 115
-
         data["suite2p_args"]["log_level"] = data["log_level"]
 
         # convert_args

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -70,9 +70,11 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
                          "Suite2P default."))
     nbinned = argschema.fields.Int(
             required=False,
-            description=("Max num of binned frames for cell detection. Below "
-                         "is an Allen-specific parameter `bin_size` from "
-                         "which this setting is derived, if not provided."))
+            description=("Max num of binned frames for cell detection. "
+                         "Below are Allen-specific parameters "
+                         "`bin_duration + movie_frame_rate` "
+                         "from which this setting can be derived, if "
+                         "not provided."))
     max_iterations = argschema.fields.Int(
             default=20,
             description="Max num iterations to detect cells. Suite2P default")
@@ -119,11 +121,23 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
                          "run a demixing step that should allow both ROIs "
                          "to share pixels."))
     # Allen-specific options
-    bin_size = argschema.fields.Int(
+    movie_frame_rate = argschema.fields.Float(
             required=False,
-            description=("If nbinned not provided, will calculate nbinned as "
-                         "nframes / bin_size. This allows consistent temporal "
-                         "downsampling across movies of different lengths."))
+            description=("The frame rate (in Hz) of the optical physiology "
+                         "movie to be Suite2P segmented. Used in conjunction "
+                         "with 'bin_duration' to derive an 'nbinned' "
+                         "Suite2P value."))
+    bin_duration = argschema.fields.Float(
+            required=False,
+            default=3.7,
+            description=("The duration of time (in seconds) that should be "
+                         "considered 1 bin for Suite2P ROI detection "
+                         "purposes. Requires a valid value for "
+                         "'movie_frame_rate' in order to derive an "
+                         "'nbinned' Suite2P value. This allows "
+                         "consistent temporal downsampling across movies "
+                         "with different lengths and/or frame rates. By "
+                         "default, 3.7 seconds."))
     output_dir = argschema.fields.OutputDir(
             required=True,
             description="for minimal and cleaner output, specifies output dir")
@@ -143,9 +157,9 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
 
     @mm.post_load
     def check_args(self, data, **kwargs):
-        if ('nbinned' not in data) & ('bin_size' not in data):
+        if ('nbinned' not in data) & ('movie_frame_rate' not in data):
             raise Suite2PWrapperException(
-                    "must provide either `nbinned` or `bin_size`")
+                    "Must provide either `nbinned` or `movie_frame_rate`")
         return data
 
     @mm.post_load
@@ -221,13 +235,18 @@ class Suite2PWrapper(argschema.ArgSchemaParser):
         self.logger.name = type(self).__name__
         self.logger.setLevel(self.args.pop('log_level'))
 
-        # determine nbinned from bin_size
+        # determine nbinned from bin_duration and movie_frame_rate
         if 'nbinned' not in self.args:
             with h5py.File(self.args['h5py'], 'r') as f:
                 nframes = f['data'].shape[0]
-            self.args['nbinned'] = int(nframes / self.args['bin_size'])
-            self.logger.info(f"movie has {nframes} frames. Setting nbinned "
-                             f"to {self.args['nbinned']}")
+            bin_size = (self.args['bin_duration']
+                        * self.args['movie_frame_rate'])
+            self.args['nbinned'] = int(nframes / bin_size)
+            self.logger.info(f"Movie has {nframes} frames collected at "
+                             f"{self.args['movie_frame_rate']} Hz. To get a "
+                             f"bin duration of {self.args['bin_duration']} "
+                             f"seconds, setting nbinned to "
+                             f"{self.args['nbinned']}.")
 
         # make a tempdir for Suite2P's output
         with tempfile.TemporaryDirectory() as tdir:

--- a/tests/pipelines/test_segment_binarize_pipeline.py
+++ b/tests/pipelines/test_segment_binarize_pipeline.py
@@ -62,7 +62,9 @@ def test_segment_binarize_pipeline(tmp_path):
     outj_path = tmp_path / "output.json"
 
     args = {"suite2p_args": {
-                "h5py": str(h5path)},
+                "h5py": str(h5path),
+                "movie_frame_rate": 31.0,
+            },
             "convert_args": {
                 "motion_correction_values": str(mcvalues_path)},
             "output_json": str(outj_path)

--- a/tests/transforms/test_suite2p_wrapper.py
+++ b/tests/transforms/test_suite2p_wrapper.py
@@ -79,7 +79,7 @@ def suite2p_side_effect(args):
 
 
 @pytest.mark.parametrize(
-        "retain_files, nbinned, bin_size, exception",
+        "retain_files, nbinned, movie_frame_rate, exception",
         [
             ([['stat.npy'], 10, None, False]),
             ([['stat.npy'], None, 10, False]),
@@ -88,7 +88,8 @@ def suite2p_side_effect(args):
             ([['all'], 10, None, False]),
             ])
 def test_suite2p_wrapper(
-        tmp_path, monkeypatch, retain_files, nbinned, bin_size, exception):
+        tmp_path, monkeypatch, retain_files, nbinned,
+        movie_frame_rate, exception):
     nframes = 100
     input_file = tmp_path / "input.h5py"
     with h5py.File(input_file, "w") as f:
@@ -103,8 +104,8 @@ def test_suite2p_wrapper(
 
     if nbinned is not None:
         args['nbinned'] = nbinned
-    if bin_size is not None:
-        args['bin_size'] = bin_size
+    if movie_frame_rate is not None:
+        args['movie_frame_rate'] = movie_frame_rate
 
     mock_suite2p = MagicMock()
     mock_suite2p.run_s2p = MagicMock()
@@ -121,7 +122,8 @@ def test_suite2p_wrapper(
     s = suite2p_wrapper.Suite2PWrapper(input_data=args, args=[])
     s.run()
 
-    if bin_size is not None:
+    if movie_frame_rate is not None:
+        bin_size = s.args['bin_duration'] * movie_frame_rate
         assert s.args['nbinned'] == int(nframes / bin_size)
 
     assert os.path.isfile(args['output_json'])


### PR DESCRIPTION
This commit replaces the `bin_size` arg. Previously, because it was
assumed that all ophys movies had the same frame rate but
different numbers of frames, the `bin_size` arg was introduced to
ensure consistent temporal downsampling across movies of with
different numbers of frames.

Thus Suite2P 'nbinned' = number_frames / bin_size

It turns out however that the frame rate betwen Scientifica
and Mesoscope movies differs drastically (31 Hz vs 11 Hz). In order
to ensure consistent temporal downsampling across movies with
different numbers of frames and/or frame rates, information about
the 'movie_frame_rate' and 'bin_duration' is also needed.

The new implementation looks like:

bin_size = bin_duration (seconds) * frame_rate (frames/second)
nbinned = nframes / bin_size

TODO

- [x] Change merge target to `master` once #70 is merged into `master` (and rebase)