### PR TITLE
adds edge normalization function

### DIFF
--- a/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
@@ -7,7 +7,8 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 def draw_graph_edges(figure: figure.Figure,
                      axis: axes.Axes,
-                     graph: nx.Graph, attribute_name: str = "Pearson"):
+                     graph: nx.Graph,
+                     attribute_name: str = "Pearson"):
     """draws graph edges from node to node, colored by weight
 
     Parameters
@@ -16,9 +17,11 @@ def draw_graph_edges(figure: figure.Figure,
         a matplotlib Figure
     axis: matplotlib.axes.Axes
         a matplotlib Axes, part of Figure
-    graphs: nx.Graph
+    graph: nx.Graph
         a networkx graph, assumed to have edges formed like
         graph.add_edge((0, 1), (0, 2), weight=1.234)
+    attibute_name: str
+        which edge attribute to plot
 
     Notes
     -----

--- a/tests/modules/segmentation/graph_utils/test_edge_attributes.py
+++ b/tests/modules/segmentation/graph_utils/test_edge_attributes.py
@@ -56,3 +56,25 @@ def test_add_pearson_edge_attributes(video_path):
 
     # make sure original node attributes came along
     assert "node_attr" in list(graph_with_edges.nodes(data=True))[0][1]
+
+
+@pytest.mark.parametrize(
+        "video_path",
+        [
+            {"video_shape": (20, 40, 40)},
+        ], indirect=["video_path"])
+def test_normalize_graph(video_path):
+    with h5py.File(video_path, "r") as f:
+        nrow, ncol = f["data"].shape[1:]
+    graph = creation.create_graph(row_min=0, row_max=(nrow - 1),
+                                  col_min=0, col_max=(ncol - 1))
+    graph = edge_attributes.add_pearson_edge_attributes(graph, video_path)
+    for n1, n2, attr in graph.edges(data=True):
+        keys = list(attr.keys())
+        assert "Pearson" in keys
+        assert "Pearson_normalized" not in keys
+    graph = edge_attributes.normalize_graph(graph, attribute_name="Pearson")
+    for n1, n2, attr in graph.edges(data=True):
+        keys = list(attr.keys())
+        assert "Pearson" in keys
+        assert "Pearson_normalized" in keys


### PR DESCRIPTION
adds in a function that normalizes an edge attribute according to a local Gaussian average.
The normalization is not particularly apparent in this example, but, you can tell from the color scale that it is applied.
The idea is that this might be helpful in compensating for regions under vasculature.

```
from ophys_etl.modules.segmentation.graph_utils import plotting, edge_attributes                                                                    
import networkx as nx                                                     
import matplotlib.pyplot as plt 

graph = nx.read_gpickle("./tmp.pkl")                                      
graph = edge_attributes.normalize_graph(graph, attribute_name="Pearson")  
f, a = plt.subplots(1, 2, clear=True, num=1, sharex=True, sharey=True)    
plotting.draw_graph_edges(f, a[0], graph, attribute_name="Pearson")       
plotting.draw_graph_edges(f, a[1], graph, attribute_name="Pearson_normalized") 
```
![Figure_1](https://user-images.githubusercontent.com/32312979/117712052-b37e4e80-b188-11eb-95ed-2f8d1d3fdb4d.png)

a wider FOV with vasculature:
![Figure_1](https://user-images.githubusercontent.com/32312979/117714587-03124980-b18c-11eb-951c-43a210fdde65.png)

