### PR TITLE
Fix pyqt dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get -y update \
     && rm -rf /var/lib/apt/* \
     && git clone -b ${SUITE2P_TAG} https://github.com/MouseLand/suite2p ./suite2p \
     && conda env update --prefix ${SUITE2P_ENV} --file ./suite2p/environment.yml \
+    && conda run --prefix ${SUITE2P_ENV} pip install pyqt5 \
     && conda run --prefix ${SUITE2P_ENV} pip install --no-cache ./suite2p \
     && git clone -b ${OPHYS_ETL_TAG} https://github.com/AllenInstitute/ophys_etl_pipelines ./ophys_etl \
     && conda run --prefix ${SUITE2P_ENV} pip install --no-cache ./ophys_etl \


### PR DESCRIPTION
a new CI build error started coming up during the docker Suite2P smoke test:
`ImportError: cannot import name 'sip' from 'PyQt5' (/envs/suite2p/lib/python3.7/site-packages/PyQt5/__init__.py)`

NOTE: we don't use the GUI, so, just getting past this import error should be enough.