### PR TITLE
Bugfix/decrosstalk/210428

### DIFF
--- a/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
+++ b/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
@@ -662,12 +662,8 @@ def plot_pair_of_rois(roi0: OphysROI,
             mn = trace_bounds[trace_key][ii]['min']
 
             if mn is None:
-                if mx is not None:
-                    mn = mx - 1
-                    trace_bounds[trace_key][ii]['min'] = mn
-                else:
-                    mn = 0
-                    trace_bounds[trace_key][ii]['min'] = mn
+                mn = 0
+                trace_bounds[trace_key][ii]['min'] = mn
 
             if mx is None:
                 mx = mn + 1

--- a/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
+++ b/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
@@ -365,10 +365,7 @@ def get_img_thumbnails(roi0: OphysROI,
     ymax = max(roi0.y0+roi0.height, roi1.y0+roi1.height)
 
     slop = 50  # ideal number of pixels beyond ROI to show
-    dim = max(roi0.width+slop,
-              roi1.width+slop,
-              roi0.height+slop,
-              roi1.height+slop)
+    dim = max(xmax-xmin+slop, ymax-ymin+slop)
 
     xmin = max(0, xmin-slop//2)
     ymin = max(0, ymin-slop//2)

--- a/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
+++ b/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
@@ -210,6 +210,14 @@ def generate_2d_histogram(data_x: np.ndarray,
     None
     """
 
+    # filter out NaNs
+    valid = np.logical_and(np.logical_not(np.isnan(data_x)),
+                           np.logical_not(np.isnan(data_y)))
+    data_x = data_x[valid]
+    data_y = data_y[valid]
+    if len(data_x) == 0:
+        return None
+
     # construct custom color map for the 2D histogram
     raw_cmap = plt.get_cmap('Blues')
     data = [raw_cmap(x) for x in np.arange(0.3, 0.95, 0.05)]

--- a/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
+++ b/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
@@ -13,6 +13,7 @@ import numpy as np
 import PIL
 import pathlib
 import itertools
+import logging
 
 from typing import Tuple, List, Dict, Optional
 
@@ -23,6 +24,9 @@ from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 
 
 from ophys_etl.modules.decrosstalk.qc_plotting.utils import add_gridlines
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_roi_pixels(roi_list: List[OphysROI]) -> Dict[int, set]:
@@ -695,6 +699,11 @@ def generate_pairwise_figures(
 
         if plane_pair[0].experiment_id > plane_pair[1].experiment_id:
             plane_pair = (plane_pair[1], plane_pair[0])
+
+        msg = 'generating pair plots for '
+        msg += f'{plane_pair[0].experiment_id}; '
+        msg += f'{plane_pair[1].experiment_id}'
+        logger.info(msg)
 
         # find the pairs of ROIs for which we must generate figures
         overlapping_rois = find_overlapping_roi_pairs(plane_pair[0].roi_list,

--- a/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
+++ b/src/ophys_etl/modules/decrosstalk/qc_plotting/pairwise_plot.py
@@ -764,13 +764,15 @@ def generate_pairwise_figures(
             raise RuntimeError(msg)
 
         # read in the max projection image for plane 0
-        raw_img = PIL.Image.open(plane_pair[0].maximum_projection_image_path)
+        raw_img = PIL.Image.open(plane_pair[0].maximum_projection_image_path,
+                                 mode='r')
         n_rows = raw_img.size[0]
         n_cols = raw_img.size[1]
         max_img_0 = np.array(raw_img).reshape(n_rows, n_cols)
 
         # read in the max projection image for plane 1
-        raw_img = PIL.Image.open(plane_pair[1].maximum_projection_image_path)
+        raw_img = PIL.Image.open(plane_pair[1].maximum_projection_image_path,
+                                 mode='r')
         n_rows = raw_img.size[0]
         n_cols = raw_img.size[1]
         max_img_1 = np.array(raw_img).reshape(n_rows, n_cols)

--- a/tests/modules/decrosstalk/test_qc_plotting.py
+++ b/tests/modules/decrosstalk/test_qc_plotting.py
@@ -345,8 +345,7 @@ def test_pairwise_plot_generation(tmpdir, expected_pairwise):
         expected_files.add(fname)
 
     for fname in expected_files:
-        if not fname.is_file():
-            raise RuntimeError(f"could not find {fname.resolve()}")
+        assert fname.is_file()
 
     # check that only the expected files are created
     file_list = pathlib.Path(tmpdir).glob('**/*')
@@ -503,8 +502,7 @@ def test_pairwise_plot_generation_nans(tmpdir,
         expected_files.add(fname)
 
     for fname in expected_files:
-        if not fname.is_file():
-            raise RuntimeError(f"could not find {fname.resolve()}")
+        assert fname.is_file()
 
     # check that only the expected files are created
     file_list = plotting_dir.glob('**/*')

--- a/tests/modules/decrosstalk/test_qc_plotting.py
+++ b/tests/modules/decrosstalk/test_qc_plotting.py
@@ -361,7 +361,8 @@ def test_pairwise_plot_generation(tmpdir, expected_pairwise):
 
 @pytest.mark.parametrize('mangling_operation', ['some', 'all',
                                                 'both_some',
-                                                'both_all'])
+                                                'both_all',
+                                                'both_value'])
 def test_pairwise_plot_generation_nans(tmpdir,
                                        expected_pairwise,
                                        mangling_operation):
@@ -378,6 +379,10 @@ def test_pairwise_plot_generation_nans(tmpdir,
         'all' -- one ROI has all of its traces set to NaN
         'both_some' -- both ROIs have some NaNs in their traces
         'both_all' -- both ROIs have all of their traces set to NaN
+        'both_value' -- both ROIs have their traces set to 1.0
+                        (this exercises the case in which the
+                        min and max values for the 2D histogram
+                        are identical)
     """
 
     this_dir = pathlib.Path(__file__).parent.resolve()
@@ -449,6 +454,8 @@ def test_pairwise_plot_generation_nans(tmpdir,
                     v[chosen] = np.NaN
                 elif 'all' in operation:
                     v[:] = np.NaN
+                elif 'value' in operation:
+                    v[:] = 1.0
                 else:
                     raise RuntimeError("cannot interpret "
                                        f"operation: {operation}")
@@ -461,6 +468,7 @@ def test_pairwise_plot_generation_nans(tmpdir,
         out_fname -- path to the new data file
         operation -- 'some' sets some trace values to NaN;
                      'all' sets all trace values to NaN
+                     'both_value' sets all trace values to 1.0
 
         Note: operation can also be 'both_some' or 'both_all'
         indicating that both ROIs in the plot have been

--- a/tests/modules/decrosstalk/test_qc_plotting.py
+++ b/tests/modules/decrosstalk/test_qc_plotting.py
@@ -1,5 +1,7 @@
 import matplotlib
 
+import pytest
+
 import pathlib
 import json
 
@@ -190,7 +192,37 @@ def test_summary_plot_generation(tmpdir):
     assert out_path.isfile()
 
 
-def test_pairwise_plot_generation(tmpdir):
+@pytest.fixture
+def expected_pairwise():
+    """
+    Pairwise plots that should be generated based on the
+    data in resources/
+    """
+    expected_files = []
+    dirname = pathlib.Path('1071738390_1071738393_roi_pairs')
+    for fname in ('1080616650_1080616555_comparison.png',
+                  '1080616658_1080616553_comparison.png',
+                  '1080616659_1080616554_comparison.png'):
+        expected_files.append(dirname / fname)
+
+    dirname = pathlib.Path('1071738394_1071738396_roi_pairs')
+    for fname in ('1080618091_1080616600_comparison.png',
+                  '1080618102_1080616618_comparison.png'):
+        expected_files.append(dirname / fname)
+
+    dirname = pathlib.Path('1071738397_1071738399_roi_pairs')
+    for fname in ('1080618093_1080623135_comparison.png',
+                  '1080618114_1080623164_comparison.png'):
+        expected_files.append(dirname / fname)
+
+    dirname = pathlib.Path('1071738400_1071738402_roi_pairs')
+    for fname in ('1080616774_1080622865_comparison.png',
+                  '1080616776_1080622881_comparison.png'):
+        expected_files.append(dirname / fname)
+    return expected_files
+
+
+def test_pairwise_plot_generation(tmpdir, expected_pairwise):
     """
     Run a smoke test on qc_plotting.generate_pairwise_figures
     """
@@ -224,28 +256,22 @@ def test_pairwise_plot_generation(tmpdir):
     generate_pairwise_figures(ophys_planes,
                               tmpdir)
 
-    expected_files = []
-    dirname = tmpdir / '1071738390_1071738393_roi_pairs'
-    for fname in ('1080616650_1080616555_comparison.png',
-                  '1080616658_1080616553_comparison.png',
-                  '1080616659_1080616554_comparison.png'):
-        expected_files.append(dirname / fname)
-
-    dirname = tmpdir / '1071738394_1071738396_roi_pairs'
-    for fname in ('1080618091_1080616600_comparison.png',
-                  '1080618102_1080616618_comparison.png'):
-        expected_files.append(dirname / fname)
-
-    dirname = tmpdir / '1071738397_1071738399_roi_pairs'
-    for fname in ('1080618093_1080623135_comparison.png',
-                  '1080618114_1080623164_comparison.png'):
-        expected_files.append(dirname / fname)
-
-    dirname = tmpdir / '1071738400_1071738402_roi_pairs'
-    for fname in ('1080616774_1080622865_comparison.png',
-                  '1080616776_1080622881_comparison.png'):
-        expected_files.append(dirname / fname)
+    expected_files = set()
+    t = pathlib.Path(tmpdir)
+    for plot_path in expected_pairwise:
+        fname = t / plot_path
+        expected_files.add(fname)
 
     for fname in expected_files:
-        if not fname.isfile():
+        if not fname.is_file():
             raise RuntimeError(f"could not find {fname.resolve()}")
+
+    # check that only the expected files are created
+    file_list = pathlib.Path(tmpdir).glob('**/*')
+    ct = 0
+    for fname in file_list:
+        if not fname.is_file():
+            continue
+        ct += 1
+        assert fname in expected_files
+    assert ct == len(expected_files)


### PR DESCRIPTION
This fixes a bug which was causing the QC plotting routines to fail on datasets with invalid ROIs (i.e. ROIs that overlapped the motion border)