### PR TITLE
updates dockerfile to default to latest suite2p release

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ LABEL description="This dockerfile provides a working environment for \
                    Allen Institute for Brain Science optical physiology data \
                    processing pipelines."
 
-ARG SUITE2P_TAG=0.7.5
+ARG SUITE2P_TAG=v0.9.3
 ARG OPHYS_ETL_TAG=main
 ARG OPHYS_ETL_COMMIT_SHA="unknown build"
 


### PR DESCRIPTION
Suite2p [v0.9.3](https://github.com/MouseLand/suite2p/releases/tag/v0.9.3) was released. This release includes the [commit](https://github.com/MouseLand/suite2p/pull/562) for our requested fix regarding spatial scale defaults.