### PR TITLE
Changes to metadata tiff parser.

### DIFF
--- a/src/ophys_etl/transforms/mesoscope_2p/metadata.py
+++ b/src/ophys_etl/transforms/mesoscope_2p/metadata.py
@@ -123,6 +123,9 @@ def tiff_header_data(filename):
         elif version == 4:
             frame_data = unflatten_dict(frame_data)
             frame_data["SI"]["hStackManager"]["zs_v3_v4"] = frame_data["SI"]["hStackManager"]["zsAllActuators"]
+            frame_data["SI"]["hFastZ"]["numFramesPerVolume"] = frame_data["SI"]["hStackManager"]["numFramesPerVolume"]
+            frame_data["SI"]["hFastZ"]["numVolumes"] = frame_data["SI"]["hStackManager"]["numVolumes"]
+            frame_data["SI"]["hFastZ"]["userZs"] = frame_data["SI"]["hStackManager"]["arbitraryZs"]
             logging.debug("Loaded %s as 2017b v1", filename)
 
         frame_data = floatify_SI_float_strings(frame_data)

--- a/src/ophys_etl/transforms/mesoscope_2p/tiff.py
+++ b/src/ophys_etl/transforms/mesoscope_2p/tiff.py
@@ -173,7 +173,7 @@ class MesoscopeTiff(object):
 
     @property
     def stack_zs(self):
-        return self.frame_metadata["SI"]["hStackManager"]["zs"]
+        return self.frame_metadata["SI"]["hStackManager"]["zs_v3_v4"]
 
     @property
     def num_volumes(self):


### PR DESCRIPTION
I am not able to test this without modifications to run_mesoscope_splitting and argschema.  This code doesn't depend on those modules directly but it is possible this is hiding a different problem.

+ It accepts a list of version types
+ Functions the same way as the original tifffile parser
+ Some variables renamed for clarity
+ Exceptions changed for clarity