### PR TITLE
clip outlier motion correction shifts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
                   # set entrypoint like this so we can handle quotes
                   docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/suite2p/bin/python -m pytest -m 'suite2p_only or suite2p_also' --ignore-glob='*test_event_detection.py' /repos/ophys_etl/tests"
                   docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/event_detection/bin/python -m pytest -m 'event_detect_only' /repos/ophys_etl/tests"
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/ophys_etl/bin/python -m pytest -m 'not suite2p_only' -m 'not event_detect_only' /repos/ophys_etl/tests"
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/ophys_etl/bin/python -m pytest -m 'not suite2p_only and not event_detect_only' /repos/ophys_etl/tests"
       - run:
           name: Run docker image smoke test
           command: |
@@ -51,8 +51,7 @@ jobs:
           command: |
             pip install .
             # pytest would be a dep in requirements.txt
-            python -m pytest -m "not suite2p_only" \
-                             -m "not event_detect_only" \
+            python -m pytest -m "not suite2p_only and not event_detect_only" \
                              --cov ophys_etl --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
           name: Test

--- a/src/ophys_etl/pipelines/suite2p_registration.py
+++ b/src/ophys_etl/pipelines/suite2p_registration.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
+from typing import Tuple, List
 
 import argschema
 import h5py
@@ -10,11 +11,13 @@ import numpy as np
 import pandas as pd
 import tifffile
 from PIL import Image
+from scipy.ndimage.filters import median_filter
 
 from ophys_etl.schemas.fields import ExistingFile, ExistingH5File
 from ophys_etl.qc.registration_qc import RegistrationQC
 from ophys_etl.transforms.suite2p_wrapper import (Suite2PWrapper,
                                                   Suite2PWrapperSchema)
+from suite2p.registration.rigid import shift_frame
 
 
 class Suite2PRegistrationInputSchema(argschema.ArgSchema):
@@ -66,6 +69,24 @@ class Suite2PRegistrationInputSchema(argschema.ArgSchema):
         default=10.0,
         description=("the preview movie will playback at this factor "
                      "times real-time."))
+    outlier_detrend_window = argschema.fields.Float(
+        required=False,
+        default=3.0,
+        description=("for outlier rejection in the xoff/yoff outputs "
+                     "of suite2p, the offsets are first de-trended "
+                     "with a median filter of this duration [seconds]. "
+                     "This value is ~30 or 90 samples in size for 11 and 31"
+                     "Hz sampling rates respectively."))
+    outlier_maxregshift = argschema.fields.Float(
+        required=False,
+        default=0.05,
+        description=("units [fraction FOV dim]. After median-filter "
+                     "detrending, outliers more than this value are "
+                     "clipped to this value in x and y offset, independently."
+                     "This is similar to Suite2P's internal maxregshift, but"
+                     "allows for low-frequency drift. Default value of 0.05 "
+                     "is typically clipping outliers to 512 * 0.05 = 25 "
+                     "pixels above or below the median trend."))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -145,6 +166,40 @@ def projection_process(data: np.ndarray,
     return proj
 
 
+def identify_and_clip_outliers(data: np.ndarray,
+                               med_filter_size: int,
+                               thresh: int) -> Tuple[np.ndarray, List]:
+    """given data, identify the indices of outliers
+    based on median filter detrending, and a threshold
+
+    Parameters
+    ----------
+    data: np.ndarray
+        1D array of samples
+    med_filter_size: int
+        the number of samples for 'size' in
+        scipy.ndimage.filters.median_filter
+    thresh: int
+        multipled by the noise estimate to establish a threshold, above
+        which, samples will be marked as outliers.
+
+    Returns
+    -------
+    data: np.ndarry
+        1D array of samples, clipped to threshold around median-filtered data
+    indices: np.ndarray
+        the indices where clipping took place
+
+    """
+    data_filtered = median_filter(data, med_filter_size, mode='nearest')
+    detrended = data - data_filtered
+    indices = np.argwhere(np.abs(detrended) > thresh).flatten()
+    data[indices] = np.clip(data[indices],
+                            data_filtered[indices] - thresh,
+                            data_filtered[indices] + thresh)
+    return data, indices
+
+
 class Suite2PRegistration(argschema.ArgSchemaParser):
     default_schema = Suite2PRegistrationInputSchema
     default_output_schema = Suite2PRegistrationOutputSchema
@@ -158,8 +213,13 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
 
         # register with Suite2P
         suite2p_args = self.args['suite2p_args']
+        self.logger.info("attempting to motion correct "
+                         f"{suite2p_args['h5py']}")
         register = Suite2PWrapper(input_data=suite2p_args, args=[])
         register.run()
+
+        # why does this logger assume the Suite2PWrapper name? reset
+        self.logger.name = type(self).__name__
 
         # get paths to Suite2P outputs
         with open(suite2p_args["output_json"], "r") as f:
@@ -167,7 +227,30 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
         tif_paths = [Path(i) for i in outj['output_files']["*.tif"]]
         ops_path = Path(outj['output_files']['ops.npy'][0])
 
-        # assemble tifs into an hdf5
+        # Suite2P ops file contains at least the following keys:
+        # ["Lx", "Ly", "nframes", "xrange", "yrange", "xoff", "yoff",
+        #  "corrXY", "meanImg"]
+        ops = np.load(ops_path, allow_pickle=True)
+
+        # identify and clip offset outliers
+        detrend_size = int(self.args['movie_frame_rate_hz'] *
+                           self.args['outlier_detrend_window'])
+        xlimit = int(ops.item()['Lx'] * self.args['outlier_maxregshift'])
+        ylimit = int(ops.item()['Ly'] * self.args['outlier_maxregshift'])
+        self.logger.info("checking whether to clip where median-filtered "
+                         "offsets exceed (x,y) limits of "
+                         f"({xlimit},{ylimit}) [pixels]")
+        delta_x, x_clipped = identify_and_clip_outliers(
+                np.array(ops.item()["xoff"]), detrend_size, xlimit)
+        delta_y, y_clipped = identify_and_clip_outliers(
+                np.array(ops.item()["yoff"]), detrend_size, ylimit)
+        clipped_indices = list(set(x_clipped).union(set(y_clipped)))
+        self.logger.info(f"{len(x_clipped)} frames clipped in x")
+        self.logger.info(f"{len(y_clipped)} frames clipped in y")
+        self.logger.info(f"{len(clipped_indices)} frames will be adjusted "
+                         "for clipping")
+
+        # accumulate data from Suite2P's tiffs
         data = []
         for fname in tif_paths:
             with tifffile.TiffFile(fname) as f:
@@ -181,6 +264,16 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
         data = np.concatenate(data, axis=0)
         data[data < 0] = 0
         data = np.uint16(data)
+
+        # anywhere we've clipped the offset, translate the frame
+        # using Suite2P's shift_frame by the difference resulting
+        # from clipping, for example, if Suite2P moved a frame
+        # by 100 pixels, and we have clipped that to 30, this will
+        # move it -70 pixels
+        for frame_index in clipped_indices:
+            dx = delta_x[frame_index] - ops.item()['xoff'][frame_index]
+            dy = delta_y[frame_index] - ops.item()['yoff'][frame_index]
+            data[frame_index] = shift_frame(data[frame_index], dy, dx)
 
         # write the hdf5
         with h5py.File(self.args['motion_corrected_output'], "w") as f:
@@ -201,20 +294,21 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
                 pilim.save(dst_path)
             self.logger.info(f"wrote {dst_path}")
 
-        # Suite2P ops file contains at least the following keys:
-        # ["Lx", "Ly", "nframes", "xrange", "yrange", "xoff", "yoff",
-        #  "corrXY", "meanImg"]
-        ops = np.load(ops_path, allow_pickle=True)
-
         # Save motion offset data to a csv file
         # TODO: This *.csv file is being created to maintain compatability
         # with current ophys processing pipeline. In the future this output
         # should be removed and a better data storage format used.
         # 01/25/2021 - NJM
+        x_is_clipped = np.zeros(delta_x.size).astype(bool)
+        x_is_clipped[x_clipped] = True
+        y_is_clipped = np.zeros(delta_y.size).astype(bool)
+        y_is_clipped[y_clipped] = True
         motion_offset_df = pd.DataFrame({
             "framenumber": list(range(ops.item()["nframes"])),
-            "x": ops.item()["xoff"],
-            "y": ops.item()["yoff"],
+            "x": delta_x,
+            "y": delta_y,
+            "x_clipped": x_is_clipped,
+            "y_clipped": y_is_clipped,
             "correlation": ops.item()["corrXY"]
         })
         motion_offset_df.to_csv(
@@ -223,6 +317,12 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
         self.logger.info(
             f"Writing the LIMS expected 'OphysMotionXyOffsetData' "
             f"csv file to: {self.args['motion_diagnostics_output']}")
+        if len(clipped_indices) != 0:
+            self.logger.warning(
+                    "some offsets have been clipped and the values "
+                    "for 'correlation' in "
+                    "{self.args['motion_diagnostics_output']} "
+                    "where (x_clipped OR y_clipped) = True are not valid")
 
         qc_args = {k: self.args[k]
                    for k in ['movie_frame_rate_hz',
@@ -232,10 +332,6 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
                              'motion_corrected_output',
                              'motion_correction_preview_output',
                              'registration_summary_output',
-                             'movie_lower_quantile',
-                             'movie_upper_quantile',
-                             'preview_frame_bin_seconds',
-                             'preview_playback_factor',
                              'log_level']}
         qc_args.update({
                 'uncorrected_path': self.args['suite2p_args']['h5py']})

--- a/src/ophys_etl/pipelines/suite2p_registration.py
+++ b/src/ophys_etl/pipelines/suite2p_registration.py
@@ -299,16 +299,12 @@ class Suite2PRegistration(argschema.ArgSchemaParser):
         # with current ophys processing pipeline. In the future this output
         # should be removed and a better data storage format used.
         # 01/25/2021 - NJM
-        x_is_clipped = np.zeros(delta_x.size).astype(bool)
-        x_is_clipped[x_clipped] = True
-        y_is_clipped = np.zeros(delta_y.size).astype(bool)
-        y_is_clipped[y_clipped] = True
         motion_offset_df = pd.DataFrame({
             "framenumber": list(range(ops.item()["nframes"])),
             "x": delta_x,
             "y": delta_y,
-            "x_clipped": x_is_clipped,
-            "y_clipped": y_is_clipped,
+            "x_pre_clip": ops.item()['xoff'],
+            "y_pre_clip": ops.item()['yoff'],
             "correlation": ops.item()["corrXY"]
         })
         motion_offset_df.to_csv(

--- a/tests/pipelines/test_suite2p_registration.py
+++ b/tests/pipelines/test_suite2p_registration.py
@@ -11,6 +11,7 @@ import pytest
 import tifffile
 
 sys.modules['suite2p'] = Mock()
+sys.modules['suite2p.registration.rigid'] = Mock()
 import ophys_etl.pipelines.suite2p_registration as s2preg  # noqa
 import ophys_etl.transforms.suite2p_wrapper as s2pw  # noqa
 
@@ -46,6 +47,41 @@ class MockSuite2PWrapper(argschema.ArgSchemaParser):
                     }
                 }
         self.output(outj)
+
+
+@pytest.mark.suite2p_only
+@pytest.mark.parametrize(
+        ("excess_indices", "deltas", "thresh", "expected_indices"), [
+            ([], [], 10, []),
+            ([123, 567], [20, 20], 10, [123, 567]),
+            ([123, 567], [8, 20], 10, [567]),
+            ([123, 567], [-20, -20], 10, [123, 567]),
+            ([123, 567], [-8, -20], 10, [567]),
+            ([123, 567, 1234, 5678], [-20, -8, 8, 20], 10, [123, 5678])
+            ])
+def test_identify_and_clip_outliers(excess_indices, deltas,
+                                    thresh, expected_indices):
+    frame_index = np.arange(10000)
+    # long-range drifts
+    baseline = 20.0 * np.cos(2.0 * np.pi * frame_index / 500)
+    additional = np.zeros_like(baseline)
+    for index, delta in zip(excess_indices, deltas):
+        additional[index] += delta
+
+    data, indices = s2preg.identify_and_clip_outliers(
+            baseline + additional,
+            10,
+            thresh)
+
+    # check that the outliers were identified
+    assert set(indices) == set(expected_indices)
+    # check that the outlier values were clipped to within
+    # the threshold of the underlying trend data
+    # with a small delta value because the median-filtered data
+    # is not quite ever the same as the baseline data
+    deltas = np.abs(data[expected_indices] - baseline[expected_indices])
+    small_delta = 1.0
+    assert np.all(deltas < thresh + small_delta)
 
 
 @pytest.mark.suite2p_only


### PR DESCRIPTION
After Suite2P motion-correction, this implements a clipping of outlier offsets relative to a median-filtered offset trend. This recovers some border real-estate in low SNR movies, where some difficult-to-register frames artifically inflate the motion border.

Example: median filter over 33 samples and clip to 30 pixels within median filter:
(just operating on offset file, full example farther down).
```
df = pd.read_csv("/allen/programs/braintv/production/neuralcoding/prod0/specimen_813702151/ophys_session_855711263/ophys_experiment_856123117/processed/856123117_suite2p_rigid_motion_transform.csv")
detrend_size = 33
delta_x, c_clipped = identify_and_clip_outliers(np.array(df['x']), detrend_size, 30)
delta_y, c_clipped = identify_and_clip_outliers(np.array(df['y']), detrend_size, 30)
```
![image](https://user-images.githubusercontent.com/32312979/106500568-d48f1f00-6476-11eb-9436-14b16fd3a8f6.png)

## Validation
I've gone through the Suite2P code and some of our processed data and confirmed that the correct way to call `shift_frame` is:
`shift_frame(frame, +yoff, +xoff)` rather than `-` signs of some combination thereof.

## full example
this experiment lost a lot of border area:
![image](https://user-images.githubusercontent.com/32312979/106531645-7f1d3700-64a3-11eb-9c97-ce96ae9e7049.png)

implementing an `outlier_maxregshift = 0.1` results in:
![image](https://user-images.githubusercontent.com/32312979/106531718-9fe58c80-64a3-11eb-89a7-c0cc1d7aaa24.png)
