### PR TITLE
active_traces.get_trace_evs returns list of np.arrays

### DIFF
--- a/src/ophys_etl/decrosstalk/active_traces.py
+++ b/src/ophys_etl/decrosstalk/active_traces.py
@@ -220,10 +220,11 @@ def _flag_to_events(traces_y0, evs, len_ne):
 
     Returns
     -------
-    traces_out -- a 2D numpy array. Each row contains the
-    active trace elements for the corresponding neuron.
+    traces_out -- a list of numpy.arrays. Each array
+    contains the active trace elements for the corresponding
+    neuron.
 
-    events_out -- a 2D numpy array of ints. Each row is
+    events_out -- a list of numpy.arrays. Each array is
     the indices of the active elements from traces_out,
 
     i.e.
@@ -279,8 +280,7 @@ def _flag_to_events(traces_y0, evs, len_ne):
         traces_out.append(_traces.astype(float))
         events_out.append(_events.astype(int))
 
-    return (np.array(traces_out, dtype=object),
-            np.array(events_out, dtype=object))
+    return (traces_out, events_out)
 
 
 def get_traces_evs(traces_y0, th_ag, len_ne):

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -450,7 +450,8 @@ def run_decrosstalk(signal_plane, ct_plane,
     for roi_id in raw_trace_events:
         flux_mask = np.ones(len(raw_traces['roi'][roi_id]['signal']),
                             dtype=bool)
-        flux_mask[raw_trace_events[roi_id]['signal']['events']] = False
+        if len(raw_trace_events[roi_id]['signal']['events']) > 0:
+            flux_mask[raw_trace_events[roi_id]['signal']['events']] = False
         _flux = np.abs(raw_traces['roi'][roi_id]['signal'][flux_mask])
         flux_sum = np.round(_flux.sum()).astype(int)
         roi_to_seed[roi_id] = flux_sum % two_to_32


### PR DESCRIPTION
rather than a ragged np.array

The casting to dtype=object necessary to return a ragged
numpy.array was occasionally converting the rows from ints
to objects, which broke the decrosstalking pipeline. Since
the output of get_trace_evs never actually needed to be a
2D numpy array, we will just return a list of arrays.

Note: this issue will be more rigorously addressed when we get around to fixing issue #148. However, this pull request should get us to a state where we can run the pipeline with confidence.