### PR TITLE
Add rigid_motion_transform.csv to suite2p_registration pipeline

### DIFF
--- a/src/ophys_etl/pipelines/suite2p_registration.py
+++ b/src/ophys_etl/pipelines/suite2p_registration.py
@@ -1,12 +1,15 @@
-import argschema
-import tempfile
-import tifffile
 import json
-import marshmallow
-import h5py
 import os
-import numpy as np
+import tempfile
 from pathlib import Path
+
+import argschema
+import h5py
+import marshmallow
+import numpy as np
+import pandas as pd
+import tifffile
+
 from ophys_etl.schemas.fields import H5InputFile
 from ophys_etl.transforms.suite2p_wrapper import (Suite2PWrapper,
                                                   Suite2PWrapperSchema)
@@ -23,6 +26,11 @@ class Suite2PRegistrationInputSchema(argschema.ArgSchema):
         required=True,
         description=("hdf5 format of diagnostics harvested from Suite2P "
                      "ops.npy"))
+    motion_offset_output = argschema.fields.OutputFile(
+        required=True,
+        description=("Desired save path for *.csv file containing motion "
+                     "correction offset data")
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -58,6 +66,10 @@ class Suite2PRegistrationOutputSchema(argschema.ArgSchema):
         required=True,
         description=("hdf5 format of diagnostics harvested from Suite2P "
                      "ops.npy"))
+    motion_offset_output = argschema.fields.OutputFile(
+        required=True,
+        description=("Path of *.csv file containing motion correction offsets")
+    )
 
 
 class Suite2PRegistration(argschema.ArgSchemaParser):
@@ -113,6 +125,22 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
                          f"{self.args['motion_diagnostics_output']}. "
                          f"Metrics are {ops_keys}.")
 
+        # Save motion offset data to a csv file
+        # TODO: This *.csv file is being created to maintain compatability
+        # with current ophys processing pipeline. In the future this output
+        # should be removed and a better data storage format used.
+        # 01/25/2021 - NJM
+        motion_offset_df = pd.DataFrame({
+            "framenumber": list(range(ops.item()["nframes"])),
+            "x": ops.item()["xoff"],
+            "y": ops.item()["yoff"],
+            "correlation": ops.item()["corrXY"]
+        })
+        motion_offset_df.to_csv(path_or_buf=self.args['motion_offset_output'],
+                                index=False)
+        self.logger.info("Writing the LIMS expected 'OphysMotionXyOffsetData' "
+                         f"csv file to: {self.args['motion_offset_output']}")
+
         # Clean up temporary directories and/or files created during
         # Schema invocation
         if self.schema.tmpdir is not None:
@@ -120,7 +148,8 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
 
         outj = {k: self.args[k]
                 for k in ['motion_corrected_output',
-                          'motion_diagnostics_output']}
+                          'motion_diagnostics_output',
+                          'motion_offset_output']}
         self.output(outj, indent=2)
 
 

--- a/src/ophys_etl/transforms/suite2p_wrapper.py
+++ b/src/ophys_etl/transforms/suite2p_wrapper.py
@@ -216,7 +216,7 @@ def copy_and_add_uid(
 
     """
 
-    copied_files = {}
+    copied_files: dict = {}
 
     for basename in basenames:
         result = list(srcdir.rglob(basename))

--- a/tests/pipelines/test_suite2p_registration.py
+++ b/tests/pipelines/test_suite2p_registration.py
@@ -64,9 +64,7 @@ def test_suite2p_registration(tmp_path, mock_ops_data):
                 "h5py": str(h5path),
             },
             "motion_corrected_output": str(tmp_path / "motion_output.h5"),
-            "motion_diagnostics_output":
-                str(tmp_path / "motion_diagnostics.h5"),
-            "motion_offset_output": str(tmp_path / "motion_offset.csv"),
+            "motion_diagnostics_output": str(tmp_path / "motion_offset.csv"),
             "output_json": str(outj_path)}
 
     with patch.object(MockSuite2PWrapper, "mock_ops_data", mock_ops_data):
@@ -78,22 +76,19 @@ def test_suite2p_registration(tmp_path, mock_ops_data):
     with open(outj_path, "r") as f:
         outj = json.load(f)
 
-    for k in ['motion_corrected_output', 'motion_diagnostics_output']:
-        assert k in outj
-        with h5py.File(outj[k], "r") as f:
-            pass
-
+    # Test that motion_corrected_output field exists and
+    # that h5 file contains correct data
+    assert 'motion_corrected_output' in outj
     with h5py.File(outj['motion_corrected_output'], "r") as f:
         data = f['data'][()]
     assert data.shape == (100, 32, 32)
     assert data.max() == 9
     assert data.min() == 0
 
-    with h5py.File(outj['motion_diagnostics_output'], "r") as f:
-        for k, v in mock_ops_data.items():
-            assert np.allclose(f[k][()], v)
-
-    obt_motion_offset_df = pd.read_csv(outj['motion_offset_output'])
+    # Test that motion_diagnostics_output field exists and that csv
+    # file contains correct data
+    assert 'motion_diagnostics_output' in outj
+    obt_motion_offset_df = pd.read_csv(outj['motion_diagnostics_output'])
     expected_frame_indices = list(range(mock_ops_data['nframes']))
     assert np.allclose(obt_motion_offset_df["framenumber"],
                        expected_frame_indices)


### PR DESCRIPTION
PR TODO:
- [ ] Perform validation that output *.csv file from new suite2p registration is using same coordinate system as previous in-house registration.

----

This commit adds a new *.csv file output with the following columns:
framenumber, x, y, correlation

framenumber: The frame indices
x: x-shifts of ophys recording for each frame
y: y-shifts of ophys recording for each frame
corrlation: Peak of phase correlation between frame and reference image
            at each timepoint

This particular file is used by downstream processes and modules
such as the cell_roi_creation_strategy and the
behavior_ophys_write_nwb_strategy.