### PR TITLE
Decrosstalk/dev/fix invalid rois

### DIFF
--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -381,6 +381,11 @@ def run_decrosstalk(signal_plane, ct_plane,
                      'crosstalk_plane': ct_plane,
                      'clobber': clobber}
 
+    # writer class that will be used to write dict of ROIs
+    # that have been invalidated for various reasons by
+    # this module
+    flag_writer_class = io_utils.InvalidFlagWriter
+
     roi_flags = {}
 
     ghost_key = 'decrosstalk_ghost'
@@ -436,6 +441,10 @@ def run_decrosstalk(signal_plane, ct_plane,
         msg += '%d (%d)' % (signal_plane.experiment_id,
                             ct_plane.experiment_id)
         logger.error(msg)
+
+        writer = flag_writer_class(data=roi_flags,
+                                   **output_kwargs)
+        writer.run()
         return roi_flags, {}
 
     #########################################
@@ -508,6 +517,9 @@ def run_decrosstalk(signal_plane, ct_plane,
         msg += '%d (%d)' % (signal_plane.experiment_id,
                             ct_plane.experiment_id)
         logger.error(msg)
+        writer = flag_writer_class(data=roi_flags,
+                                   **output_kwargs)
+        writer.run()
         return roi_flags, unmixed_traces
 
     unmixed_trace_validation = d_utils.validate_traces(unmixed_traces)
@@ -537,6 +549,9 @@ def run_decrosstalk(signal_plane, ct_plane,
         msg += '%d (%d)' % (signal_plane.experiment_id,
                             ct_plane.experiment_id)
         logger.error(msg)
+        writer = flag_writer_class(data=roi_flags,
+                                   **output_kwargs)
+        writer.run()
         return roi_flags, unmixed_traces
 
     ###################################################
@@ -651,8 +666,8 @@ def run_decrosstalk(signal_plane, ct_plane,
         del writer
         del writer_class
 
-    writer = io_utils.InvalidFlagWriter(data=roi_flags,
-                                        **output_kwargs)
+    writer = flag_writer_class(data=roi_flags,
+                               **output_kwargs)
     writer.run()
 
     return roi_flags, unmixed_traces

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -176,6 +176,7 @@ def unmix_all_ROIs(raw_roi_traces, seed_lookup=None):
                 if k == 'use_avg_mixing_matrix':
                     continue
                 _out['poorly_converged_%s' % k] = unmixed_roi[k]
+                _out[k] = np.NaN*np.zeros(unmixed_roi[k].shape, dtype=float)
         output['roi'][roi_id] = _out
 
     # calculate avg mixing matrix from successful iterations

--- a/src/ophys_etl/decrosstalk/io_utils.py
+++ b/src/ophys_etl/decrosstalk/io_utils.py
@@ -330,6 +330,16 @@ class OutH5WriterOld(OldOutputWriter):
         local_data['data_signal'] = signal_data
         local_data['data_crosstalk'] = crosstalk_data
         local_data['roi_demixed'] = demixed
+
+        for roi_id in roi_names:
+            key_set = set(self.data[prefix][roi_id].keys())
+            if 'poorly_converged_mixing_matrix' in key_set:
+                for suffix in ('signal', 'crosstalk', 'mixing_matrix'):
+                    field = 'poorly_converged_%s' % suffix
+                    k = '%d/%s' % (roi_id, field)
+                    v = self.data[prefix][roi_id][field]
+                    local_data[k] = v
+
         return local_data
 
     def run(self):

--- a/src/ophys_etl/transforms/decrosstalk_wrapper.py
+++ b/src/ophys_etl/transforms/decrosstalk_wrapper.py
@@ -82,6 +82,22 @@ class DecrosstalkWrapper(argschema.ArgSchemaParser):
                         if roi_id not in invalid_roi:
                             roi_names.append(roi_id)
                             data.append(traces_0[k][roi_id]['signal'])
+
+                    # add in np.arrays of NaNs for the invalid ROIs
+                    # so that downstream modules don't get confused
+                    # when the number of ROIs in the experiment changes
+                    # (we are adding NaNs because there is no well-defind
+                    # 'unmixed' trace for these cases; the invalid ROI flags
+                    # added to LIMS by this module will exempt these traces
+                    # from further processing)
+                    if len(data) > 0:
+                        n_t = len(data[0])
+                    else:
+                        n_t = 10000
+                    for roi_id in invalid_roi:
+                        roi_names.append(roi_id)
+                        data.append(np.NaN*np.ones(n_t, dtype=float))
+
                     roi_names = np.array(roi_names)
                     data = np.array(data)
                     with h5py.File(out_fname, 'w') as out_file:


### PR DESCRIPTION
This PR fixes a few issues with our decrosstalking works in our pipeline

1) For ROIs that are deemed invalid, nonsense rows are added to the output `*_traces.h5` files. Originally, we omitted invalid traces, but that was causing downstream processing modules to fail.

2) Make sure that, in cases where the average mixing matrix for the whole plane was used to get the unmixed traces, the poorly converged traces and mixing matrix are still saved to the `*_out.h5` for quality control purposes.

3) Make sure that `_invalid_flags.json` is always written for quality control purposes.