### PR TITLE
Mesocope plane extraction fix

### DIFF
--- a/src/ophys_etl/transforms/mesoscope_2p/scripts/extract_planes.py
+++ b/src/ophys_etl/transforms/mesoscope_2p/scripts/extract_planes.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import json
 import numpy as np
+from hashlib import sha256
 from ophys_etl.transforms.mesoscope_2p.metadata import SI_stringify_floats
 from ophys_etl.transforms.mesoscope_2p.tiff import MesoscopeTiff
 from ophys_etl.transforms.mesoscope_2p.conversion_utils import (
@@ -10,7 +11,7 @@ from ophys_etl.transforms.mesoscope_2p.conversion_utils import (
 
 def get_outfile(plane, folder, prefix=None, extension="tif"):
     if plane.flagged:
-        name = "no_roi_match"
+        name = "no_roi_match" + sha256(plane.asarray()).hexdigest()
     elif plane.metadata["name"]:
         name = plane.metadata["name"]
     else:

--- a/src/ophys_etl/transforms/mesoscope_2p/scripts/extract_planes.py
+++ b/src/ophys_etl/transforms/mesoscope_2p/scripts/extract_planes.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import json
 import numpy as np
+
 from hashlib import sha256
 from ophys_etl.transforms.mesoscope_2p.metadata import SI_stringify_floats
 from ophys_etl.transforms.mesoscope_2p.tiff import MesoscopeTiff

--- a/src/ophys_etl/transforms/mesoscope_2p/tiff.py
+++ b/src/ophys_etl/transforms/mesoscope_2p/tiff.py
@@ -1,5 +1,6 @@
 import numpy as np
 import logging
+
 from tifffile import TiffFile
 from .metadata import tiff_header_data, RoiMetadata
 
@@ -277,7 +278,7 @@ class MesoscopeTiff(object):
     def volume_stride(self):
         stride = 0
         # this logic is probably incorrect if there are 2+ volume scans
-        #  with identical zs, but needs testing to confirm
+        # with identical zs, but needs testing to confirm
         for zs in self.volume_scans:
             if any([roi for roi in self.rois if roi.volume_scanned(zs)]):
                 stride += 1
@@ -341,8 +342,8 @@ class MesoscopeTiff(object):
         if self._volumes is None:
             self._volumes = []
             page_offset = 0
-             # this logic is probably incorrect if there are 2+ volume scans
-             #  with identical zs, but needs testing to confirm
+            # this logic is probably incorrect if there are 2+ volume scans
+            # with identical zs, but needs testing to confirm
             for zs in self.volume_scans:
                 scanned = [roi for roi in self.rois if roi.volume_scanned(zs)]
                 if len(scanned) > 1:


### PR DESCRIPTION
This should fix plane extraction in the case where there are fastZs defined that don't get scanned by the microscope and thus don't end up in the tiff. Throw an error if the number of page offsets doesn't match the striding, since in that case the data is certainly being split wrong. During initial testing we didn't have a scenario where there were fastZs that didn't end up in the tiff, so I'm not sure what changed. Missed test case in the beginning I guess.

Added some comments on volume scans. I'm not able to test them since I don't have access to the rig, but it seems like they are incorrect in the case of 2 or more volume scans with identical z profiles. Maybe that doesn't happen ever, I don't know.

I didn't have much to work with for testing. Used 1040797492_averaged_surface.tiff. Previous code was trying to split that to 8 files due to 4 unscanned z=0 planes, but was actually just generating 5 files with clobber due to naming all the unscanned outputs the same (I added a hash to avoid this before I went on to fix the rest). This was resulting in incorrect page offsets for the 4 scanned planes, and only half as much data being used for averaging them as should have been.

It would definitely be good to test this alongside current code for full extraction against a mix of datasets, given how little data I had for testing.

Not really sure how to unit test, since it mostly depends on ScanImage metadata I don't remember the structure of. Didn't have time back then.