### PR TITLE
Update postprocess_rois.py

### DIFF
--- a/src/ophys_etl/transforms/postprocess_rois.py
+++ b/src/ophys_etl/transforms/postprocess_rois.py
@@ -64,7 +64,7 @@ class PostProcessROIsInputSchema(ArgSchema):
         description=("The quantile against which an ROI is binarized. If not "
                      "provided will use default function value of 0.1."))
     npixel_threshold = Int(
-        default=85,
+        default=40,
         required=False,
         description=("ROIs with fewer pixels than this will be labeled as "
                      "invalid and small size."))


### PR DESCRIPTION
makes 40 pixels the default npixel_threshold cutoff