### PR TITLE
New dff traces

### DIFF
--- a/src/ophys_etl/pipelines/dff.py
+++ b/src/ophys_etl/pipelines/dff.py
@@ -138,7 +138,11 @@ class DffJob(ArgSchemaParser):
         # The traces can be large, so load them into memory 'row-wise' and
         #   rely on reference counting for cleanup.
         # Default in h5 is C order storage so this should be fairly efficient
-        for i in range(traces_dataset.shape[0]):
+        trace_len = traces_dataset.shape[0]
+        self.logger.info(f"Computing dff traces: 0/{trace_len}")
+        for i in range(trace_len):
+            if (i % 20 == 0) and (i != 0):
+                self.logger.info(f"Working on {i}/{trace_len}...")
             trace = traces_dataset[i, :]
             dff, sigma_dff, small_baseline = compute_dff_trace(
                 trace,
@@ -148,6 +152,7 @@ class DffJob(ArgSchemaParser):
             small_baselines[i] = small_baseline
             dff_dataset[i] = dff
 
+        self.logger.info("Dff traces complete.")
         # Clean up
         output_h5.close()
         input_h5.close()

--- a/src/ophys_etl/pipelines/dff.py
+++ b/src/ophys_etl/pipelines/dff.py
@@ -116,7 +116,7 @@ class DffJob(ArgSchemaParser):
     """
     This is the job runner for the dF/F computation from F (fluorescence)
     traces. The primary data input is the h5 file produced by neuropil
-    subtraction, which contains the "corrected fluorescence trace"
+    subtraction, which contains the neuropil-corrected fluorescence trace.
     (by default in the "CF" key).
 
     NOTE: There has historically been no data saved in the output json

--- a/src/ophys_etl/pipelines/dff.py
+++ b/src/ophys_etl/pipelines/dff.py
@@ -1,0 +1,161 @@
+# Compute deltaF/F
+from argschema import ArgSchema, ArgSchemaParser, fields
+from marshmallow import post_load
+import numpy as np
+import h5py
+
+from ophys_etl.transforms.trace_transforms import compute_dff_trace
+
+
+class DffJobSchema(ArgSchema):
+    input_file = fields.InputFile(
+        required=True,
+        description=("Input h5 file containing fluorescence traces and the "
+                     "associated ROI IDs (in datasets specified by the keys "
+                     "'input_dataset' and 'roi_field', respectively.")
+        )
+    output_file = fields.OutputFile(
+        required=True,
+        description="h5 file to write the results of dff computation."
+        )
+    movie_frame_rate_hz = fields.Float(
+        required=True,
+        description=("Acquisition frame rate for the trace data in "
+                     "`input_dataset`")
+    )
+    log_level = fields.Int(
+        required=False,
+        default=20      # logging.INFO
+        )
+    input_dataset = fields.Str(
+        required=False,
+        default="FC",
+        description="Key of h5 dataset to use from `input_file`."
+    )
+    roi_field = fields.Str(
+        required=False,
+        default="roi_names",
+        description=("The h5 dataset key in both the `input_file` and "
+                     "`output_file` containing ROI IDs associated with "
+                     "traces.")
+        )
+    output_dataset = fields.Str(
+        required=False,
+        default="data",
+        description=("h5 dataset key used to store the computed dff traces "
+                     "in `output_file`.")
+    )
+    sigma_dataset = fields.Str(
+        required=False,
+        default="sigma_dff",
+        description=("h5 dataset key used to store the estimated noise "
+                     "standard deviation for the dff traces in `output_file`.")
+    )
+    baseline_frames_dataset = fields.Str(
+        required=False,
+        default="num_small_baseline_frames",
+        description=("h5 dataset key used to store the number of small "
+                     "baseline frames (where the computed baseline of the "
+                     "fluorescence trace was smaller than its estimated "
+                     "noise standard deviation) in `output_file`.")
+    )
+    long_baseline_filter_s = fields.Int(
+        required=False,
+        default=600,
+        description=("Number of seconds to use in the rolling median "
+                     "filter for for computing the baseline activity. "
+                     "The length of the filter is the frame rate of the "
+                     "signal in Hz * the long baseline filter seconds ("
+                     "+1 if the result is even, since the median filter "
+                     "length must be odd).")
+    )
+    short_filter_s = fields.Float(
+        required=False,
+        default=3.333,
+        description=("Number of seconds to use in the rolling median "
+                     "filter for the short timescale detrending. "
+                     "The length of the filter is the frame rate of the "
+                     "signal in Hz * the short baseline filter seconds ("
+                     "+1 if the result is even, since the median filter "
+                     "length must be odd).")
+    )
+
+    @post_load
+    def filter_s_to_frames(self, item, **kwargs):
+        """Convert number of seconds to number of frames for the
+        filters `short_filter_s`, `long_baseline_filter_s`. If the
+        number of frames is even, add 1."""
+        short_frames = int(np.round(
+            item["movie_frame_rate_hz"] * item["short_filter_s"]))
+        long_frames = int(np.round(
+            item["movie_frame_rate_hz"] * item["long_baseline_filter_s"]))
+        # Has to be odd
+        item["short_filter_frames"] = (
+            short_frames if short_frames % 2 else short_frames + 1)
+        item["long_filter_frames"] = (
+            long_frames if long_frames % 2 else long_frames + 1)
+        return item
+
+
+class DffJob(ArgSchemaParser):
+    """
+    This is the job runner for the dF/F computation from F (fluorescence)
+    traces. The primary data input is the h5 file produced by neuropil
+    subtraction, which contains the "corrected fluorescence trace"
+    (by default in the "CF" key).
+
+    NOTE: There has historically been no data saved in the output json
+    for this job in the AllenSDK, so the output json is just a
+    placeholder (empty dictionary).
+    """
+    default_schema = DffJobSchema
+
+    def run(self):
+        # Set up file and data pointers
+        input_h5 = h5py.File(self.args["input_file"], "r")
+        output_h5 = h5py.File(self.args["output_file"], "w")
+        roi_dataset = input_h5[self.args["roi_field"]]
+        traces_dataset = input_h5[self.args["input_dataset"]]
+
+        # Initialize storage
+        dff_dataset = output_h5.create_dataset(
+            self.args["output_dataset"], traces_dataset.shape)
+        sigma_dffs = output_h5.create_dataset(
+            self.args["sigma_dataset"], roi_dataset.shape)
+        small_baselines = output_h5.create_dataset(
+            self.args["baseline_frames_dataset"], roi_dataset.shape)
+        # Copy over the roi names
+        output_h5.create_dataset(self.args["roi_field"],
+                                 data=input_h5[self.args["roi_field"]][()])
+
+        # Check for id mapping mismatches
+        if roi_dataset.shape[0] != traces_dataset.shape[0]:
+            raise ValueError(
+                f"Can't associate ROIs of shape {roi_dataset.shape} "
+                f"to traces of shape {traces_dataset.shape}")
+
+        # Run computation
+        # The traces can be large, so load them into memory 'row-wise' and
+        #   rely on reference counting for cleanup.
+        # Default in h5 is C order storage so this should be fairly efficient
+        for i in range(traces_dataset.shape[0]):
+            trace = traces_dataset[i, :]
+            dff, sigma_dff, small_baseline = compute_dff_trace(
+                trace,
+                self.args["long_filter_frames"],
+                self.args["short_filter_frames"])
+            sigma_dffs[i] = sigma_dff
+            small_baselines[i] = small_baseline
+            dff_dataset[i] = dff
+
+        # Clean up
+        output_h5.close()
+        input_h5.close()
+
+        # Output json placeholder; no info saved in SDK pipeline
+        self.output({}, indent=2)
+
+
+if __name__ == "__main__":    # pragma: nocover
+    dff_job = DffJob()
+    dff_job.run()

--- a/src/ophys_etl/transforms/trace_transforms.py
+++ b/src/ophys_etl/transforms/trace_transforms.py
@@ -118,10 +118,19 @@ def noise_std(x: np.ndarray, filter_length: int = 31) -> float:
     return robust_std(filtered_noise_1)
 
 
-def dff_trace(corrected_fluorescence_trace: np.ndarray,
-              long_filter_length: int,
-              short_filter_length: int) -> Tuple[np.ndarray, float, int]:
+def compute_dff_trace(corrected_fluorescence_trace: np.ndarray,
+                      long_filter_length: int,
+                      short_filter_length: int
+                      ) -> Tuple[np.ndarray, float, int]:
     """
+    Compute the "delta F over F" from the fluorescence trace.
+    Uses configurable length median filters to compute baseline for
+    baseline-subtraction and short timescale detrending.
+    Returns the artifact-corrected and detrended dF/F, along with
+    additional metadata for QA: the estimated standard deviation of
+    the noise ("sigma_dff") and the number of frames where the
+    computed baseline was less than the standard deviation of the noise.
+
     Parameters
     ----------
     corrected_fluorescence_trace: np.array

--- a/src/ophys_etl/transforms/trace_transforms.py
+++ b/src/ophys_etl/transforms/trace_transforms.py
@@ -152,7 +152,7 @@ def compute_dff_trace(corrected_fluorescence_trace: np.ndarray,
         filter) was less than or equal to the estimated noise of the
         `corrected_fluorescence_trace`.
     """
-    sigma_f = noise_std(corrected_fluorescence_trace)
+    sigma_f = noise_std(corrected_fluorescence_trace, short_filter_length)
 
     # Long timescale median filter for baseline subtraction
     baseline = medfilt(corrected_fluorescence_trace, long_filter_length)
@@ -160,7 +160,7 @@ def compute_dff_trace(corrected_fluorescence_trace: np.ndarray,
            / np.maximum(baseline, sigma_f))
     num_small_baseline_frames = np.sum(baseline <= sigma_f)
 
-    sigma_dff = noise_std(dff)
+    sigma_dff = noise_std(dff, short_filter_length)
 
     # Short timescale detrending
     filtered_dff = medfilt(dff, short_filter_length)

--- a/src/ophys_etl/transforms/trace_transforms.py
+++ b/src/ophys_etl/transforms/trace_transforms.py
@@ -134,7 +134,7 @@ def compute_dff_trace(corrected_fluorescence_trace: np.ndarray,
     Parameters
     ----------
     corrected_fluorescence_trace: np.array
-        1d numpy array of the corrected fluorescence trace
+        1d numpy array of the neuropil-corrected fluorescence trace
     long_filter_length: int
         Length (in number of elements) of the long median filter used
         to compute a rolling baseline. Must be an odd number.

--- a/src/ophys_etl/transforms/trace_transforms.py
+++ b/src/ophys_etl/transforms/trace_transforms.py
@@ -1,7 +1,13 @@
-from typing import List
+from typing import List, Tuple
+from functools import partial
 
 import numpy as np
 from scipy.sparse import coo_matrix
+from scipy.ndimage.filters import median_filter
+
+
+# Partial for simplifying repeat median filter calls
+medfilt = partial(median_filter, mode='constant')
 
 
 def extract_traces(movie_frames: np.ndarray, rois: List[coo_matrix],
@@ -57,3 +63,100 @@ def extract_traces(movie_frames: np.ndarray, rois: List[coo_matrix],
                 traces[indx, time_slice] = raw_trace
 
     return traces
+
+
+def robust_std(x: np.ndarray) -> float:
+    """Compute the median absolute deviation assuming normally
+    distributed data. This is a robust statistic.
+
+    Parameters
+    ----------
+    x: np.ndarray
+        A numeric, 1d numpy array
+    Returns
+    -------
+    float:
+        A robust estimation of standard deviation.
+    Notes
+    -----
+    If `x` is an empty array or contains any NaNs, will return NaN.
+    """
+    mad = np.median(np.abs(x - np.median(x)))
+    return 1.4826*mad
+
+
+def noise_std(x: np.ndarray, filter_length: int = 31) -> float:
+    """Compute a robust estimation of the standard deviation of the
+    noise in a signal `x`. The noise is left after subtracting
+    a rolling median filter value from the signal. Outliers are removed
+    in 2 stages to make the estimation robust.
+
+    Parameters
+    ----------
+    x: np.ndarray
+        1d array of signal (perhaps with noise)
+    filter_length: int (default=31)
+        Length of the median filter to compute a rolling baseline,
+        which is subtracted from the signal `x`. Must be an odd number.
+
+    Returns
+    -------
+    float:
+        A robust estimation of the standard deviation of the noise.
+        If any valurs of `x` are NaN, returns NaN.
+    """
+    if any(np.isnan(x)):
+        return np.NaN
+    noise = x - medfilt(x, filter_length)
+    # first pass removing positive outlier peaks
+    # TODO: Confirm with scientific team that this is really what they want
+    # (method is fragile if possibly have 0 as min)
+    filtered_noise_0 = noise[noise < (1.5 * np.abs(noise.min()))]
+    rstd = robust_std(filtered_noise_0)
+    # second pass removing remaining pos and neg peak outliers
+    filtered_noise_1 = filtered_noise_0[abs(filtered_noise_0) < (2.5 * rstd)]
+    return robust_std(filtered_noise_1)
+
+
+def dff_trace(corrected_fluorescence_trace: np.ndarray,
+              long_filter_length: int,
+              short_filter_length: int) -> Tuple[np.ndarray, float, int]:
+    """
+    Parameters
+    ----------
+    corrected_fluorescence_trace: np.array
+        1d numpy array of the corrected fluorescence trace
+    long_filter_length: int
+        Length (in number of elements) of the long median filter used
+        to compute a rolling baseline. Must be an odd number.
+    short_filter_length: int (default=31)
+        Length (in number of elements) for a short median filter used
+        for short timescale detrending.
+    Returns
+    -------
+    np.ndarray:
+        The "dff" (delta_fluorescence/fluorescence) trace, 1d np.array
+    float:
+        The estimated standard deviation of the noise in the dff trace
+    int:
+        Number of frames where the baseline (long timescape median
+        filter) was less than or equal to the estimated noise of the
+        `corrected_fluorescence_trace`.
+    """
+    sigma_f = noise_std(corrected_fluorescence_trace)
+
+    # Long timescale median filter for baseline subtraction
+    baseline = medfilt(corrected_fluorescence_trace, long_filter_length)
+    dff = ((corrected_fluorescence_trace - baseline)
+           / np.maximum(baseline, sigma_f))
+    num_small_baseline_frames = np.sum(baseline <= sigma_f)
+
+    sigma_dff = noise_std(dff)
+
+    # Short timescale detrending
+    filtered_dff = medfilt(dff, short_filter_length)
+    # Constrain to 2.5x the estimated noise of dff
+    filtered_dff = np.minimum(filtered_dff, 2.5*sigma_dff)
+    detrended_dff = dff - filtered_dff
+
+    return detrended_dff, sigma_dff, num_small_baseline_frames

--- a/tests/pipelines/test_dff.py
+++ b/tests/pipelines/test_dff.py
@@ -1,0 +1,69 @@
+import numpy as np
+import h5py
+import pytest
+import json
+
+from ophys_etl.pipelines.dff import DffJob, DffJobSchema
+from ophys_etl.pipelines import dff
+
+
+@pytest.fixture
+def trace_h5(tmp_path):
+    with h5py.File(tmp_path / "input_trace.h5", "w") as f:
+        f.create_dataset("FC", data=np.ones((3, 100)))
+        f.create_dataset("roi_names",
+                         data=np.array([b'abc', b'123', b'drm'], dtype='|S3'))
+    f.close()
+    yield
+
+
+def test_dff_job_run(tmp_path, trace_h5, monkeypatch):
+    def mock_dff(x, y, z): return x, 0.1, 10
+
+    args = {
+        "input_file": str(tmp_path / "input_trace.h5"),
+        "output_file": str(tmp_path / "output_dff.h5"),
+        "output_json": str(tmp_path / "output_json.json"),
+        "movie_frame_rate_hz": 10.0,
+    }
+    dff_job = DffJob(input_data=args, args=[])
+    monkeypatch.setattr(dff, "compute_dff_trace", mock_dff)
+    dff_job.run()
+    # Load the output and check
+    with h5py.File(args["output_file"], "r") as f:
+        assert list(f.keys()) == [
+            "data", "num_small_baseline_frames", "roi_names", "sigma_dff"]
+        np.testing.assert_array_equal(np.ones((3, 100)), f["data"][()])
+        np.testing.assert_array_equal(
+            np.array([b'abc', b'123', b'drm'], dtype='|S3'),
+            f["roi_names"][()])
+        np.testing.assert_allclose(     # float stuff...
+            np.array([0.1, 0.1, 0.1]), f["sigma_dff"])
+        np.testing.assert_array_equal(
+            np.array([10, 10, 10]),
+            f["num_small_baseline_frames"])
+    with open(args["output_json"], "r") as f:
+        assert {} == json.load(f)
+
+
+@pytest.mark.parametrize(
+    "frame_rate, short_filter_s, long_filter_s, expected_short, expected_long",
+    [
+        (30., 3.3, 600., 99, 18001),
+        (11.1, 10.0, 1001., 111, 11111)
+    ]
+)
+def test_dff_schema_post_load(tmp_path, trace_h5, frame_rate, short_filter_s,
+                              long_filter_s, expected_short, expected_long):
+    args = {
+        "input_file": str(tmp_path / "input_trace.h5"),
+        "output_file": str(tmp_path / "output_dff.h5"),
+        "long_baseline_filter_s": long_filter_s,
+        "short_filter_s": short_filter_s,
+        "movie_frame_rate_hz": frame_rate
+    }
+    data = DffJobSchema().load(args)
+    assert data["short_filter_frames"] == expected_short
+    assert isinstance(data["short_filter_frames"], int)
+    assert data["long_filter_frames"] == expected_long
+    assert isinstance(data["long_filter_frames"], int)

--- a/tests/pipelines/test_dff.py
+++ b/tests/pipelines/test_dff.py
@@ -29,7 +29,7 @@ def test_dff_job_run(tmp_path, trace_h5, monkeypatch):
         "output_json": str(tmp_path / "output_json.json"),
         "movie_frame_rate_hz": 10.0,
     }
-    expected_output = {"output_file": args["output_file"], 
+    expected_output = {"output_file": args["output_file"],
                        "created_at": 123456789}
 
     dff_job = DffJob(input_data=args, args=[])

--- a/tests/transforms/test_trace_transforms.py
+++ b/tests/transforms/test_trace_transforms.py
@@ -92,7 +92,7 @@ def test_noise_std(x, expected, monkeypatch):
 def test_dff_trace(monkeypatch):
     """
     Notes:
-    If we don't constrain this it's very unwieldy. Not using 
+    If we don't constrain this it's very unwieldy. Not using
     parametrization because these values need to be
     monkeypatched thoughtfully to make a unit test work out
     Isn't a great candidate for mock because most of the
@@ -102,7 +102,7 @@ def test_dff_trace(monkeypatch):
     monkeypatch.setattr(tx, "medfilt", lambda x, y: x-1.0)
     f_trace = np.array([1.1, 2., 3., 3., 3., 11.])    # 2 "small baseline"
 
-    dff, sigma, small_baseline = tx.dff_trace(f_trace, 1, 1)
+    dff, sigma, small_baseline = tx.compute_dff_trace(f_trace, 1, 1)
     assert 2 == small_baseline
     assert 1.0 == sigma     # monkeypatched noise_std
     np.testing.assert_array_equal(np.ones(6), dff)

--- a/tests/transforms/test_trace_transforms.py
+++ b/tests/transforms/test_trace_transforms.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from scipy.sparse import coo_matrix
 
-from ophys_etl.transforms import trace_transforms
+from ophys_etl.transforms import trace_transforms as tx
 
 
 @pytest.mark.parametrize("frames, rois, normalize_by_roi_size, expected", [
@@ -56,7 +56,53 @@ from ophys_etl.transforms import trace_transforms
 def test_extract_traces(frames, rois, normalize_by_roi_size, expected):
     rois = [coo_matrix(roi) for roi in rois]
 
-    obtained = trace_transforms.extract_traces(frames, rois,
-                                               normalize_by_roi_size)
+    obtained = tx.extract_traces(frames, rois, normalize_by_roi_size)
 
     assert np.allclose(obtained, expected)
+
+
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        (np.zeros(10), 0.0),    # Zeros
+        (np.ones(20), 0.0),     # All same, not zero
+        (np.array([-1, -1, -1]), 0.0),   # Negatives
+        (np.array([]), np.NaN),   # Empty
+        (np.array([0, 0, np.NaN, 0.0]), np.NaN),     # Has NaN
+        (np.array([1]), 0.0),    # Unit
+        (np.array([-1, 2, 3]), 1.4826)    # Typical
+    ]
+)
+def test_robust_std(x, expected):
+    np.testing.assert_equal(expected, tx.robust_std(x))
+
+
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        (np.array([0, 1, 2, 3, np.NaN]), np.NaN),
+        (np.array([4, 10, 4, 5, 4]), 2.5)
+    ])
+def test_noise_std(x, expected, monkeypatch):
+    monkeypatch.setattr(tx, "robust_std", lambda x: x.max())
+    monkeypatch.setattr(tx, "medfilt", lambda x, y: x/2)
+    np.testing.assert_equal(expected, tx.noise_std(x))
+
+
+def test_dff_trace(monkeypatch):
+    """
+    Notes:
+    If we don't constrain this it's very unwieldy. Not using 
+    parametrization because these values need to be
+    monkeypatched thoughtfully to make a unit test work out
+    Isn't a great candidate for mock because most of the
+    logic pertains to filtering numpy arrays anyway.
+    """
+    monkeypatch.setattr(tx, "noise_std", lambda x: 1.0)
+    monkeypatch.setattr(tx, "medfilt", lambda x, y: x-1.0)
+    f_trace = np.array([1.1, 2., 3., 3., 3., 11.])    # 2 "small baseline"
+
+    dff, sigma, small_baseline = tx.dff_trace(f_trace, 1, 1)
+    assert 2 == small_baseline
+    assert 1.0 == sigma     # monkeypatched noise_std
+    np.testing.assert_array_equal(np.ones(6), dff)

--- a/tests/transforms/test_trace_transforms.py
+++ b/tests/transforms/test_trace_transforms.py
@@ -98,7 +98,7 @@ def test_dff_trace(monkeypatch):
     Isn't a great candidate for mock because most of the
     logic pertains to filtering numpy arrays anyway.
     """
-    monkeypatch.setattr(tx, "noise_std", lambda x: 1.0)
+    monkeypatch.setattr(tx, "noise_std", lambda x, y: 1.0)
     monkeypatch.setattr(tx, "medfilt", lambda x, y: x-1.0)
     f_trace = np.array([1.1, 2., 3., 3., 3., 11.])    # 2 "small baseline"
 


### PR DESCRIPTION
Note that this does not update the LIMS runner. We will need to deploy + toggle the executable for the visual behavior project after the next LIMS release (which should include the update for adding "movie_frame_rate_hz" to the input json for this job queue).

**Example** `ophys_session_1058716998/ophys_experiment_1058835259`:

![image](https://user-images.githubusercontent.com/34227334/97346105-3de40e00-1848-11eb-9781-9e88be686dc1.png)

Correct number of ROIs were output (261) by the new job runner.


**From Farzaneh's negative dff example:**  AllenSDK issue #1669

Original (with negative spike)
![image](https://user-images.githubusercontent.com/34227334/97348879-01b2ac80-184c-11eb-8d1c-f57c3d2d2545.png)

New -- assuming 11 Hz frame rate since it's mesoscope data; using 3 minute median baseline
![download](https://user-images.githubusercontent.com/34227334/97350098-8e119f00-184d-11eb-91c5-d80a1b0d681b.png)

Overlaid (all):
![download](https://user-images.githubusercontent.com/34227334/97350162-a386c900-184d-11eb-9f05-f7bd514680d9.png)

Overlaid (negative spike cropped out; start at frame 4000):
![download](https://user-images.githubusercontent.com/34227334/97350201-b13c4e80-184d-11eb-9e62-69cd2e124103.png)
