### PR TITLE
add optional maximum_projection_iamge_file to schema

### DIFF
--- a/src/ophys_etl/modules/decrosstalk/decrosstalk_schema.py
+++ b/src/ophys_etl/modules/decrosstalk/decrosstalk_schema.py
@@ -31,6 +31,10 @@ class PlaneSchema(argschema.schemas.DefaultSchema):
                 required=True,
                 many=True)
 
+    maximum_projection_image_file = argschema.fields.InputFile(
+                        description='path to maximum projection image',
+                        required=False)
+
 
 class PlanePairSchema(argschema.schemas.DefaultSchema):
 


### PR DESCRIPTION
The DECROSSTALK queue is failing because we updated the input json schema before the module was ready to handle it. This PR adds the new field as an optional field in the schema, allowing the queue to run on the new input json files (all of the results and outputs will be according to the original data model; this will change once

https://github.com/AllenInstitute/ophys_etl_pipelines/tree/ticket-149/dev/decrosstalk/qc/model

gets merged)