### PR TITLE
explicit pad mode for numpy 1.16 (inside container)

### DIFF
--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -38,7 +38,8 @@ def full_mask_constructor(mask_matrix: List[List[bool]], x: int, y: int,
     height, width = np.array(mask_matrix).shape
     mask = np.pad(mask_matrix,
                   pad_width=((y, shape[0] - height - y),
-                             (x, shape[1] - width - x)))
+                             (x, shape[1] - width - x)),
+                  mode='constant')
     return mask
 
 


### PR DESCRIPTION
fixes failed container test because of old numpy required arg.