### PR TITLE
Decrosstalk/data structures/dev

### DIFF
--- a/src/ophys_etl/decrosstalk/active_traces.py
+++ b/src/ophys_etl/decrosstalk/active_traces.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple, List, Dict
+from typing import Union, Tuple, List, Dict, Optional
 import numpy as np
 import scipy.stats
 
@@ -8,9 +8,9 @@ __all__ = ['get_trace_events',
 
 
 def mode_robust(input_data: np.ndarray,
-                axis: Union[None, int] = None) -> Union[np.ndarray,
-                                                        np.int,
-                                                        np.float]:
+                axis: Optional[int] = None) -> Union[np.ndarray,
+                                                     np.int,
+                                                     np.float]:
     """
     Robust estimator of the mode of a data set using the half-sample mode.
 

--- a/src/ophys_etl/decrosstalk/active_traces.py
+++ b/src/ophys_etl/decrosstalk/active_traces.py
@@ -24,7 +24,8 @@ def mode_robust(input_data: np.ndarray,
 
     Returns
     -------
-    A np.ndarray containing the mode of input_data
+    A scalar (or, if slicing along an axis, an np.ndarray)
+    containing the mode of input_data
     """
     if axis is not None:
         def fnc(x: np.ndarray): return mode_robust(x)

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -45,12 +45,12 @@ def get_raw_traces(signal_plane: DecrosstalkingOphysPlane,
         _roi = dc_types.ROIChannels()
         _neuropil = dc_types.ROIChannels()
 
-        _roi['signal'] = signal_traces['roi'][roi_id]
-        _roi['crosstalk'] = crosstalk_traces['roi'][roi_id]
+        _roi['signal'] = signal_traces['roi'][roi_id]['signal']
+        _roi['crosstalk'] = crosstalk_traces['roi'][roi_id]['signal']
         output['roi'][roi_id] = _roi
 
-        _neuropil['signal'] = signal_traces['neuropil'][roi_id]
-        _neuropil['crosstalk'] = crosstalk_traces['neuropil'][roi_id]
+        _neuropil['signal'] = signal_traces['neuropil'][roi_id]['signal']
+        _neuropil['crosstalk'] = crosstalk_traces['neuropil'][roi_id]['signal']
         output['neuropil'][roi_id] = _neuropil
 
     return output

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -84,8 +84,8 @@ def unmix_ROI(roi_traces: dc_types.ROIChannels,
     (unmixed_signals,
      mixing_matrix,
      roi_demixed) = ica_utils.run_ica(ica_input,
-                                      seed=seed,
-                                      iters=iters)
+                                      iters,
+                                      seed)
 
     assert unmixed_signals.shape == ica_input.shape
 

--- a/src/ophys_etl/decrosstalk/decrosstalk_types.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_types.py
@@ -9,9 +9,6 @@ class BasicDictWrapper(object):
             return True
         return False
 
-    def keys(self) -> List:
-        return list(self._data.keys())
-
     def __len__(self) -> int:
         return len(self._data)
 
@@ -135,6 +132,9 @@ class ROIChannels(BasicDictWrapper):
     def pop(self, key):
         raise NotImplementedError("ROIChannels does not support pop")
 
+    def keys(self) -> List[str]:
+        return list(self._data.keys())
+
 
 class ROIDict(BasicDictWrapper):
     """
@@ -164,6 +164,9 @@ class ROIDict(BasicDictWrapper):
 
     def pop(self, key: int) -> ROIChannels:
         return self._data.pop(key)
+
+    def keys(self) -> List[int]:
+        return list(self._data.keys())
 
 
 class ROISetDict(object):
@@ -326,3 +329,6 @@ class ROIEventSet(BasicDictWrapper):
 
     def pop(self, key: int) -> ROIEventChannels:
         return self._data.pop(key)
+
+    def keys(self) -> List[int]:
+        return list(self._data.keys())

--- a/src/ophys_etl/decrosstalk/decrosstalk_types.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_types.py
@@ -1,0 +1,158 @@
+import numpy as np
+
+
+class BasicDictWrapper(object):
+
+    def pop(self, key):
+        return self._data.pop(key)
+
+    def __contains__(self, key):
+        if key in self._data:
+            return True
+        return False
+
+    def keys(self):
+        return list(self._data.keys())
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        raise NotImplementedError("Did not implement iterator over "
+                                  "BasicDictWrapper")
+
+class ROIChannels(BasicDictWrapper):
+
+    def __init__(self):
+        self._data = {}
+        self._valid_keys = ('signal',
+                            'crosstalk',
+                            'mixing_matrix',
+                            'poorly_converged_signal',
+                            'poorly_converged_crosstalk',
+                            'poorly_converged_mixing_matrix',
+                            'use_avg_mixing_matrix')
+
+    def _validate_np_array(self, key, value,
+                           expected_ndim=None,
+                           expected_shape=None,
+                           expected_dtype=None):
+
+        if not isinstance(value, np.ndarray):
+            msg = '%s must be a np.ndarray; you gave %s\n' % (key, type(value))
+            raise ValueError(msg)
+        elif not len(value.shape) == expected_ndim:
+            msg = '%s must be a %d-dimensional array; ' % (key, expected_ndim)
+            msg += 'you gave %d-dimensional array' % (len(value.shape))
+            raise ValueError(msg)
+        elif value.dtype != expected_dtype:
+            msg = '%s must be a np.ndarray ' % key
+            msg += 'of dtype %s;' % str(expected_dtype)
+            msg += ' you gave %s' % str(value.dtype)
+            raise ValueError(msg)
+        elif expected_shape is not None and value.shape != expected_shape:
+            msg = '%s must be of shape %s; ' % (key, str(expected_shape))
+            msg += 'you gave %s' % (str(value.shape))
+            raise ValueError(msg)
+        return True
+
+    def __setitem__(self, key: str, value):
+        float_type = np.dtype(float)
+        if key == 'signal':
+            self._validate_np_array('signal', value,
+                                    expected_ndim=1,
+                                    expected_shape=None,
+                                    expected_dtype=float_type)
+            self._data[key] = value
+        elif key == 'crosstalk':
+            self._validate_np_array('crosstalk', value,
+                                    expected_ndim=1,
+                                    expected_shape=None,
+                                    expected_dtype=float_type)
+            self._data[key] = value
+        elif key == 'mixing_matrix':
+            self._validate_np_array('mixing_matrix', value,
+                                    expected_ndim=2,
+                                    expected_shape=(2, 2),
+                                    expected_dtype=float_type)
+            self._data[key] = value
+        elif key == 'poorly_converged_signal':
+            self._validate_np_array('poorly_converged_signal', value,
+                                    expected_ndim=1,
+                                    expected_shape=None,
+                                    expected_dtype=float_type)
+            self._data[key] = value
+        elif key == 'poorly_converged_crosstalk':
+            self._validate_np_array('poorly_converged_crosstalk', value,
+                                    expected_ndim=1,
+                                    expected_shape=None,
+                                    expected_dtype=float_type)
+            self._data[key] = value
+        elif key == 'poorly_converged_mixing_matrix':
+            self._validate_np_array('poorly_converged_mixing_matrix', value,
+                                    expected_ndim=2,
+                                    expected_shape=(2, 2),
+                                    expected_dtype=float_type)
+            self._data[key] = value
+        elif key == 'use_avg_mixing_matrix':
+            if not isinstance(value, bool):
+                msg = 'use_avg_mixing_matrix must be a boolean; '
+                msg += 'you gave %s' % type(value)
+                raise ValueError(msg)
+            self._data[key] = value
+        else:
+            msg = 'Keys for ROIChannels must be one of:\n'
+            msg += str(self._valid_keys)
+            msg += '\nyou gave: %s' % key
+            raise KeyError(msg)
+
+    def __getitem__(self, key: str):
+        if key in self._valid_keys:
+            return np.copy(self._data[key])
+        msg = 'Keys for ROIChannels must be one of:\n'
+        msg += str(self._valid_keys)
+        msg += '\nyou gave: %s' % key
+        raise KeyError(msg)
+
+    def pop(self, key):
+        raise NotImplementedError("ROIChannels does not support pop")
+
+
+class ROIDict(BasicDictWrapper):
+
+    def __init__(self):
+        self._data = {}
+
+    def __setitem__(self, roi_id: int, value: ROIChannels):
+        if not isinstance(roi_id, int):
+            msg = 'ROIDict keys must be ints; '
+            msg += 'you are using %s' % str(type(roi_id))
+            raise KeyError(msg)
+        if not isinstance(value, ROIChannels):
+            msg = 'ROIDict values must be ROIChannels; '
+            msg += 'youa reusing %s' % (str(type(value)))
+            raise ValueError(msg)
+        self._data[roi_id] = value
+
+    def __getitem__(self, roi_id: int):
+        return self._data[roi_id]
+
+
+class ROISetDict(object):
+
+    def __init__(self):
+        self._roi = ROIDict()
+        self._neuropil = ROIDict()
+
+    def __setitem__(self, key, value):
+        raise NotImplementedError("ROISetDict does not implement __setitem__")
+
+    def __getitem__(self, key: str):
+        if key == 'roi':
+            return self._roi
+        elif key == 'neuropil':
+            return self._neuropil
+        msg = "The only legal keys for ROISetDict "
+        msg += "are 'roi' and 'neuropil'; "
+        msg += "you passed '%s'" % str(key)
+        raise KeyError(msg)

--- a/src/ophys_etl/decrosstalk/decrosstalk_types.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_types.py
@@ -25,6 +25,20 @@ class BasicDictWrapper(object):
 
 
 class ROIChannels(BasicDictWrapper):
+    """
+    A wrapper around a dict meant to store all of the decrosstalk-related
+    data for one ROI.
+
+    Valid key, value pairs are:
+
+    'signal' -- a 1-D np.ndarray of floats containing a trace
+    'crosstalk' -- a 1-D np.ndarray of floats containing a trace
+    'mixing_matrix' -- a 2x2 np.ndarray of floats
+    'poorly_converged_signal' -- same type as 'signal'
+    'poorly_converged_crosstalk' -- same type as 'crosstalk'
+    'poorly_converged_mixing_matrix' -- same type as 'mixing_matrix'
+    'use_avg_mixing_matrix' -- a boolean
+    """
 
     def __init__(self):
         self._data = {}
@@ -122,6 +136,13 @@ class ROIChannels(BasicDictWrapper):
 
 
 class ROIDict(BasicDictWrapper):
+    """
+    A wrapper around a dict meant to store the decrosstalk-related
+    data for many ROIs.
+
+    Key/Value pairs must all be (int, ROIChannels) where int is the
+    ROI's roi_id.
+    """
 
     def __init__(self):
         self._data = {}
@@ -142,6 +163,14 @@ class ROIDict(BasicDictWrapper):
 
 
 class ROISetDict(object):
+    """
+    Wrapper around dict meant to store the ROI and Neuropil trace
+    data for a set of ROIs.
+
+    Valid keys are 'roi' and 'neuropil', each of which stores an
+    ROIDict containing the relevant data for the ROIs measured in
+    that type of footprint (ROI or neuropil).
+    """
 
     def __init__(self):
         self._roi = ROIDict()
@@ -165,6 +194,17 @@ class ROISetDict(object):
 
 
 class ROIEvents(object):
+    """
+    A wrapper around dict meant to store the active trace data for an
+    ROI. Valid key/value pairs are
+
+    'trace' -- a 1-D np.ndarray of floats containing trace values
+    'events' -- a 1-D np.ndarray of ints containing indexes of active timesteps
+
+    The idea is that, given a raw_trace stored somewhere else,
+
+    raw_trace[ROIEvents['events']] == ROIEvents['trace']
+    """
 
     def __init__(self):
         self._data = {}
@@ -210,6 +250,13 @@ class ROIEvents(object):
 
 
 class ROIEventChannels(object):
+    """
+    A wrapper around dict meant to store the active trace data for the
+    signal and crosstalk channels in an ROI.
+
+    Valid keys are 'signal' and 'crosstalk', each of which stores an
+    ROIEvents
+    """
 
     def __init__(self):
         self._data = {}
@@ -237,6 +284,11 @@ class ROIEventChannels(object):
 
 
 class ROIEventSet(BasicDictWrapper):
+    """
+    A wrapper around dict meant to store all of the ROIEventChannels for
+    a set of ROIs. Valid keys are ints (the roi_ids of the ROIs). Valid
+    values are ROIEventChannels.
+    """
 
     def __init__(self):
         self._data = {}

--- a/src/ophys_etl/decrosstalk/decrosstalk_types.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_types.py
@@ -155,7 +155,7 @@ class ROIDict(BasicDictWrapper):
             raise KeyError(msg)
         if not isinstance(value, ROIChannels):
             msg = 'ROIDict values must be ROIChannels; '
-            msg += 'youa reusing %s' % (str(type(value)))
+            msg += 'you are using %s' % (str(type(value)))
             raise ValueError(msg)
         self._data[roi_id] = value
 

--- a/src/ophys_etl/decrosstalk/decrosstalk_types.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_types.py
@@ -5,9 +5,7 @@ import numpy as np
 class BasicDictWrapper(object):
 
     def __contains__(self, key) -> bool:
-        if key in self._data:
-            return True
-        return False
+        return key in self._data
 
     def __len__(self) -> int:
         return len(self._data)

--- a/src/ophys_etl/decrosstalk/decrosstalk_utils.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_utils.py
@@ -47,23 +47,8 @@ def validate_traces(trace_dict: dc_types.ROISetDict) -> Dict[int, bool]:
 
     Parameters
     -----------
-    trace_dict contains the traces to be validated. It has a structure like:
-
-        trace_dict['roi'][roi_id]['signal'] = np.array of trace of signal
-                                              values for ROI
-
-        trace_dict['roi'][roi_id]['crosstalk'] = np.array of trace of
-                                                 crosstalk values for ROI
-
-        trace_dict['neuropil'][roi_id]['signal'] = np.array of trace of
-                                                   signal values defined
-                                                   in the neuropil
-                                                   around ROI
-
-        trace_dict['neuropil'][roi_id]['crosstalk'] = np.array of trace of
-                                                      crosstalk values
-                                                      defined in the
-                                                      neuropil around ROI
+    trace_dict -- a decrosstalk_types.ROISetDict containing the active
+                  traces to be validated
 
     Returns
     -------
@@ -112,24 +97,21 @@ def find_independent_events(signal_events: dc_types.ROIEvents,
     then any events that are not exact matches (i.e. occurring at the same
     time point) will be considered independent events.
 
-    Args:
-        signal_events: a dict
-            signal_events['trace'] is an array of the trace flux
-                                   values of the signal channel
+    Parameters
+    ----------
+    signal_events -- a decrosstalk_types.ROIEvents containing the active
+                     traces from the signal channel
 
-            signal_events['events'] is an array of the timestamp
-                                    indices of the signal channel
+    crosstalk_events -- a decrosstalk_types.ROIEvents containing the active
+                        traces from the crosstalk channel
 
-        crosstalk_events: a dict (same structure as signal_events)
+    window -- an int specifying the amount of blurring to use (default=2)
 
-        window (int): the amount of blurring to use (default=2)
-
-    Returns:
-        independent_events: a dict of events that were in signal_events,
-                            but not crosstalk_events +/- window
-
-            independent_events['trace'] is an array of the trace flux values
-            indpendent_events['events'] is an array of the timestamp indices
+    Returns
+    -------
+    independent_events -- a decrosstalking_types.ROIEvents containing
+                          the active traces and events that were in
+                          signal_events, but not crosstalk_events +/- window
     """
     blurred_crosstalk = np.unique(np.concatenate([crosstalk_events['events']+ii
                                                   for ii in
@@ -155,29 +137,24 @@ def validate_cell_crosstalk(signal_events: dc_types.ROIEvents,
     Determine if an ROI is a valid cell or a ghost based on the
     events detected in the signal and crosstalk channels
 
-    Args:
-        signal_events: a dict
-            signal_events['trace'] is an array of the trace
-                                   flux values of the signal channel
+    Parameters
+    ----------
+    signal_events -- a decrosstalk_types.ROIEvents containing the active
+                     traces from the signal channel
 
-            signal_events['events'] is an array of the timestamp
-                                    indices of the signal channel
+    crosstalk_events -- a decrosstalk_types.ROIEvents containing the active
+                        traces from the crosstalk channel
 
-        crosstalk_events: a dict (same structure as signal_events)
+    window -- an int specifying the amount of blurring to use (default=2)
 
-        window (int): the amount of blurring to use in
-                      find_independent_events (default=2)
+    Returns
+    -------
+    is_valid_roi -- a boolean indicating whether or not there were independent
+                    events in signal_events
 
-    Returns:
-        is_valid_roi : a boolean that is true if there are
-                       any independent events in the signal channel
-
-        independent_events: a dict of events that were in signal_events,
-                            but not crosstalk_events +/- window
-
-            independent_events['trace'] is an array of the trace flux values
-            indpendent_events['events'] is an array of the timestamp indices
-
+    independent_events -- a decrosstalking_types.ROIEvents containing
+                          the active traces and events that were in
+                          signal_events, but not crosstalk_events +/- window
     """
 
     independent_events = find_independent_events(signal_events,

--- a/src/ophys_etl/decrosstalk/decrosstalk_utils.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk_utils.py
@@ -1,8 +1,12 @@
+from typing import Dict, Tuple
 import numpy as np
 import scipy.stats
 
+import ophys_etl.decrosstalk.decrosstalk_types as dc_types
 
-def get_crosstalk_data(signal, crosstalk):
+
+def get_crosstalk_data(signal: np.ndarray,
+                       crosstalk: np.ndarray) -> Dict[str, float]:
     """
     Use linear regression to calculate the ratio between signal
     and crosstalk in an ROI.
@@ -35,7 +39,7 @@ def get_crosstalk_data(signal, crosstalk):
             'r_value': result.rvalue}
 
 
-def validate_traces(trace_dict):
+def validate_traces(trace_dict: dc_types.ROISetDict) -> Dict[int, bool]:
     """
     Check a traces_dict for validity.
     Validity is defined as neuropil and roi traces having the same shape.
@@ -96,7 +100,9 @@ def validate_traces(trace_dict):
     return output_dict
 
 
-def find_independent_events(signal_events, crosstalk_events, window=2):
+def find_independent_events(signal_events: dc_types.ROIEvents,
+                            crosstalk_events: dc_types.ROIEvents,
+                            window: int = 2) -> dc_types.ROIEvents:
     """
     Calculate independent events between signal_events and crosstalk_events.
 
@@ -133,11 +139,18 @@ def find_independent_events(signal_events, crosstalk_events, window=2):
     valid_signal_events = np.where(np.logical_not(
                                    np.isin(signal_events['events'],
                                            blurred_crosstalk)))
-    return {'trace': signal_events['trace'][valid_signal_events],
-            'events': signal_events['events'][valid_signal_events]}
+
+    output = dc_types.ROIEvents()
+    output['trace'] = signal_events['trace'][valid_signal_events]
+    output['events'] = signal_events['events'][valid_signal_events]
+
+    return output
 
 
-def validate_cell_crosstalk(signal_events, crosstalk_events, window=2):
+def validate_cell_crosstalk(signal_events: dc_types.ROIEvents,
+                            crosstalk_events: dc_types.ROIEvents,
+                            window: int = 2) -> Tuple[bool,
+                                                      dc_types.ROIEvents]:
     """
     Determine if an ROI is a valid cell or a ghost based on the
     events detected in the signal and crosstalk channels

--- a/src/ophys_etl/decrosstalk/ica_utils.py
+++ b/src/ophys_etl/decrosstalk/ica_utils.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple, Union
+
 import numpy as np
 import copy
 from scipy.stats import pearsonr
@@ -9,7 +11,8 @@ __all__ = ["whiten_data",
            "run_ica"]
 
 
-def pearson_ica_in_to_out(signal_in, signal_out):
+def pearson_ica_in_to_out(signal_in: np.ndarray,
+                          signal_out: np.ndarray) -> List[float]:
     """
     Function to compute correlations between two vectors (traces in our case)
 
@@ -51,7 +54,9 @@ def pearson_ica_in_to_out(signal_in, signal_out):
     return [cor_0_0, cor_0_1, cor_1_1, cor_1_0]
 
 
-def whiten_data(x):
+def whiten_data(x: np.ndarray) -> Tuple[np.ndarray,
+                                        np.ndarray,
+                                        np.ndarray]:
     """
     Function to debias (subtract mean) and whiten* the data
 
@@ -79,7 +84,8 @@ def whiten_data(x):
     return np.dot(u, v) * n, w, m
 
 
-def fix_source_assignment(ica_input, ica_output):
+def fix_source_assignment(ica_input: np.ndarray,
+                          ica_output: np.ndarray) -> Tuple[np.ndarray, bool]:
     """
     Function to rearrange the rows of ica_output so that
     the first row is the one that most strongly resembles
@@ -118,7 +124,15 @@ def fix_source_assignment(ica_input, ica_output):
     return ica_output_corrected, swapped_flag
 
 
-def run_ica(ica_input, iters, seed, verbose=False):
+def run_ica(ica_input: np.ndarray,
+            iters: int,
+            seed: int,
+            verbose: bool = False) -> Union[Tuple[np.ndarray,
+                                                  np.ndarray,
+                                                  bool],
+                                            Tuple[np.ndarray,
+                                                  np.ndarray,
+                                                  bool, bool]]:
     """
     ica_input -- an MxN numpy array; in the context of the decrosstalk
     problem, N=the number of timesteps; M=2 (first row is signal;

--- a/src/ophys_etl/decrosstalk/io_utils.py
+++ b/src/ophys_etl/decrosstalk/io_utils.py
@@ -31,7 +31,7 @@ def _write_data_to_h5(file_handle, data_dict):
     key_list = list(data_dict.keys())
     for key in key_list:
         value = data_dict[key]
-        if isinstance(value, dict):
+        if hasattr(value, 'keys'):
             group = file_handle.create_group(str(key))
             _write_data_to_h5(group, value)
         else:
@@ -69,7 +69,7 @@ def write_to_h5(file_name, data_dict, clobber=False):
     clobber -- boolean; if False, will not overwrite an existing file
     (default=False)
     """
-    if not isinstance(data_dict, dict):
+    if not hasattr(data_dict, 'keys'):
         msg = '\nInput to write_to_h5 not a dict\n'
         msg += 'Input was %s' % str(type(data_dict))
         raise RuntimeError(msg)

--- a/src/ophys_etl/transforms/decrosstalk_wrapper.py
+++ b/src/ophys_etl/transforms/decrosstalk_wrapper.py
@@ -72,8 +72,6 @@ class DecrosstalkWrapper(argschema.ArgSchemaParser):
 
                 for k in ('roi', 'neuropil'):
                     out_fname = output_schema['output_%s_trace_file' % k]
-                    if k not in traces_0:
-                        continue
                     data = []
                     roi_names = []
                     roi_list = list(traces_0[k].keys())

--- a/tests/decrosstalk/test_event_types.py
+++ b/tests/decrosstalk/test_event_types.py
@@ -1,0 +1,166 @@
+import pytest
+import ophys_etl.decrosstalk.decrosstalk_types as dc_types
+import numpy as np
+from numpy.testing import assert_array_almost_equal as np_almost
+from numpy.testing import assert_array_equal as np_equal
+
+
+def test_ROIEvents():
+
+    trace = np.linspace(0, 2.0, 5)
+    events = np.arange(5, dtype=int)
+    roi_events = dc_types.ROIEvents()
+    roi_events['trace'] = trace
+    roi_events['events'] = events
+
+    np_almost(roi_events['trace'], np.linspace(0, 2.0, 5), decimal=10)
+    np_equal(roi_events['events'], np.arange(5, dtype=int))
+
+
+def test_ROIEvents_exceptions():
+
+    trace = np.linspace(0, 2.0, 5)
+    events = np.arange(5, dtype=int)
+    roi_events = dc_types.ROIEvents()
+
+    with pytest.raises(KeyError):
+        roi_events['boom'] = trace
+    with pytest.raises(ValueError):
+        roi_events['trace'] = events
+    with pytest.raises(ValueError):
+        roi_events['events'] = trace
+    with pytest.raises(ValueError):
+        roi_events['events'] = 5
+    with pytest.raises(ValueError):
+        roi_events['trace'] = 6.7
+    with pytest.raises(ValueError):
+        roi_events['trace'] = np.array([[1.1, 2.2], [3.4, 5.5]])
+
+    roi_events['trace'] = trace
+    roi_events['events'] = events
+
+    _ = roi_events['trace']
+    _ = roi_events['events']
+    with pytest.raises(KeyError):
+        _ = roi_events['boom']
+
+
+def test_ROIEventChannels():
+    rng = np.random.RandomState(1245)
+    traces = list([rng.random_sample(10)
+                   for ii in range(2)])
+    events = list([rng.randint(0, 20, size=10)
+                   for ii in range(2)])
+
+    event_set = dc_types.ROIEventChannels()
+    for ii, k in enumerate(('signal', 'crosstalk')):
+        ee = dc_types.ROIEvents()
+        ee['trace'] = traces[ii]
+        ee['events'] = events[ii]
+        event_set[k] = ee
+
+    np_almost(event_set['signal']['trace'], traces[0], decimal=10)
+    np_equal(event_set['signal']['events'], events[0])
+    np_almost(event_set['crosstalk']['trace'], traces[1], decimal=10)
+    np_equal(event_set['crosstalk']['events'], events[1])
+
+
+def test_ROIEventChannels_exceptions():
+
+    event_set = dc_types.ROIEventChannels()
+    ee = dc_types.ROIEvents()
+    ee['trace'] = np.linspace(0, 1, 7)
+    ee['events'] = np.arange(7, dtype=int)
+
+    with pytest.raises(KeyError):
+        event_set['a'] = ee
+
+    with pytest.raises(ValueError):
+        event_set['signal'] = np.linspace(1, 9, 12)
+
+    event_set['signal'] = ee
+
+    with pytest.raises(KeyError):
+        _ = event_set['b']
+
+
+def test_ROIEventSet():
+    event_set = dc_types.ROIEventSet()
+    rng = np.random.RandomState(888812)
+    true_trace_s = []
+    true_event_s = []
+    true_trace_c = []
+    true_event_c = []
+    for ii in range(3):
+        t = rng.random_sample(13)
+        e = rng.randint(0, 111, size=13)
+        signal = dc_types.ROIEvents()
+        signal['trace'] = t
+        signal['events'] = e
+        true_trace_s.append(t)
+        true_event_s.append(e)
+
+        t = rng.random_sample(13)
+        e = rng.randint(0, 111, size=13)
+        crosstalk = dc_types.ROIEvents()
+        crosstalk['trace'] = t
+        crosstalk['events'] = e
+        true_trace_c.append(t)
+        true_event_c.append(e)
+
+        channels = dc_types.ROIEventChannels()
+        channels['signal'] = signal
+        channels['crosstalk'] = crosstalk
+        event_set[ii] = channels
+
+    for ii in range(3):
+        np_almost(event_set[ii]['signal']['trace'],
+                  true_trace_s[ii], decimal=10)
+        np_equal(event_set[ii]['signal']['events'],
+                 true_event_s[ii])
+        np_almost(event_set[ii]['crosstalk']['trace'],
+                  true_trace_c[ii], decimal=10)
+        np_equal(event_set[ii]['crosstalk']['events'],
+                 true_event_c[ii])
+    assert 0 in event_set
+    assert 1 in event_set
+    assert 2 in event_set
+    assert 3 not in event_set
+    keys = event_set.keys()
+    keys.sort()
+    assert keys == [0, 1, 2]
+    channels = event_set.pop(1)
+    np_almost(channels['signal']['trace'],
+              true_trace_s[1], decimal=10)
+    np_equal(channels['signal']['events'],
+             true_event_s[1])
+    np_almost(channels['crosstalk']['trace'],
+              true_trace_c[1], decimal=10)
+    np_equal(channels['crosstalk']['events'],
+             true_event_c[1])
+    assert 0 in event_set
+    assert 2 in event_set
+    assert 1 not in event_set
+    keys = event_set.keys()
+    keys.sort()
+    assert keys == [0, 2]
+
+
+def test_ROIEventSet_exceptions():
+
+    channel = dc_types.ROIEventChannels()
+    e = dc_types.ROIEvents()
+    e['trace'] = np.linspace(1, 3, 10)
+    e['events'] = np.arange(10, dtype=int)
+    channel['signal'] = e
+    e = dc_types.ROIEvents()
+    e['trace'] = np.linspace(1, 7, 10)
+    e['events'] = np.arange(10, 20, dtype=int)
+    channel['crosstalk'] = e
+
+    event_set = dc_types.ROIEventSet()
+    with pytest.raises(KeyError):
+        event_set['signal'] = e
+    with pytest.raises(ValueError):
+        event_set[9] = np.linspace(2, 7, 20)
+    event_set[9] = channel

--- a/tests/decrosstalk/test_ophys_movie.py
+++ b/tests/decrosstalk/test_ophys_movie.py
@@ -62,29 +62,29 @@ def _run_ophys_movie_test(tmp_filename):
     trace_output = ophys_movie.get_trace(roi_list)
 
     assert len(trace_output['roi']) == 3
-    assert trace_output['roi'][0].shape == (200,)
-    assert trace_output['roi'][1].shape == (200,)
-    assert trace_output['roi'][2].shape == (200,)
+    assert trace_output['roi'][0]['signal'].shape == (200,)
+    assert trace_output['roi'][1]['signal'].shape == (200,)
+    assert trace_output['roi'][2]['signal'].shape == (200,)
 
-    np.testing.assert_array_equal(trace_output['roi'][0][33:58],
+    np.testing.assert_array_equal(trace_output['roi'][0]['signal'][33:58],
                                   2.0*np.ones(25, dtype=float))
 
-    np.testing.assert_array_equal(trace_output['roi'][0][:33],
+    np.testing.assert_array_equal(trace_output['roi'][0]['signal'][:33],
                                   np.zeros(33, dtype=float))
 
-    np.testing.assert_array_equal(trace_output['roi'][0][58:],
+    np.testing.assert_array_equal(trace_output['roi'][0]['signal'][58:],
                                   np.zeros(142, dtype=float))
 
-    np.testing.assert_array_equal(trace_output['roi'][1][22:73],
+    np.testing.assert_array_equal(trace_output['roi'][1]['signal'][22:73],
                                   3.0*np.ones(51, dtype=float))
 
-    np.testing.assert_array_equal(trace_output['roi'][1][:22],
+    np.testing.assert_array_equal(trace_output['roi'][1]['signal'][:22],
                                   np.zeros(22, dtype=float))
 
-    np.testing.assert_array_equal(trace_output['roi'][1][73:],
+    np.testing.assert_array_equal(trace_output['roi'][1]['signal'][73:],
                                   np.zeros(127, dtype=float))
 
-    np.testing.assert_array_equal(trace_output['roi'][2],
+    np.testing.assert_array_equal(trace_output['roi'][2]['signal'],
                                   np.zeros(200, dtype=float))
 
 

--- a/tests/decrosstalk/test_trace_types.py
+++ b/tests/decrosstalk/test_trace_types.py
@@ -1,0 +1,303 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_array_almost_equal as np_almost
+import ophys_etl.decrosstalk.decrosstalk_types as dc_types
+
+
+def test_ROIChannels():
+
+    signal = np.arange(9, dtype=float)
+    crosstalk = np.arange(8, 17, dtype=float)
+    mm = np.array([[1.2, 3.4], [5.6, 7.9]])
+    p_signal = signal+0.01
+    p_crosstalk = crosstalk+0.7
+    p_mm = mm+0.9
+    channels = dc_types.ROIChannels()
+    channels['signal'] = signal
+    channels['crosstalk'] = crosstalk
+    channels['mixing_matrix'] = mm
+    channels['poorly_converged_signal'] = p_signal
+    channels['poorly_converged_crosstalk'] = p_crosstalk
+    channels['poorly_converged_mixing_matrix'] = p_mm
+    channels['use_avg_mixing_matrix'] = False
+
+    np_almost(channels['signal'], signal, decimal=10)
+    np_almost(channels['crosstalk'], crosstalk, decimal=10)
+    np_almost(channels['mixing_matrix'], mm, decimal=10)
+    np_almost(p_signal,
+              channels['poorly_converged_signal'], decimal=10)
+    np_almost(p_crosstalk,
+              channels['poorly_converged_crosstalk'], decimal=10)
+    np_almost(p_mm,
+              channels['poorly_converged_mixing_matrix'], decimal=10)
+    assert not channels['use_avg_mixing_matrix']
+
+
+def test_ROIChannel_exceptions():
+
+    bad_signals = [np.array([1, 2, 3], dtype=int),
+                   np.array([[1.1, 2.2], [3.4, 5.4]], dtype=float),
+                   1.4]
+
+    for bad_val in bad_signals:
+        channels = dc_types.ROIChannels()
+        with pytest.raises(ValueError):
+            channels['signal'] = bad_val
+
+    for bad_val in bad_signals:
+        channels = dc_types.ROIChannels()
+        with pytest.raises(ValueError):
+            channels['crosstalk'] = bad_val
+
+    for bad_val in bad_signals:
+        with pytest.raises(ValueError):
+            channels = dc_types.ROIChannels()
+            channels['poorly_converged_signal'] = bad_val
+
+    for bad_val in bad_signals:
+        channels = dc_types.ROIChannels()
+        with pytest.raises(ValueError):
+            channels['poorly_converged_crosstalk'] = bad_val
+
+    bad_mm = [np.array([1.5, 6.7, 3.4]),
+              np.array([[1, 3], [7, 9]], dtype=int),
+              4.5]
+    for bad_val in bad_mm:
+        channels = dc_types.ROIChannels()
+        with pytest.raises(ValueError):
+            channels['mixing_matrix'] = bad_val
+    for bad_val in bad_mm:
+        channels = dc_types.ROIChannels()
+        with pytest.raises(ValueError):
+            channels['poorly_converged_mixing_matrix'] = bad_val
+
+    channels = dc_types.ROIChannels()
+    with pytest.raises(ValueError):
+        channels['use_avg_mixing_matrix'] = 'True'
+
+    channels = dc_types.ROIChannels()
+    channels['signal'] = np.arange(9, dtype=float)
+    with pytest.raises(NotImplementedError):
+        channels.pop('signal')
+
+    channels = dc_types.ROIChannels()
+    with pytest.raises(KeyError):
+        channels['abracadabra'] = 9
+
+
+def test_ROIChannels_in():
+
+    signal = np.arange(9, dtype=float)
+    crosstalk = np.arange(8, 17, dtype=float)
+    mm = np.array([[1.2, 3.4], [5.6, 7.9]])
+    p_signal = signal+0.01
+    p_crosstalk = crosstalk+0.7
+    p_mm = mm+0.9
+    channels = dc_types.ROIChannels()
+    channels['signal'] = signal
+    assert 'signal' in channels
+    assert 'crosstalk' not in channels
+    assert 'mixing_matrix' not in channels
+    assert 'poorly_converged_signal' not in channels
+    assert 'poorly_converged_crosstalk' not in channels
+    assert 'poorly_converged_mixing_matrix' not in channels
+    assert 'use_avg_mixing_matrix' not in channels
+
+    channels['crosstalk'] = crosstalk
+    assert 'signal' in channels
+    assert 'crosstalk' in channels
+    assert 'mixing_matrix' not in channels
+    assert 'poorly_converged_signal' not in channels
+    assert 'poorly_converged_crosstalk' not in channels
+    assert 'poorly_converged_mixing_matrix' not in channels
+    assert 'use_avg_mixing_matrix' not in channels
+
+    channels['mixing_matrix'] = mm
+    assert 'signal' in channels
+    assert 'crosstalk' in channels
+    assert 'mixing_matrix' in channels
+    assert 'poorly_converged_signal' not in channels
+    assert 'poorly_converged_crosstalk' not in channels
+    assert 'poorly_converged_mixing_matrix' not in channels
+    assert 'use_avg_mixing_matrix' not in channels
+
+    keys = channels.keys()
+    keys.sort()
+    assert keys == ['crosstalk', 'mixing_matrix', 'signal']
+
+    channels['poorly_converged_signal'] = p_signal
+    assert 'signal' in channels
+    assert 'crosstalk' in channels
+    assert 'mixing_matrix' in channels
+    assert 'poorly_converged_signal' in channels
+    assert 'poorly_converged_crosstalk' not in channels
+    assert 'poorly_converged_mixing_matrix' not in channels
+    assert 'use_avg_mixing_matrix' not in channels
+
+    channels['poorly_converged_crosstalk'] = p_crosstalk
+    assert 'signal' in channels
+    assert 'crosstalk' in channels
+    assert 'mixing_matrix' in channels
+    assert 'poorly_converged_signal' in channels
+    assert 'poorly_converged_crosstalk' in channels
+    assert 'poorly_converged_mixing_matrix' not in channels
+    assert 'use_avg_mixing_matrix' not in channels
+
+    keys = channels.keys()
+    keys.sort()
+    assert keys == ['crosstalk', 'mixing_matrix',
+                    'poorly_converged_crosstalk',
+                    'poorly_converged_signal',
+                    'signal']
+
+    channels['poorly_converged_mixing_matrix'] = p_mm
+    assert 'signal' in channels
+    assert 'crosstalk' in channels
+    assert 'mixing_matrix' in channels
+    assert 'poorly_converged_signal' in channels
+    assert 'poorly_converged_crosstalk' in channels
+    assert 'poorly_converged_mixing_matrix' in channels
+    assert 'use_avg_mixing_matrix' not in channels
+
+    channels['use_avg_mixing_matrix'] = False
+    assert 'signal' in channels
+    assert 'crosstalk' in channels
+    assert 'mixing_matrix' in channels
+    assert 'poorly_converged_signal' in channels
+    assert 'poorly_converged_crosstalk' in channels
+    assert 'poorly_converged_mixing_matrix' in channels
+    assert 'use_avg_mixing_matrix' in channels
+
+    keys = channels.keys()
+    keys.sort()
+    assert keys == ['crosstalk',
+                    'mixing_matrix',
+                    'poorly_converged_crosstalk',
+                    'poorly_converged_mixing_matrix',
+                    'poorly_converged_signal',
+                    'signal',
+                    'use_avg_mixing_matrix']
+
+
+def test_ROIDict():
+
+    channel = dc_types.ROIChannels()
+    channel['signal'] = np.array([9.2, 3.4, 6.7])
+    channel['use_avg_mixing_matrix'] = False
+    roi_dict = dc_types.ROIDict()
+    roi_dict[9] = channel
+
+    np_almost(roi_dict[9]['signal'],
+              np.array([9.2, 3.4, 6.7]),
+              decimal=9)
+
+    assert not roi_dict[9]['use_avg_mixing_matrix']
+
+
+def test_ROIDict_exceptions():
+
+    channel = dc_types.ROIChannels()
+    channel['signal'] = np.array([9.2, 3.4, 6.7])
+    channel['use_avg_mixing_matrix'] = False
+
+    roi_dict = dc_types.ROIDict()
+    with pytest.raises(KeyError):
+        roi_dict['aa'] = channel
+
+    roi_dict = dc_types.ROIDict()
+    with pytest.raises(ValueError):
+        roi_dict[11] = 'abcde'
+
+
+def test_ROIDict_pop_and_keys():
+    rng = np.random.RandomState(1123)
+    s1 = rng.random_sample(10)
+    c1 = rng.random_sample(10)
+    s2 = rng.random_sample(14)
+    c2 = rng.random_sample(14)
+
+    channel1 = dc_types.ROIChannels()
+    channel1['signal'] = s1
+    channel1['crosstalk'] = c1
+
+    channel2 = dc_types.ROIChannels()
+    channel2['signal'] = s2
+    channel2['crosstalk'] = c2
+
+    roi_dict = dc_types.ROIDict()
+    roi_dict[88] = channel1
+    roi_dict[77] = channel2
+
+    keys = roi_dict.keys()
+    keys.sort()
+    assert keys == [77, 88]
+
+    assert 77 in roi_dict
+    assert 88 in roi_dict
+    assert 55 not in roi_dict
+
+    test = roi_dict.pop(88)
+    assert 77 in roi_dict
+    assert 88 not in roi_dict
+    assert roi_dict.keys() == [77]
+
+    np_almost(test['signal'], s1, decimal=10)
+    np_almost(test['crosstalk'], c1, decimal=10)
+
+    np_almost(roi_dict[77]['signal'], s2, decimal=10)
+    np_almost(roi_dict[77]['crosstalk'], c2, decimal=10)
+
+
+def test_ROISetDict():
+
+    rng = np.random.RandomState(53124)
+    signals = list([rng.random_sample(10) for ii in range(4)])
+    crosstalks = list([rng.random_sample(10) for ii in range(4)])
+
+    roi_set_dict = dc_types.ROISetDict()
+
+    for ii in range(2):
+        c = dc_types.ROIChannels()
+        c['signal'] = signals[ii]
+        c['crosstalk'] = crosstalks[ii]
+        roi_set_dict['roi'][ii] = c
+
+    for ii in range(2, 4):
+        c = dc_types.ROIChannels()
+        c['signal'] = signals[ii]
+        c['crosstalk'] = crosstalks[ii]
+        roi_set_dict['neuropil'][ii-2] = c
+
+    np_almost(roi_set_dict['roi'][0]['signal'],
+              signals[0], decimal=10)
+
+    np_almost(roi_set_dict['roi'][1]['signal'],
+              signals[1], decimal=10)
+
+    np_almost(roi_set_dict['roi'][0]['crosstalk'],
+              crosstalks[0], decimal=10)
+
+    np_almost(roi_set_dict['roi'][1]['crosstalk'],
+              crosstalks[1], decimal=10)
+
+    np_almost(roi_set_dict['neuropil'][0]['signal'],
+              signals[2], decimal=10)
+
+    np_almost(roi_set_dict['neuropil'][1]['signal'],
+              signals[3], decimal=10)
+
+    np_almost(roi_set_dict['neuropil'][0]['crosstalk'],
+              crosstalks[2], decimal=10)
+
+    np_almost(roi_set_dict['neuropil'][1]['crosstalk'],
+              crosstalks[3], decimal=10)
+
+
+def test_ROISetDict_exceptions():
+
+    roi_set = dc_types.ROISetDict()
+    with pytest.raises(NotImplementedError):
+        roi_set['roi'] = dc_types.ROIDict()
+
+    with pytest.raises(KeyError):
+        roi_set[9]


### PR DESCRIPTION
This PR creates classes designed for carrying around the internal data used by the decrosstalking module. This allows us to use type hinting in the decrosstalking modules, as requested by @djkapner 

I did not implement type hinting in
- `roi_masks.py` since that is code that was legacy code copied directly from the AllenSDK. Type hinting it felt out of scope. I can revisit that decision if requested.
- `io_utils.py` since this module exists solely to support quality control data and will presumably change once we assume ownership of the visualization code.

Either of those decisions can be revisited. I just want to open this for comment now since there are logic updates I need to make to the pipeline and I want to be able to build them on top of this branch.
