### PR TITLE
casts offsets to floats

### DIFF
--- a/src/ophys_etl/utils/motion_border.py
+++ b/src/ophys_etl/utils/motion_border.py
@@ -86,7 +86,7 @@ def get_max_correction_from_file(
     """
     motion_correction_df = pd.read_csv(input_csv)
     motion_border = get_max_correction_values(
-        x_series=motion_correction_df['x'],
-        y_series=motion_correction_df['y'],
+        x_series=motion_correction_df['x'].astype('float'),
+        y_series=motion_correction_df['y'].astype('float'),
         max_shift=max_shift)
     return motion_border


### PR DESCRIPTION
Suite2P motion offsets are integers. Previously, these were floats.
On pandas read, they has `numpy.int64` data type. The values for max corrections was maintaining this data type and could not be serialized to LIMS-compatible json.