### PR TITLE
Gh 122 - Dewarping code cleanup

### DIFF
--- a/src/ophys_etl/transforms/sine_dewarp.py
+++ b/src/ophys_etl/transforms/sine_dewarp.py
@@ -568,10 +568,11 @@ def run_dewarping(FOVwidth: int,
         )
 
         # Chunk the movie up to prevent an error caused by multiprocessing
-        # returning too much data
+        # returning too much data. Use math.ceil in case there are fewer
+        # than chunk_size frame, then we just make one chunk.
         chunk_size = 1000
         movie_chunks = np.array_split(
-            movie, int(T / chunk_size), axis=0
+            movie, math.ceil(T / chunk_size), axis=0
         )
 
         # Use multiprocessing to dewarp one chunk of the movie at a time


### PR DESCRIPTION
This is a PR to address the issues in [GitHub Issue 122](https://github.com/AllenInstitute/ophys_etl_pipelines/issues/122).

It cleans up the logging, as well s removing incorrect comments, and some unnecessary code. There was on rare bug introduced in the last PR that only comes up when testing the code on small videos (fewer than 1000 frames). That has been fixed here as well.

I have run the code on Synapse and checked the log file to verify that the logs are cleaner now, and that the code still passes the regression test after removing the unnecessary code.

This work has also spawned [a new ticket](https://github.com/AllenInstitute/ophys_etl_pipelines/issues/130).