### PR TITLE
Bugfix/morphological empty rois

### DIFF
--- a/src/ophys_etl/transforms/postprocess_rois.py
+++ b/src/ophys_etl/transforms/postprocess_rois.py
@@ -78,7 +78,10 @@ class PostProcessROIsInputSchema(ArgSchema):
         default=True,
         required=False,
         description=("whether to perform morphological operations after "
-                     "binarization"))
+                     "binarization. ROIs that are washed away to empty "
+                     "after this operation are eliminated from the record. "
+                     "This can apply to ROIs that were previously labeled "
+                     "as small size, for example."))
 
 
 class PostProcessROIs(ArgSchemaParser):
@@ -142,6 +145,8 @@ class PostProcessROIs(ArgSchemaParser):
         if self.args['morphological_ops']:
             compatible_rois = [morphological_transform(roi, shape=movie_shape)
                                for roi in compatible_rois]
+            # eliminate None
+            compatible_rois = [roi for roi in compatible_rois if roi]
 
         # validate ROIs
         errors = DenseROISchema(many=True).validate(compatible_rois)

--- a/src/ophys_etl/transforms/postprocess_rois.py
+++ b/src/ophys_etl/transforms/postprocess_rois.py
@@ -145,8 +145,12 @@ class PostProcessROIs(ArgSchemaParser):
         if self.args['morphological_ops']:
             compatible_rois = [morphological_transform(roi, shape=movie_shape)
                                for roi in compatible_rois]
+            n_rois = len(compatible_rois)
             # eliminate None
             compatible_rois = [roi for roi in compatible_rois if roi]
+            n_rois_morphed = len(compatible_rois)
+            self.logger.info("morphological transform reduced number of "
+                             f"ROIs from {n_rois} to {n_rois_morphed}")
 
         # validate ROIs
         errors = DenseROISchema(many=True).validate(compatible_rois)

--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -74,7 +74,8 @@ def roi_from_full_mask(roi: DenseROI, mask: np.ndarray
     return roi
 
 
-def morphological_transform(roi: DenseROI, shape: Tuple[int, int]) -> DenseROI:
+def morphological_transform(roi: DenseROI, shape: Tuple[int, int]
+                            ) -> Union[DenseROI, None]:
     """performs a closing followed by an opening to clean up pixelated
     appearance of ROIs
 
@@ -89,12 +90,7 @@ def morphological_transform(roi: DenseROI, shape: Tuple[int, int]) -> DenseROI:
     Returns
     -------
     roi: DenseROI
-        transformed roi
-
-    Raises
-    ------
-    ValueError
-        if the operation leaves no pixels
+        transformed roi or None if empty after transform
 
     """
 
@@ -103,9 +99,6 @@ def morphological_transform(roi: DenseROI, shape: Tuple[int, int]) -> DenseROI:
     mask = binary_closing(mask, selem=structuring_element)
     mask = binary_opening(mask, selem=structuring_element)
     new_roi = roi_from_full_mask(roi, mask)
-    if new_roi is None:
-        raise ValueError(f"roi {roi['id']} had no pixels left after "
-                         "morphological transform")
     return new_roi
 
 

--- a/src/ophys_etl/transforms/roi_transforms.py
+++ b/src/ophys_etl/transforms/roi_transforms.py
@@ -63,10 +63,10 @@ def roi_from_full_mask(roi: DenseROI, mask: np.ndarray
     where = np.where(mask)
     if where[0].size == 0:
         return None
-    roi['x'] = where[1].min()
-    roi['width'] = where[1].ptp() + 1
-    roi['y'] = where[0].min()
-    roi['height'] = where[0].ptp() + 1
+    roi['x'] = int(where[1].min())
+    roi['width'] = int(where[1].ptp() + 1)
+    roi['y'] = int(where[0].min())
+    roi['height'] = int(where[0].ptp() + 1)
     list_mask = []
     for y in range(roi['y'], roi['y'] + roi['height']):
         list_mask.append(mask[y, roi['x']:(roi['x'] + roi['width'])].tolist())

--- a/tests/transforms/test_roi_transforms.py
+++ b/tests/transforms/test_roi_transforms.py
@@ -82,7 +82,7 @@ def test_roi_from_full_mask(full_mask, roi, expected):
 
 
 @pytest.mark.parametrize(
-    "mask_matrix, fail",
+    "mask_matrix, expect_None",
     [
         (
             [[True, True], [False, True]],
@@ -97,7 +97,7 @@ def test_roi_from_full_mask(full_mask, roi, expected):
         )
     ]
 )
-def test_morphological_transform(mask_matrix, fail):
+def test_morphological_transform(mask_matrix, expect_None):
     d = DenseROI(id=1, x=23, y=34, width=128, height=128, valid_roi=True,
                  mask_matrix=mask_matrix,
                  max_correction_up=12,
@@ -106,9 +106,8 @@ def test_morphological_transform(mask_matrix, fail):
                  max_correction_right=12,
                  mask_image_plane=0,
                  exclusion_labels=['small_size', 'motion_border'])
-    if fail:
-        with pytest.raises(ValueError, match=r".*had no pixels left"):
-            roi_transforms.morphological_transform(d, (50, 50))
+    if expect_None:
+        assert roi_transforms.morphological_transform(d, (50, 50)) is None
         return
 
     morphed = roi_transforms.morphological_transform(d, (50, 50))


### PR DESCRIPTION
Resolves some issues that came up when running real data:
* the raised ValueError on completely eroded ROIs was written with valid, > 40 pixel ROIs in mind. But small-sized ROIs are passed to the morpohological filter also, they are just labeled as small. Changed to return a None if the ROI is eroded away.
* eventual json.dump failed because of numpy int64s.
* adds logging message.