### PR TITLE
Moves codecov reports dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,14 @@ jobs:
           # https://sylabs.io/guides/3.6/user-guide/singularity_and_docker.html#best-practices
           command: |
                   set -e
+                  mkdir $PWD/coverage_outputs
                   # set entrypoint like this so we can handle quotes
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/suite2p/bin/python -m pytest -m 'suite2p_only or suite2p_also' --ignore='/repos/ophys_etl/tests/modules/event_detection' /repos/ophys_etl/tests"
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/event_detection/bin/python -m pytest -m 'event_detect_only' /repos/ophys_etl/tests"
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} -c "/envs/ophys_etl/bin/python -m pytest -m 'not suite2p_only and not event_detect_only' /repos/ophys_etl/tests"
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs:/coverage_outputs alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/suite2p_container_test.sh
+                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs/suite2p_cov.xml -cF suite2p_tests
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs:/coverage_outputs alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/event_container_test.sh
+                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs/event_cov.xml -cF event_detection_tests
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs:/coverage_outputs alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/general_container_test.sh
+                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs/general_cov.xml -cF general_tests
       - run:
           name: Run docker image smoke test
           command: |
@@ -52,9 +56,7 @@ jobs:
             pip install --upgrade pip
             pip install .
             # pytest would be a dep in requirements.txt
-            python -m pytest -m "not suite2p_only and not event_detect_only" \
-                             --cov ophys_etl --cov-report xml
-            bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
+            python -m pytest -m "not suite2p_only and not event_detect_only"
           name: Test
 
   build38: 

--- a/.circleci/scripts/event_container_test.sh
+++ b/.circleci/scripts/event_container_test.sh
@@ -1,0 +1,8 @@
+set -e
+export COVERAGE_FILE=/tmp/.coverage
+cd /repos/ophys_etl/
+/envs/event_detection/bin/python -m \
+    pytest -m "event_detect_only" \
+    --cov-report xml:/coverage_outputs/event_cov.xml \
+    --cov ophys_etl \
+    tests

--- a/.circleci/scripts/general_container_test.sh
+++ b/.circleci/scripts/general_container_test.sh
@@ -1,0 +1,8 @@
+set -e
+export COVERAGE_FILE=/tmp/.coverage
+cd /repos/ophys_etl/
+/envs/ophys_etl/bin/python -m \
+    pytest -m "not suite2p_only and not event_detect_only" \
+    --cov-report xml:/coverage_outputs/general_cov.xml \
+    --cov ophys_etl \
+    tests

--- a/.circleci/scripts/suite2p_container_test.sh
+++ b/.circleci/scripts/suite2p_container_test.sh
@@ -1,0 +1,9 @@
+set -e
+export COVERAGE_FILE=/tmp/.coverage
+cd /repos/ophys_etl/
+/envs/suite2p/bin/python -m \
+    pytest -m "suite2p_only or suite2p_also" \
+    --ignore=/repos/ophys_etl/tests/modules/event_detection \
+    --cov-report xml:/coverage_outputs/suite2p_cov.xml \
+    --cov ophys_etl \
+    tests


### PR DESCRIPTION
This PR measures code coverage inside the 3 container test runs (in specific environments) rather than just in the default outside-container test. This makes the CI-reported test coverage and codecov reports accurately reflect the tests run (in particular coverage from pytests marked `suite2p_only` and `event_detect_only`is now captured).

I followed the **Codecov _Outside_ Docker** strategy described [here](https://docs.codecov.io/docs/testing-with-docker).

In the process, I moved the container test commands outside of `.circleci/config.yml` to their own shell scripts to make it easier to write (and read) without worrying about passing a long multi-command quoted string into the the docker `/bin/bash -c`

On codecov site, coverage can now be diagnosed by toggling the different tags (i.e. `suite2p_tests`, ...)
![image](https://user-images.githubusercontent.com/32312979/110542161-90c6af80-80dd-11eb-9bfd-ea47fa062566.png)

Current coverage of modules is measured correctly now. For example `event_detection` was reporting ~30% coverage but it is now >90%
![image](https://user-images.githubusercontent.com/32312979/110542731-4abe1b80-80de-11eb-9f72-28e44df4bb11.png)
