### PR TITLE
Improves sine dewarp dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             pip install .
             # pytest would be a dep in requirements.txt
             python -m pytest -m "not suite2p_only and not event_detect_only"
+            bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -cF not_container_tests
           name: Test
 
   build38: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             pip install --upgrade pip
             pip install .
             # pytest would be a dep in requirements.txt
-            python -m pytest -m "not suite2p_only and not event_detect_only"
+            python -m pytest -m "not suite2p_only and not event_detect_only" --cov ophys_etl --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -cF not_container_tests
           name: Test
 

--- a/src/ophys_etl/modules/sine_dewarp/__main__.py
+++ b/src/ophys_etl/modules/sine_dewarp/__main__.py
@@ -1,152 +1,77 @@
-import argparse
+import argschema
 import functools
-import logging
 import math
-import multiprocessing
 import time
 import h5py
-import json
 import numpy as np
+from multiprocessing import Pool
 
 from ophys_etl.modules.sine_dewarp import utils
+from ophys_etl.modules.sine_dewarp.schemas import SineDewarpInputSchema
 
-valid_nr_methods = [0, 1, 2, 3]
 
+class SineDewarp(argschema.ArgSchemaParser):
+    default_schema = SineDewarpInputSchema
 
-def run_dewarping(FOVwidth: int,
-                  noise_reduction: int,
-                  threads: int,
-                  input_file: str,
-                  input_dataset: str,
-                  output_file: str,
-                  output_dataset: str,
-                  aL: float,
-                  aR: float,
-                  bL: float,
-                  bR: float) -> None:
-    """
-    Dewarp the movie frame by frame, utilizing multiprocessing (along with
-    manual chunking of the movie beforehand) to increase efficiency.
+    def run(self):
+        self.logger.name = type(self).__name__
 
-    Parameters
-    ----------
-    FOVwidth: int
-        Field of View width. Will be the width of the output image, unless 0,
-        then it will be the width of the input image.
-    noise_reduction: int
-        The noise reduction method that will be used in dewarping.
-    threads: int
-        The number of worker threads to use in multiprocessing.
-    input_file: str
-        File path where the input h5 is saved.
-    input_dataset: str
-        The name of the dataset representing the movie within the
-        input h5 file.
-    output_file: str
-        File path where the h5 containing the dewarped video will be saved.
-    output_dataset: str,
-        The name of the dataset representing the movie within the
-        output h5 file.
-    aL: float
-        How far into the image (from the left side inward, in pixels) the
-        warping occurs. This is specific to the experiment, and is known
-        at the time of data collection.
-    aR: float
-        How far into the image (from the right side inward, in pixels) the
-        warping occurs. This is specific to the experiment, and is known
-        at the time of data collection.
-    bL: float
-        Roughly, a measurement of how strong the warping effect was on
-        the left side for the given experiment.
-    bR: float
-        Roughly, a measurement of how strong the warping effect was on
-        the right side for the given experiment.
-    Returns
-    -------
-    """
+        # read the movie into memory
+        with h5py.File(self.args["input_h5"], "r") as input_file:
+            movie = input_file['data'][()]
+        movie_shape = movie.shape
+        movie_dtype = movie.dtype
+        T, y_orig, x_orig = movie.shape
+        self.logger.info(f"read {self.args['input_h5']} with shape "
+                         f"{movie_shape}")
 
-    # Get statistics about the movie
-    input_h5_file = h5py.File(input_file, 'r')
-    movie = input_h5_file[input_dataset]
-
-    movie_shape = movie.shape
-    movie_dtype = movie.dtype
-    T, y_orig, x_orig = movie.shape
-
-    xtable = utils.create_xtable(movie, aL, aR, bL, bR, noise_reduction)
-
-    utils.make_output_file(output_file, output_dataset, xtable,
-                           FOVwidth, movie_shape, movie_dtype)
-
-    start_time = time.time()
-    with multiprocessing.Pool(threads) as pool, \
-         h5py.File(output_file, "a") as f:
+        # prepare for writing the output movie
+        xtable = utils.create_xtable(movie,
+                                     self.args["aL"],
+                                     self.args["aR"],
+                                     self.args["bL"],
+                                     self.args["bR"],
+                                     self.args["noise_reduction"])
+        self.logger.info("created xtable")
+        utils.make_output_file(self.args["output_h5"],
+                               "data",
+                               xtable,
+                               self.args["FOV_width"],
+                               movie_shape,
+                               movie_dtype)
 
         fn = functools.partial(
-            utils.xdewarp,
-            FOVwidth=FOVwidth,
-            xtable=xtable,
-            noise_reduction=noise_reduction
-        )
+                utils.xdewarp,
+                FOVwidth=self.args["FOV_width"],
+                xtable=xtable,
+                noise_reduction=self.args["noise_reduction"])
 
-        # Chunk the movie up to prevent an error caused by multiprocessing
-        # returning too much data. Use math.ceil in case there are fewer
-        # than chunk_size frame, then we just make one chunk.
-        chunk_size = 1000
-        movie_chunks = np.array_split(
-            movie, math.ceil(T / chunk_size), axis=0
-        )
+        # write the output movie
+        start_time = time.time()
+        with Pool(self.args["n_parallel_workers"]) as pool, \
+                h5py.File(self.args["output_h5"], "a") as f:
+            # Chunk the movie up to prevent an error caused by multiprocessing
+            # returning too much data. Use math.ceil in case there are fewer
+            # than chunk_size frame, then we just make one chunk.
+            chunk_size = 1000
+            movie_chunks = np.array_split(
+                movie, math.ceil(T / chunk_size), axis=0
+            )
 
-        # Use multiprocessing to dewarp one chunk of the movie at a time
-        dewarped_so_far = 0
-        for movie_chunk in movie_chunks:
-            for frame_num, frame in enumerate(pool.map(fn, movie_chunk)):
-                f[output_dataset][dewarped_so_far + frame_num, :, :] = frame
+            # Use multiprocessing to dewarp one chunk of the movie at a time
+            dewarped_so_far = 0
+            for movie_chunk in movie_chunks:
+                for frame_num, frame in enumerate(pool.map(fn, movie_chunk)):
+                    f["data"][dewarped_so_far + frame_num, :, :] = \
+                            frame
+                dewarped_so_far = dewarped_so_far + len(movie_chunk)
 
-            dewarped_so_far = dewarped_so_far + len(movie_chunk)
+        end_time = time.time()
+        self.logger.info(f"Elapsed time (s): {end_time - start_time}")
 
-    input_h5_file.close()
-
-    end_time = time.time()
-    logging.debug(f"Elapsed time (s): {end_time - start_time}")
+        self.output(dict())
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('input_json')
-    parser.add_argument('output_json')
-    parser.add_argument('--log_level', default=logging.DEBUG)
-    parser.add_argument('--threads', default=4, type=int)
-    parser.add_argument('--FOVwidth', default=0, type=int)
-    parser.add_argument('--noise_reduction', default=0, type=int)
-    args = parser.parse_args()
-
-    logging.getLogger().setLevel(args.log_level)
-
-    if args.noise_reduction not in valid_nr_methods:
-        raise(
-            f"{args.noise_reduction} is not a valid noise "
-            f"reduction option. Must be one of {valid_nr_methods}. "
-            f"Using default value noise_reduction = 0.\n",
-            UserWarning
-        )
-    else:
-        logging.debug(f"noise_reduction: {args.noise_reduction}")
-
-    with open(args.input_json, 'r') as json_file:
-        input_data = json.load(json_file)
-    input_h5, output_h5, aL, aR, bL, bR = utils.parse_input(input_data)
-
-    run_dewarping(
-        FOVwidth=args.FOVwidth,
-        noise_reduction=args.noise_reduction,
-        threads=args.threads,
-        input_file=input_h5,
-        input_dataset="data",
-        output_file=output_h5,
-        output_dataset="data",
-        aL=aL, aR=aR, bL=bL, bR=bR
-    )
-
-    with open(args.output_json, 'w') as outfile:
-        json.dump({}, outfile)
+    smod = SineDewarp()
+    smod.run()

--- a/src/ophys_etl/modules/sine_dewarp/__main__.py
+++ b/src/ophys_etl/modules/sine_dewarp/__main__.py
@@ -53,7 +53,7 @@ class SineDewarp(argschema.ArgSchemaParser):
             # Chunk the movie up to prevent an error caused by multiprocessing
             # returning too much data. Use math.ceil in case there are fewer
             # than chunk_size frame, then we just make one chunk.
-            chunk_size = 1000
+            chunk_size = self.args["chunk_size"]
             movie_chunks = np.array_split(
                 movie, math.ceil(T / chunk_size), axis=0
             )

--- a/src/ophys_etl/modules/sine_dewarp/schemas.py
+++ b/src/ophys_etl/modules/sine_dewarp/schemas.py
@@ -52,3 +52,8 @@ class SineDewarpInputSchema(argschema.ArgSchema):
         required=True,
         description=("as far as I can tell, this is not used, but we need "
                      "this in the schema to match the current LIMS strategy."))
+    chunk_size = argschema.fields.Int(
+        required=False,
+        default=1000,
+        description=("size of chunks, in frames, for breaking up processing "
+                     "into smaller jobs"))

--- a/src/ophys_etl/modules/sine_dewarp/schemas.py
+++ b/src/ophys_etl/modules/sine_dewarp/schemas.py
@@ -1,0 +1,54 @@
+import argschema
+
+from ophys_etl.schemas.fields import H5InputFile
+
+
+class SineDewarpInputSchema(argschema.ArgSchema):
+    log_level = argschema.fields.Str(default="INFO")
+    input_h5 = H5InputFile(
+        required=True,
+        description="h5 movie file to be dewarped")
+    output_h5 = argschema.fields.OutputFile(
+        required=True,
+        description="destination path for dewarped movie")
+    aL = argschema.fields.Float(
+        required=True,
+        description=("How far into the image (from the left side inward, "
+                     "in pixels) the warping occurs. This is specific to "
+                     "the experiment, and is known at the time of data "
+                     "collection."))
+    aR = argschema.fields.Float(
+        required=True,
+        description=("How far into the image (from the right side inward, "
+                     "in pixels) the warping occurs. This is specific to "
+                     "the experiment, and is known at the time of data "
+                     "collection."))
+    bL = argschema.fields.Float(
+        required=True,
+        description=("Roughly, a measurement of how strong the warping effect "
+                     "was on the left side for the given experiment."))
+    bR = argschema.fields.Float(
+        required=True,
+        description=("Roughly, a measurement of how strong the warping effect "
+                     "was on the right side for the given experiment."))
+    n_parallel_workers = argschema.fields.Int(
+        required=False,
+        default=4,
+        description="how many multiprocessing workers")
+    FOV_width = argschema.fields.Int(
+        required=False,
+        default=0,
+        description=("Field of View width. Will be the width of the output "
+                     "image, unless 0, then it will be the width of the input "
+                     "image."))
+    noise_reduction = argschema.fields.Int(
+        required=False,
+        default=0,
+        description=("1: Reduce the data value by 2 * sigma. "
+                     "2: Reduce the data value by sigma and normalize it. "
+                     "3: Normalize the data value."
+                     "else: No noise reduction"))
+    equipment_name = argschema.fields.Str(
+        required=True,
+        description=("as far as I can tell, this is not used, but we need "
+                     "this in the schema to match the current LIMS strategy."))

--- a/src/ophys_etl/modules/sine_dewarp/utils.py
+++ b/src/ophys_etl/modules/sine_dewarp/utils.py
@@ -1,6 +1,5 @@
 import h5py
 import logging
-import json
 import math
 import numpy as np
 from pathlib import Path
@@ -356,78 +355,6 @@ def create_xtable(movie: np.ndarray,
     logging.debug(table)
 
     return table
-
-
-def parse_input(data: json) -> (str, str, float, float, float, float):
-    """
-    Compute a number of statistics about the images to be dewarped.
-
-    Parameters
-    ----------
-    data: json
-        Data from the input json file.
-    Returns
-    -------
-    input_h5: str
-        File path where the input h5 is saved.
-    output_h5: str
-        File path where the output h5 is saved.
-    aL: float
-        How far into the image (from the left side inward, in pixels) the
-        warping occurs. This is specific to the experiment, and is known
-        at the time of data collection.
-    aR: float
-        How far into the image (from the right side inward, in pixels) the
-        warping occurs. This is specific to the experiment, and is known
-        at the time of data collection.
-    bL: float
-        Roughly, a measurement of how strong the warping effect was on
-        the left side for the given experiment.
-    bR: float
-        Roughly, a measurement of how strong the warping effect was on
-        the right side for the given experiment.
-    """
-
-    input_h5 = data.get('input_h5', None)
-    if input_h5 is None:
-        raise KeyError("input JSON does not have required field: 'input_h5'")
-    if not Path(input_h5).is_file():
-        raise IOError(f"{input_h5} does not exist")
-
-    output_h5 = data.get('output_h5', None)
-    if output_h5 is None:
-        raise KeyError("input JSON does not have required field: 'output_h5'")
-
-    equipment_name = data.get("equipment_name", None)
-    if equipment_name is None:
-        raise KeyError("input JSON does not have"
-                       "required field: 'equipment_name'")
-
-    aLstr = data.get("aL", None)
-    if aLstr is None:
-        raise KeyError(f"parameter aL not determined for {equipment_name}")
-    aL = float(aLstr)
-
-    aRstr = data.get("aR", None)
-    if aRstr is None:
-        raise KeyError(f"parameter aR not determined for {equipment_name}")
-    aR = float(aRstr)
-
-    bLstr = data.get("bL", None)
-    if bLstr is None:
-        raise KeyError(f"parameter bL not determined for {equipment_name}")
-    bL = float(bLstr)
-
-    bRstr = data.get("bR", None)
-    if bRstr is None:
-        raise KeyError(f"parameter bR not determined for {equipment_name}")
-    bR = float(bRstr)
-
-    logging.debug(f"Equipment name: {str(equipment_name)}")
-    logging.debug(f"aL: {aL}   aR: {aR}")
-    logging.debug(f"bL: {bL}   bR: {bR}")
-
-    return input_h5, output_h5, aL, aR, bL, bR
 
 
 def make_output_file(output_file: str,

--- a/tests/modules/sine_dewarp/test_sine_dewarp.py
+++ b/tests/modules/sine_dewarp/test_sine_dewarp.py
@@ -1,0 +1,39 @@
+import pytest
+import h5py
+import numpy as np
+from pathlib import Path
+
+from ophys_etl.modules.sine_dewarp.__main__ import SineDewarp
+
+
+@pytest.fixture
+def input_h5(tmpdir):
+    fname = tmpdir / "input.h5"
+    with h5py.File(fname, "w") as f:
+        f.create_dataset("data",
+                         data=np.zeros((2000, 512, 512), dtype="uint8"))
+    yield str(fname)
+
+
+def test_sine_dewarp_end_to_end(input_h5, tmpdir):
+    output_h5 = str(tmpdir / "output.h5")
+    output_json = str(tmpdir / "output.json")
+    args = {
+            "input_h5": input_h5,
+            "output_h5": output_h5,
+            "equipment_name": "CAM2P.3",
+            "aL": "160.0",
+            "aR": "160.0",
+            "bL": "85.0",
+            "bR": "90.0",
+            "output_json": output_json}
+    smod = SineDewarp(input_data=args, args=[])
+    smod.run()
+
+    assert Path(output_h5).is_file()
+    assert Path(output_json).is_file()
+
+    with h5py.File(output_h5, "r") as f:
+        assert "data" in list(f.keys())
+        assert f['data'].shape[0:2] == (2000, 512)
+        assert f['data'].shape[2] < 512

--- a/tests/modules/sine_dewarp/test_sine_dewarp.py
+++ b/tests/modules/sine_dewarp/test_sine_dewarp.py
@@ -2,6 +2,7 @@ import pytest
 import h5py
 import numpy as np
 from pathlib import Path
+import os
 
 from ophys_etl.modules.sine_dewarp.__main__ import SineDewarp
 
@@ -11,8 +12,9 @@ def input_h5(tmpdir):
     fname = tmpdir / "input.h5"
     with h5py.File(fname, "w") as f:
         f.create_dataset("data",
-                         data=np.zeros((2000, 512, 512), dtype="uint8"))
+                         data=np.zeros((10, 512, 512), dtype="uint8"))
     yield str(fname)
+    os.remove(fname)
 
 
 def test_sine_dewarp_end_to_end(input_h5, tmpdir):
@@ -26,6 +28,7 @@ def test_sine_dewarp_end_to_end(input_h5, tmpdir):
             "aR": "160.0",
             "bL": "85.0",
             "bR": "90.0",
+            "chunk_size": 2,
             "output_json": output_json}
     smod = SineDewarp(input_data=args, args=[])
     smod.run()
@@ -35,5 +38,5 @@ def test_sine_dewarp_end_to_end(input_h5, tmpdir):
 
     with h5py.File(output_h5, "r") as f:
         assert "data" in list(f.keys())
-        assert f['data'].shape[0:2] == (2000, 512)
+        assert f['data'].shape[0:2] == (10, 512)
         assert f['data'].shape[2] < 512


### PR DESCRIPTION

### this PR
* replaces argparse with a argschema
* lightly fixes up the main workflow
* adds a quick end-to-end test for coverage and debugging

### validation
* successfully reran last production dewarp job in ~25 minutes with ~160GB RAM (3x the movie size)

### next steps
could probably be improved to use 2x movie size or even less, but, this seems to work.