### PR TITLE
adds utility for making pearsonr plots from movies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,10 @@ RUN apt-get -y update \
     && conda run --prefix ${SUITE2P_ENV} pip install --no-cache ./ophys_etl \
     && echo "use for suite2p "$(conda run --prefix ${SUITE2P_ENV} which python) \
     && conda create --prefix ${OPHYS_ETL_ENV} python=3.8 \
+    # the following installs scipy/numpy with MKL backend,
+    # if requirements.txt specifies a different version, these will get overwritten
+    # and some other BLAS backend will be used - speed will decrease
+    && conda run --prefix ${OPHYS_ETL_ENV} conda install scipy \
     && conda run --prefix ${OPHYS_ETL_ENV} pip install --no-cache ./ophys_etl \
     && echo "use for ophys_etl "$(conda run --prefix ${OPHYS_ETL_ENV} which python) \
     && conda create --prefix ${EVENT_DETECT_ENV} python=3.8 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ croissant-ml==0.0.2
 typing_extensions
 tifffile
 scikit-image
+networkx

--- a/src/ophys_etl/qc/video/correlation_graph.py
+++ b/src/ophys_etl/qc/video/correlation_graph.py
@@ -1,0 +1,99 @@
+import argschema
+import h5py
+import itertools
+import networkx as nx
+import numpy as np
+import multiprocessing
+from scipy.stats import pearsonr
+from pathlib import Path
+from typing import List
+
+from ophys_etl.qc.video.schemas import CorrelationGraphInputSchema
+
+
+def index_split(nelem: int, n_segments: int) -> List[List]:
+    """splits elements into multiple ranges, with an overlap of 1
+    These indices will be used in a numpy x[a:b] way, such that
+    specifying [a, b] will result in indices a -> (b - 1)
+    """
+    indices = [[i.min(), i.max()] for i in
+               np.array_split(np.arange(nelem), n_segments)]
+    for index in indices:
+        index[1] += 1
+    for index in indices[1:]:
+        index[0] -= 1
+    return indices
+
+
+def weight_calculation(video_path: Path, row_indices: List[int],
+                       col_indices: List[int]) -> nx.Graph:
+    """produces a graph with edges weighted according to
+    Pearson's correlation coefficient, and nodes labeled according as
+    (row_index, col_index).
+    Each pixel is connected to 8 nearest-neighbors.
+    """
+
+    with h5py.File(video_path, "r") as f:
+        data = f["data"][:,
+                         row_indices[0]: row_indices[1],
+                         col_indices[0]: col_indices[1]]
+
+    # relative indices of 8 nearest-neighbors
+    nbrs = list(itertools.product([-1, 0, 1], repeat=2))
+    nbrs.pop(nbrs.index((0, 0)))
+
+    nrow = data.shape[1]
+    ncol = data.shape[2]
+    r0 = row_indices[0]
+    c0 = col_indices[0]
+
+    graph = nx.Graph()
+    for irow in range(nrow):
+        for icol in range(ncol):
+            for dx, dy in nbrs:
+                # a local edge, appropriate for indexing the loaded data
+                edge = [(irow, icol), (irow + dy, icol + dx)]
+                if (edge[1][0] < 0) | (edge[1][0] >= nrow):
+                    continue
+                if (edge[1][1] < 0) | (edge[1][1] >= ncol):
+                    continue
+                # a global edge, appropriate for the entire FOV
+                global_edge = [(edge[0][0] + r0, edge[0][1] + c0),
+                               (edge[1][0] + r0, edge[1][1] + c0)]
+                if not graph.has_edge(*global_edge):
+                    weight = pearsonr(
+                            data[:, edge[0][0], edge[0][1]],
+                            data[:, edge[1][0], edge[1][1]])[0]
+                    graph.add_edge(*global_edge, weight=weight)
+
+    return graph
+
+
+class CorrelationGraph(argschema.ArgSchemaParser):
+    default_schema = CorrelationGraphInputSchema
+
+    def run(self):
+        self.logger.name = type(self).__name__
+
+        with h5py.File(self.args["video_path"], "r") as f:
+            nrow, ncol = f["data"].shape[1:]
+        row_indices = index_split(nrow, self.args["n_segments"])
+        col_indices = index_split(nrow, self.args["n_segments"])
+        args = [(self.args["video_path"], rows, cols)
+                for rows, cols in itertools.product(row_indices, col_indices)]
+
+        if len(args) == 1:
+            graph = weight_calculation(*args[0])
+        else:
+            self.logger.info(f"splitting into {len(args)} jobs")
+            with multiprocessing.Pool(len(args)) as pool:
+                graphs = pool.starmap(weight_calculation, args)
+            graph = nx.compose_all(graphs)
+
+        nx.write_gpickle(graph, self.args["graph_output"])
+        self.logger.info(f"wrote {self.args['graph_output']}")
+
+
+if __name__ == "__main__":
+    cg = CorrelationGraph()
+    cg.run()

--- a/src/ophys_etl/qc/video/correlation_graph.py
+++ b/src/ophys_etl/qc/video/correlation_graph.py
@@ -98,7 +98,7 @@ class CorrelationGraph(argschema.ArgSchemaParser):
             self.logger.info(f"splitting into {len(args)} jobs")
             with multiprocessing.Pool(len(args)) as pool:
                 graphs = pool.starmap(weight_calculation, args)
-            self.logger.info(f"combining graphs from jobs")
+            self.logger.info("combining graphs from jobs")
             graph = nx.compose_all(graphs)
 
         nx.write_gpickle(graph, self.args["graph_output"])

--- a/src/ophys_etl/qc/video/correlation_graph.py
+++ b/src/ophys_etl/qc/video/correlation_graph.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List
 
 from ophys_etl.qc.video.schemas import CorrelationGraphInputSchema
+from ophys_etl.qc.video.correlation_graph_plot import CorrelationGraphPlot
 
 
 def index_split(nelem: int, n_segments: int) -> List[List]:
@@ -104,6 +105,13 @@ class CorrelationGraph(argschema.ArgSchemaParser):
         nx.write_gpickle(graph, self.args["graph_output"])
         self.logger.info(f"wrote {self.args['graph_output']}")
         self.logger.info(f"finished in {time.time() - t0:2f} seconds")
+
+        if "plot_output" in self.args:
+            plot_args = {
+                    "graph_input": self.args["graph_output"],
+                    "plot_output": self.args["plot_output"]}
+            cgp = CorrelationGraphPlot(input_data=plot_args, args=[])
+            cgp.run()
 
 
 if __name__ == "__main__":

--- a/src/ophys_etl/qc/video/correlation_graph.py
+++ b/src/ophys_etl/qc/video/correlation_graph.py
@@ -78,7 +78,7 @@ class CorrelationGraph(argschema.ArgSchemaParser):
         with h5py.File(self.args["video_path"], "r") as f:
             nrow, ncol = f["data"].shape[1:]
         row_indices = index_split(nrow, self.args["n_segments"])
-        col_indices = index_split(nrow, self.args["n_segments"])
+        col_indices = index_split(ncol, self.args["n_segments"])
         args = [(self.args["video_path"], rows, cols)
                 for rows, cols in itertools.product(row_indices, col_indices)]
 

--- a/src/ophys_etl/qc/video/correlation_graph.py
+++ b/src/ophys_etl/qc/video/correlation_graph.py
@@ -98,6 +98,7 @@ class CorrelationGraph(argschema.ArgSchemaParser):
             self.logger.info(f"splitting into {len(args)} jobs")
             with multiprocessing.Pool(len(args)) as pool:
                 graphs = pool.starmap(weight_calculation, args)
+            self.logger.info(f"combining graphs from jobs")
             graph = nx.compose_all(graphs)
 
         nx.write_gpickle(graph, self.args["graph_output"])

--- a/src/ophys_etl/qc/video/correlation_graph_plot.py
+++ b/src/ophys_etl/qc/video/correlation_graph_plot.py
@@ -18,13 +18,14 @@ def draw_graph_edges(figure, axis, graph):
     line_coll = LineCollection(segments, linestyle='solid',
                                cmap="plasma", linewidths=0.3)
     line_coll.set_array(weights)
-    axis.add_collection(line_coll)
     vals = np.concatenate(line_coll.get_segments())
     mnvals = vals.min(axis=0)
     mxvals = vals.max(axis=0)
     ppvals = vals.ptp(axis=0)
     buffx = 0.02 * ppvals[0]
     buffy = 0.02 * ppvals[1]
+    line_coll.set_linewidth(0.3 * 512 / ppvals[0])
+    axis.add_collection(line_coll)
     axis.set_xlim(mnvals[0] - buffx, mxvals[0] + buffx)
     axis.set_ylim(mnvals[1] - buffy, mxvals[1] + buffy)
     # invert yaxis for image-like orientation

--- a/src/ophys_etl/qc/video/correlation_graph_plot.py
+++ b/src/ophys_etl/qc/video/correlation_graph_plot.py
@@ -16,7 +16,7 @@ def draw_graph_edges(figure, axis, graph):
     for edge in graph.edges:
         segments.append([edge[0][::-1], edge[1][::-1]])
     line_coll = LineCollection(segments, linestyle='solid',
-                               cmap="plasma")
+                               cmap="plasma", linewidths=0.3)
     line_coll.set_array(weights)
     axis.add_collection(line_coll)
     vals = np.concatenate(line_coll.get_segments())
@@ -27,6 +27,8 @@ def draw_graph_edges(figure, axis, graph):
     buffy = 0.02 * ppvals[1]
     axis.set_xlim(mnvals[0] - buffx, mxvals[0] + buffx)
     axis.set_ylim(mnvals[1] - buffy, mxvals[1] + buffy)
+    # invert yaxis for image-like orientation
+    axis.invert_yaxis()
     axis.set_aspect("equal")
     divider = make_axes_locatable(axis)
     cax = divider.append_axes("right", size="5%", pad=0.05)
@@ -41,10 +43,10 @@ class CorrelationGraphPlot(argschema.ArgSchemaParser):
         self.logger.name = type(self).__name__
 
         graph = nx.read_gpickle(self.args["graph_input"])
-        fig, axis = plt.subplots(1, 1, clear=True, num=1, figsize=(8, 8))
+        fig, axis = plt.subplots(1, 1, clear=True, num=1, figsize=(16, 16))
         draw_graph_edges(fig, axis, graph)
 
-        fig.savefig(self.args["plot_output"])
+        fig.savefig(self.args["plot_output"], dpi=300)
         self.logger.info(f"wrote {self.args['plot_output']}")
 
 

--- a/src/ophys_etl/qc/video/correlation_graph_plot.py
+++ b/src/ophys_etl/qc/video/correlation_graph_plot.py
@@ -8,8 +8,24 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from ophys_etl.qc.video.schemas import CorrelationGraphPlotInputSchema
 
 
-def draw_graph_edges(figure, axis, graph):
+def draw_graph_edges(figure: plt.Figure, axis: plt.Axes, graph: nx.Graph):
+    """draws graph edges from node to node, colored by weight
 
+    Parameters
+    ----------
+    figure: plt.Figure
+        a matplotlib Figure
+    axis: plt.Axes
+        a matplotlib Axes, part of Figure
+    graphs: nx.Graph
+        a networkx graph, assumed to have edges formed like
+        graph.add_edge((0, 1), (0, 2), weight=1.234)
+
+    Notes
+    -----
+    modifes figure and axis in-place
+
+    """
     weights = np.array([i["weight"] for i in graph.edges.values()])
     # graph is (row, col), transpose to get (x, y)
     segments = []

--- a/src/ophys_etl/qc/video/correlation_graph_plot.py
+++ b/src/ophys_etl/qc/video/correlation_graph_plot.py
@@ -51,6 +51,6 @@ class CorrelationGraphPlot(argschema.ArgSchemaParser):
         self.logger.info(f"wrote {self.args['plot_output']}")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: nocover
     cg = CorrelationGraphPlot()
     cg.run()

--- a/src/ophys_etl/qc/video/correlation_graph_plot.py
+++ b/src/ophys_etl/qc/video/correlation_graph_plot.py
@@ -1,0 +1,53 @@
+import argschema
+import networkx as nx
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+from ophys_etl.qc.video.schemas import CorrelationGraphPlotInputSchema
+
+
+def draw_graph_edges(figure, axis, graph):
+
+    weights = np.array([i["weight"] for i in graph.edges.values()])
+    # graph is (row, col), transpose to get (x, y)
+    segments = []
+    for edge in graph.edges:
+        segments.append([edge[0][::-1], edge[1][::-1]])
+    line_coll = LineCollection(segments, linestyle='solid',
+                               cmap="plasma")
+    line_coll.set_array(weights)
+    axis.add_collection(line_coll)
+    vals = np.concatenate(line_coll.get_segments())
+    mnvals = vals.min(axis=0)
+    mxvals = vals.max(axis=0)
+    ppvals = vals.ptp(axis=0)
+    buffx = 0.02 * ppvals[0]
+    buffy = 0.02 * ppvals[1]
+    axis.set_xlim(mnvals[0] - buffx, mxvals[0] + buffx)
+    axis.set_ylim(mnvals[1] - buffy, mxvals[1] + buffy)
+    axis.set_aspect("equal")
+    divider = make_axes_locatable(axis)
+    cax = divider.append_axes("right", size="5%", pad=0.05)
+    figure.colorbar(line_coll, ax=axis, cax=cax)
+    axis.set_title("PCC neighbor graph")
+
+
+class CorrelationGraphPlot(argschema.ArgSchemaParser):
+    default_schema = CorrelationGraphPlotInputSchema
+
+    def run(self):
+        self.logger.name = type(self).__name__
+
+        graph = nx.read_gpickle(self.args["graph_input"])
+        fig, axis = plt.subplots(1, 1, clear=True, num=1, figsize=(8, 8))
+        draw_graph_edges(fig, axis, graph)
+
+        fig.savefig(self.args["plot_output"])
+        self.logger.info(f"wrote {self.args['plot_output']}")
+
+
+if __name__ == "__main__":
+    cg = CorrelationGraphPlot()
+    cg.run()

--- a/src/ophys_etl/qc/video/schemas.py
+++ b/src/ophys_etl/qc/video/schemas.py
@@ -11,7 +11,7 @@ class CorrelationGraphInputSchema(argschema.ArgSchema):
         required=False,
         default=1,
         description=("number of segments in both x and y to engage "
-                     "multiprocessing. n_bisects^2 workers will be "
+                     "multiprocessing. n_segments^2 workers will be "
                      "created to distribute the load. If == 1, "
                      "multiprocessing not invoked at all."))
     graph_output = argschema.fields.OutputFile(
@@ -20,7 +20,8 @@ class CorrelationGraphInputSchema(argschema.ArgSchema):
     plot_output = argschema.fields.OutputFile(
         required=False,
         description=("if provided, will create a plot and write to this "
-                     "location"))
+                     "location. passed to matplotlib.pyplot.Figure.savefig()"
+                     ".png being a typical suffix"))
 
 
 class CorrelationGraphPlotInputSchema(argschema.ArgSchema):

--- a/src/ophys_etl/qc/video/schemas.py
+++ b/src/ophys_etl/qc/video/schemas.py
@@ -17,6 +17,10 @@ class CorrelationGraphInputSchema(argschema.ArgSchema):
     graph_output = argschema.fields.OutputFile(
         required=True,
         description="destination file for networkx.write_gpickle()")
+    plot_output = argschema.fields.OutputFile(
+        required=False,
+        description=("if provided, will create a plot and write to this "
+                     "location"))
 
 
 class CorrelationGraphPlotInputSchema(argschema.ArgSchema):

--- a/src/ophys_etl/qc/video/schemas.py
+++ b/src/ophys_etl/qc/video/schemas.py
@@ -1,0 +1,29 @@
+import argschema
+
+
+class CorrelationGraphInputSchema(argschema.ArgSchema):
+    log_level = argschema.fields.LogLevel(default="INFO")
+    video_path = argschema.fields.InputFile(
+        required=True,
+        description=("path to hdf5 video with movie stored "
+                     "in dataset 'data' nframes x nrow x ncol"))
+    n_segments = argschema.fields.Int(
+        required=False,
+        default=1,
+        description=("number of segments in both x and y to engage "
+                     "multiprocessing. n_bisects^2 workers will be "
+                     "created to distribute the load. If == 1, "
+                     "multiprocessing not invoked at all."))
+    graph_output = argschema.fields.OutputFile(
+        required=True,
+        description="destination file for networkx.write_gpickle()")
+
+
+class CorrelationGraphPlotInputSchema(argschema.ArgSchema):
+    log_level = argschema.fields.LogLevel(default="INFO")
+    graph_input = argschema.fields.InputFile(
+        required=True,
+        description="source file for networkx.read_gpickle()")
+    plot_output = argschema.fields.OutputFile(
+        required=True,
+        description=("destination png for plot"))

--- a/tests/qc/video/test_correlation_graph.py
+++ b/tests/qc/video/test_correlation_graph.py
@@ -1,0 +1,69 @@
+import pytest
+import h5py
+import numpy as np
+import networkx as nx
+from pathlib import Path
+
+import matplotlib as mpl
+mpl.use('Agg')
+
+import ophys_etl.qc.video.correlation_graph as cg  # noqa: E402
+
+
+@pytest.fixture
+def video_shape():
+    return (20, 40, 40)
+
+
+@pytest.fixture
+def video_path(tmpdir, video_shape):
+    vpath = Path(tmpdir / "video.h5")
+    data = np.random.randint(0, 2**15, size=video_shape, dtype='uint16')
+    with h5py.File(vpath, "w") as f:
+        f.create_dataset("data", data=data)
+    yield vpath
+
+
+@pytest.mark.parametrize(
+        "n, n_segments, expected",
+        [
+            (100, 1, [[0, 100]]),
+            (100, 2, [[0, 50], [49, 100]]),
+            (100, 3, [[0, 34], [33, 67], [66, 100]])
+            ])
+def test_index_split(n, n_segments, expected):
+    indices = cg.index_split(n, n_segments)
+    for i, e in zip(indices, expected):
+        assert i == e
+    # check that the first index is overlapping by at least 1 index
+    for i in range(len(indices))[1:]:
+        assert indices[i][0] <= (indices[i][1] - 1)
+
+
+def test_weight_calculation(video_path, video_shape):
+    graph = cg.weight_calculation(
+            video_path,
+            [0, video_shape[1]],
+            [0, video_shape[2]])
+    assert isinstance(graph, nx.Graph)
+    # how many edges for 8 NN
+    nedges = (video_shape[1] - 1) * video_shape[2]
+    nedges += (video_shape[2] - 1) * video_shape[1]
+    nedges += 2 * (video_shape[1] - 1) * (video_shape[2] - 1)
+    assert len(graph.edges) == nedges
+
+
+@pytest.mark.parametrize("n_segments", [1, 2])
+def test_correlation_graph(video_path, n_segments):
+    graph_path = video_path.parent / "graph.pkl"
+    plot_path = video_path.parent / "graph_plot.png"
+    args = {
+            "video_path": str(video_path),
+            "n_segments": n_segments,
+            "graph_output": str(graph_path),
+            "plot_output": str(plot_path)
+            }
+    cgraph = cg.CorrelationGraph(input_data=args, args=[])
+    cgraph.run()
+    assert graph_path.exists()
+    assert plot_path.exists()

--- a/tests/qc/video/test_correlation_graph_plot.py
+++ b/tests/qc/video/test_correlation_graph_plot.py
@@ -1,0 +1,39 @@
+import pytest
+import networkx as nx
+from pathlib import Path
+import matplotlib as mpl
+mpl.use('Agg')
+import matplotlib.pyplot as plt  # noqa: E402
+
+import ophys_etl.qc.video.correlation_graph_plot as cgp  # noqa: E402
+
+
+@pytest.fixture
+def graph():
+    g = nx.Graph()
+    g.add_edge((0, 0), (0, 1), weight=1.0)
+    g.add_edge((0, 0), (0, 2), weight=1.1)
+    g.add_edge((1, 0), (0, 2), weight=1.2)
+    return g
+
+
+@pytest.fixture
+def graph_path(graph, tmpdir):
+    gpath = tmpdir / "graph.pkl"
+    nx.write_gpickle(graph, str(gpath))
+    yield gpath
+
+
+def test_draw_graph_edges(graph):
+    fig, axis = plt.subplots(1, 1, num=1, clear=True)
+    cgp.draw_graph_edges(fig, axis, graph)
+
+
+def test_correlation_graph_plot(graph_path):
+    plot_path = Path(graph_path).parent / "plot.png"
+    args = {
+            "graph_input": str(graph_path),
+            "plot_output": str(plot_path)}
+    cg = cgp.CorrelationGraphPlot(input_data=args, args=[])
+    cg.run()
+    assert plot_path.exists()


### PR DESCRIPTION
Given an hdf5 movie, produces plots like:
![image](https://user-images.githubusercontent.com/32312979/115055259-1a645c80-9e96-11eb-8010-c8d914afcf84.png)
where the colors are showing the Pearson correlation coefficient between neighbors.

NOTE: on a sizable node with `n_segments=8` and a 21,000 frame movie, this takes ~5 minutes.
```
$ python -m ophys_etl.qc.video.correlation_graph --help
usage: correlation_graph.py [-h] [--video_path VIDEO_PATH]
                            [--graph_output GRAPH_OUTPUT] [--input_json INPUT_JSON]
                            [--output_json OUTPUT_JSON] [--plot_output PLOT_OUTPUT]
                            [--log_level LOG_LEVEL] [--n_segments N_SEGMENTS]

optional arguments:
  -h, --help            show this help message and exit

CorrelationGraphInputSchema:
  --video_path VIDEO_PATH
                        path to hdf5 video with movie stored in dataset 'data'
                        nframes x nrow x ncol (REQUIRED)
  --graph_output GRAPH_OUTPUT
                        destination file for networkx.write_gpickle() (REQUIRED)
  --input_json INPUT_JSON
                        file path of input json file
  --output_json OUTPUT_JSON
                        file path to output json file
  --plot_output PLOT_OUTPUT
                        if provided, will create a plot and write to this location
  --log_level LOG_LEVEL
                        set log level (default=INFO)
  --n_segments N_SEGMENTS
                        number of segments in both x and y to engage
                        multiprocessing. n_segments^2 workers will be created to
                        distribute the load. If == 1, multiprocessing not invoked at
                        all. (default=1)
```