### PR TITLE
Decrosstalk/dev/bugfixes/20210201

### DIFF
--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -556,6 +556,11 @@ def run_decrosstalk(signal_plane: DecrosstalkingOphysPlane,
 
     del raw_trace_events
 
+    # if there was no activity in the raw traces, return an
+    # empty ROISetDict because none of the ROIs were valid
+    if len(raw_traces['roi']) == 0:
+        return roi_flags, dc_types.ROISetDict()
+
     ###########################################################
     # use Independent Component Analysis to separate out signal
     # and crosstalk

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -393,8 +393,8 @@ def clean_negative_traces(trace_dict: dc_types.ROISetDict) -> dc_types.ROISetDic
                                  -999.0)
 
             if np.isnan(threshold).any():
-                 raise RuntimeError("There were NaNs in "
-                                    "clean_negative_traces.threshold")
+                raise RuntimeError("There were NaNs in "
+                                   "clean_negative_traces.threshold")
 
             # clip the trace at threshold
             trace = trace_dict[obj][roi_id]['signal']

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -378,11 +378,14 @@ def clean_negative_traces(trace_dict: dc_types.ROISetDict) -> dc_types.ROISetDic
              std) = _centered_rolling_mean(trace_dict[obj][roi_id]['signal'],
                                            mask,
                                            1980)
+
             threshold = mean-2.0*std
-            threshold = np.where(threshold > 0.0, threshold, mean)
+
             if (threshold < 0.0).any():
-                raise RuntimeError("threshold in clean_negative_traces "
-                                   "%e" % threshold.min())
+                msg = 'The unmixed "%s" trace for roi %d ' % (obj, roi_id)
+                msg += 'contained negative flux values'
+                logger.warning(msg)
+
 
             # clip the trace at threshold
             trace = trace_dict[obj][roi_id]['signal']

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -392,6 +392,10 @@ def clean_negative_traces(trace_dict: dc_types.ROISetDict) -> dc_types.ROISetDic
                                  threshold,
                                  -999.0)
 
+            if np.isnan(threshold).any():
+                 raise RuntimeError("There were NaNs in "
+                                    "clean_negative_traces.threshold")
+
             # clip the trace at threshold
             trace = trace_dict[obj][roi_id]['signal']
             trace = np.where(trace > threshold, trace, threshold)

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -117,6 +117,35 @@ def unmix_all_ROIs(raw_roi_traces: dc_types.ROISetDict,
 
     A decrosstalk_types.ROISetDict containing the unmixed trace data for the
     ROIs.
+
+    Notes
+    -----
+    This method makes two attempts at decrosstalking each ROI using
+    Independent Component Analysis. On the first attempt, each ROI
+    (not neuropil) is decrosstalked as an independent entity. It is
+    possible that this process will not converge for any given ROI.
+
+    On the second attempt, an average demixing matrix is constructed
+    from the demixing matrices of those ROIs for which the first attempt
+    did converge. This average demixing matrix is to decrosstalk any
+    ROIs for which the first attempt did not converge.
+
+    Neuropils are then decrosstalked using the demixing matrix
+    corresponding to their associated ROI (whether the ROI-specific
+    demixing matrix or, in the case that the first attempt did not
+    converge, the average demixing matrix).
+
+    If the first attempt does not converge for any ROIs, there are no
+    demixing matrices from which to construct an average demixing
+    matrix and it is impossible to salvage any of the ROIs. In this case,
+    the boolean that is the first returned object of this method will
+    be set to False and the output ROISetDict will be emtpy.
+
+    If decrosstalking converged for any ROIs (and an average demixing
+    matrix is thus possible), that boolean will be set to True.
+
+    The unmixed traces, however they were achieved, will be saved in
+    the output ROISetDict.
     """
 
     output = dc_types.ROISetDict()

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -338,25 +338,32 @@ def _centered_rolling_mean(data: np.ndarray,
     i0 = window-1
     i1 = window-1+n_t-window
 
-    true_sum = np.zeros(n_t, dtype=float)
-    true_sum[half:n_t-half] = sum_[i0:i1]
-    true_sum[:half] = sum_[i0]
-    true_sum[n_t-half:] = sum_[i1]
+    # if mask has a run of `False`s that is longer than
+    # `window`, the mean and std calculations below will
+    # end up dividing by zero because there are zero valid
+    # elements over which to take the mean and std. This
+    # np.errstate context will suppress those warnings.
+    with np.errstate(divide='ignore', invalid='ignore'):
+        true_sum = np.zeros(n_t, dtype=float)
+        true_sum[half:n_t-half] = sum_[i0:i1]
+        true_sum[:half] = sum_[i0]
+        true_sum[n_t-half:] = sum_[i1]
 
-    true_sum_sq = np.zeros(n_t, dtype=float)
-    true_sum_sq[half:n_t-half] = sum_sq[i0:i1]
-    true_sum_sq[:half] = sum_sq[i0]
-    true_sum_sq[n_t-half:] = sum_sq[i1]
+        true_sum_sq = np.zeros(n_t, dtype=float)
+        true_sum_sq[half:n_t-half] = sum_sq[i0:i1]
+        true_sum_sq[:half] = sum_sq[i0]
+        true_sum_sq[n_t-half:] = sum_sq[i1]
 
-    true_mask_sum = np.zeros(n_t, dtype=float)
-    true_mask_sum[half:n_t-half] = mask_sum[i0:i1]
-    true_mask_sum[:half] = mask_sum[i0]
-    true_mask_sum[n_t-half:] = mask_sum[i1]
+        true_mask_sum = np.zeros(n_t, dtype=float)
+        true_mask_sum[half:n_t-half] = mask_sum[i0:i1]
+        true_mask_sum[:half] = mask_sum[i0]
+        true_mask_sum[n_t-half:] = mask_sum[i1]
 
-    mean = true_sum/true_mask_sum
-    var = (true_sum_sq/true_mask_sum - mean*mean)
-    var *= (true_mask_sum/(true_mask_sum-1))
-    std = np.sqrt(var)
+        mean = true_sum/true_mask_sum
+        var = (true_sum_sq/true_mask_sum - mean*mean)
+        var *= (true_mask_sum/(true_mask_sum-1))
+        std = np.sqrt(var)
+
     return mean, std
 
 

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -386,6 +386,11 @@ def clean_negative_traces(trace_dict: dc_types.ROISetDict) -> dc_types.ROISetDic
                 msg += 'contained negative flux values'
                 logger.warning(msg)
 
+            # if there were no valid timesteps when calculating the rolling
+            # mean, set the threshold to a very negative value
+            threshold = np.where(np.logical_not(np.isnan(threshold)),
+                                 threshold,
+                                 -999.0)
 
             # clip the trace at threshold
             trace = trace_dict[obj][roi_id]['signal']

--- a/src/ophys_etl/decrosstalk/decrosstalk.py
+++ b/src/ophys_etl/decrosstalk/decrosstalk.py
@@ -112,6 +112,9 @@ def unmix_all_ROIs(raw_roi_traces: dc_types.ROISetDict,
 
     Returns
     -------
+    A boolean indicating whether or not we were able to successfully
+    unmix the ROIs in this input ROISetDict
+
     A decrosstalk_types.ROISetDict containing the unmixed trace data for the
     ROIs.
     """

--- a/src/ophys_etl/transforms/decrosstalk_wrapper.py
+++ b/src/ophys_etl/transforms/decrosstalk_wrapper.py
@@ -104,7 +104,9 @@ class DecrosstalkWrapper(argschema.ArgSchemaParser):
 
             for roi in plane_0.roi_list:
                 if roi.roi_id not in roi_names:
-                    raise RuntimeError("ROI %d not in final output" % roi.roi_id)
+                    msg = "ROI %d " % roi.roi_id
+                    msg += "not in final output"
+                    raise RuntimeError(msg)
 
             output_pair['planes'] = plane_pair
             coupled_planes.append(output_pair)

--- a/src/ophys_etl/transforms/decrosstalk_wrapper.py
+++ b/src/ophys_etl/transforms/decrosstalk_wrapper.py
@@ -102,6 +102,10 @@ class DecrosstalkWrapper(argschema.ArgSchemaParser):
                         out_file.create_dataset('roi_names', data=roi_names)
                         out_file.create_dataset('data', data=data)
 
+            for roi in plane_0.roi_list:
+                if roi.roi_id not in roi_names:
+                    raise RuntimeError("ROI %d not in final output" % roi.roi_id)
+
             output_pair['planes'] = plane_pair
             coupled_planes.append(output_pair)
 

--- a/src/ophys_etl/transforms/decrosstalk_wrapper.py
+++ b/src/ophys_etl/transforms/decrosstalk_wrapper.py
@@ -105,7 +105,10 @@ class DecrosstalkWrapper(argschema.ArgSchemaParser):
             for roi in plane_0.roi_list:
                 if roi.roi_id not in roi_names:
                     msg = "ROI %d " % roi.roi_id
-                    msg += "not in final output"
+                    msg += "not in final output trace file.\n"
+                    msg += "This should not be possible. "
+                    msg += "Check to make sure invalid ROIs are "
+                    msg += "still being written to the trace file."
                     raise RuntimeError(msg)
 
             output_pair['planes'] = plane_pair

--- a/tests/decrosstalk/test_decrosstalk_methods.py
+++ b/tests/decrosstalk/test_decrosstalk_methods.py
@@ -77,6 +77,7 @@ def test_clean_negative_traces():
     assert cleaned['roi'][0]['signal'].min() > 6.0
     assert cleaned['roi'][0]['signal'].min() < 7.0
     assert abs(cleaned['roi'][0]['signal'][77] - 15.0) < 0.001
+    assert not np.isnan(cleaned['roi'][0]['signal']).any()
 
     np.testing.assert_array_equal(cleaned['roi'][1]['signal'], nan_trace)
 

--- a/tests/decrosstalk/test_decrosstalk_methods.py
+++ b/tests/decrosstalk/test_decrosstalk_methods.py
@@ -43,7 +43,7 @@ def test_rolling_mean_and_std():
         assert abs(s-std[ii]) < 1.0e-10
 
     mask = np.ones(100, dtype=bool)
-    idx = np.unique(rng.randint(0,100,20))
+    idx = np.unique(rng.randint(0, 100, 20))
     mask[idx] = False
 
     mean, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
@@ -91,7 +91,6 @@ def test_rolling_mean_and_std():
             assert abs(s-std[ii]) < 1.0e-10
 
     assert edge_case_exercised
-
 
 
 def test_clean_negative_traces():

--- a/tests/decrosstalk/test_decrosstalk_methods.py
+++ b/tests/decrosstalk/test_decrosstalk_methods.py
@@ -102,7 +102,7 @@ def test_clean_negative_traces():
     trace[99] = 1.0
     roi = dc_types.ROIChannels()
     roi['signal'] = trace
-    roi['crosstalk'] = np.zeros(1000, dtype=float)
+    roi['crosstalk'] = rng.random_sample(1000)
     input_data['roi'][0] = roi
 
     trace = rng.normal(11.0, 0.2, size=1000)
@@ -110,7 +110,7 @@ def test_clean_negative_traces():
     trace[88] = 1.0
     roi = dc_types.ROIChannels()
     roi['signal'] = trace
-    roi['crosstalk'] = np.zeros(1000, dtype=float)
+    roi['crosstalk'] = rng.random_sample(1000)
     input_data['neuropil'][0] = roi
 
     # make sure traces with NaNs are left untouched
@@ -120,7 +120,7 @@ def test_clean_negative_traces():
     nan_trace[44] = np.NaN
     roi = dc_types.ROIChannels()
     roi['signal'] = nan_trace
-    roi['crosstalk'] = np.zeros(1000, dtype=float)
+    roi['crosstalk'] = rng.random_sample(1000)
     input_data['roi'][1] = roi
 
     cleaned = decrosstalk.clean_negative_traces(input_data)

--- a/tests/decrosstalk/test_decrosstalk_methods.py
+++ b/tests/decrosstalk/test_decrosstalk_methods.py
@@ -3,12 +3,12 @@ import ophys_etl.decrosstalk.decrosstalk_types as dc_types
 import ophys_etl.decrosstalk.decrosstalk as decrosstalk
 
 
-def test_rolling_median_and_std():
+def test_rolling_mean_and_std():
 
     rng = np.random.RandomState(11123)
     data = rng.random_sample(100)
     mask = np.ones(100, dtype=bool)
-    med, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
+    mean, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
     for ii in range(100):
         i0 = ii-5
         if i0 < 0:
@@ -19,11 +19,11 @@ def test_rolling_median_and_std():
             i0 = 90
         m = np.mean(data[i0:i1])
         s = np.std(data[i0:i1], ddof=1)
-        assert abs(m-med[ii]) < 1.0e-10
+        assert abs(m-mean[ii]) < 1.0e-10
         assert abs(s-std[ii]) < 1.0e-10
 
     mask[0:100:2] = False
-    med, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
+    mean, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
     for ii in range(100):
         i0 = ii-5
         if i0 < 0:
@@ -39,8 +39,59 @@ def test_rolling_median_and_std():
             m = np.mean(data[i0:i1:2])
             s = np.std(data[i0:i1:2], ddof=1)
 
-        assert abs(m-med[ii]) < 1.0e-10
+        assert abs(m-mean[ii]) < 1.0e-10
         assert abs(s-std[ii]) < 1.0e-10
+
+    mask = np.ones(100, dtype=bool)
+    idx = np.unique(rng.randint(0,100,20))
+    mask[idx] = False
+
+    mean, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
+    for ii in range(100):
+        i0 = ii-5
+        if i0 < 0:
+            i0 = 0
+        i1 = i0+10
+        if i1 > 100:
+            i1 = 100
+            i0 = 90
+        d = data[i0:i1][mask[i0:i1]]
+        m = np.mean(d)
+        s = np.std(d, ddof=1)
+
+        assert abs(m-mean[ii]) < 1.0e-10
+        assert abs(s-std[ii]) < 1.0e-10
+
+    # test case where stretch of `False` in mask is longer than window
+    edge_case_exercised = False
+    mask[50:75] = False
+    mean, std = decrosstalk._centered_rolling_mean(data, mask, window=10)
+    for ii in range(100):
+        i0 = ii-5
+        if i0 < 0:
+            i0 = 0
+        i1 = i0+10
+        if i1 > 100:
+            i1 = 100
+            i0 = 90
+        sub_mask = mask[i0:i1]
+        d = data[i0:i1][sub_mask]
+
+        if sub_mask.sum() < 2:
+            edge_case_exercised = True
+            if sub_mask.sum() == 0:
+                assert np.isnan(mean[ii])
+            else:
+                assert abs(mean[ii] - np.mean(d)) < 1.0e-10
+            assert np.isnan(std[ii])
+        else:
+            m = np.mean(d)
+            s = np.std(d, ddof=1)
+            assert abs(m-mean[ii]) < 1.0e-10
+            assert abs(s-std[ii]) < 1.0e-10
+
+    assert edge_case_exercised
+
 
 
 def test_clean_negative_traces():


### PR DESCRIPTION
This PR addresses the failures encountered during Wayne's reprocessing over the weekend.

Cases were being pushed through in which

1) No activity was observed in the raw traces. This was causing `clean_negative_traces` to fail, because there was nothing to clean. The pipeline now exits, producing an empty set of ROIs whenever this occurs.

2) The baseline of the unmixed signal channel was negative. I had originally written the code so that it would raise an exception in this case, since it seemed scientifically invalid. Natalia asked that we let these ROIs go through and be examined in QC. I have changed the code to just log a warning whenever this occurs.