### PR TITLE
adds graph binning utility

### DIFF
--- a/src/ophys_etl/modules/segmentation/postprocess_utils/sorting.py
+++ b/src/ophys_etl/modules/segmentation/postprocess_utils/sorting.py
@@ -1,0 +1,86 @@
+import networkx as nx
+import numpy as np
+from typing import Union, List, Optional, Tuple, Dict
+
+
+def bin_graph(graph: nx.Graph,
+              bins: Union[int, List[Union[int, float]], str],
+              sort_type: str = "node_count",
+              attribute_name: Optional[str] = None,
+              right: bool = False,
+              max_inclusive: bool = True,
+              ) -> Tuple[Dict[int, nx.Graph], np.ndarray]:
+    """sorts the connected components of a graph by specified
+    sort_type metric and returns binned combined graphs
+
+    Parameters
+    ----------
+    graph: nx.Graph
+        the input graph. Presumably this has multiple connected components,
+        i.e. it is the result of segmentation.
+    sort_type: str
+        numerical metric for sorting graph connected components
+        'node_count': bin components by number of nodes
+        'degree': bin components by average degree
+        'edge_attribute': bin components by average edge attribute
+        'node_attribute': bin components by average node attribute
+    attribute_name: str
+        if 'sort_type' is 'edge_attribute' or 'node_attribute' this is the
+        attribute name from which to extract the metric
+    bins: int or list of scalars or str
+        passed as 'bins' to np.histogram_bin_edges()
+    right: bool
+        passed as 'right' to np.digitize
+    max_inclusive: bool
+        if True, modifies returned values from np.digitize to make
+        sure the final bin is inclusive of the endpoint
+
+
+    Returns
+    -------
+    binned_graphs: dict
+        keys are indices, as returned by np.digitize()
+        values are the graphs
+    bin_edges: array of dtype float
+        the bin edges as returned by np.histogram_bin_edges()
+
+    """
+    subgraphs = [graph.subgraph(i) for i in nx.connected_components(graph)]
+
+    # extract specified metric
+    if sort_type == "node_count":
+        values = np.array([len(i) for i in subgraphs])
+    elif sort_type == "degree":
+        values = [sum([i[1] for i in subgraph.degree]) / len(subgraph)
+                  for subgraph in subgraphs]
+    elif sort_type == "edge_attribute":
+        values = [np.array(list(
+                      nx.get_edge_attributes(
+                          i, attribute_name).values())).mean()
+                  for i in subgraphs]
+    elif sort_type == "node_attribute":
+        values = [np.array(list(
+                      nx.get_node_attributes(
+                          i, attribute_name).values())).mean()
+                  for i in subgraphs]
+
+    # set up the bins
+    bin_edges = np.histogram_bin_edges(values, bins)
+    if max_inclusive:
+        bmax = bin_edges[-1]
+        bin_edges[-1] += np.diff(values).mean() * 1e-5
+    bin_indices = np.digitize(values, bin_edges)
+
+    # collect nodes in bins
+    node_lists = dict()
+    for bin_index, subgraph in zip(bin_indices, subgraphs):
+        if bin_index not in node_lists:
+            node_lists[bin_index] = []
+        node_lists[bin_index].extend(list(subgraph.nodes))
+
+    binned_graphs = {k: graph.subgraph(v) for k, v in node_lists.items()}
+
+    if max_inclusive:
+        bin_edges[-1] = bmax
+
+    return binned_graphs, bin_edges

--- a/tests/modules/segmentation/postprocess_utils/test_sorting.py
+++ b/tests/modules/segmentation/postprocess_utils/test_sorting.py
@@ -1,0 +1,56 @@
+import pytest
+import networkx as nx
+
+from ophys_etl.modules.segmentation.postprocess_utils import sorting
+
+
+@pytest.fixture
+def graph_to_bin():
+    """a graph whose connected components are distinguishable
+    by node attribute, edge attribute, node count, and degree
+    """
+    g = nx.Graph()
+
+    # first connected_component
+    g.add_node(1, node_attr=0)
+    g.add_node(2, node_attr=0)
+    g.add_node(3, node_attr=0)
+    g.add_edge(1, 2, edge_attr=0)
+    g.add_edge(1, 3, edge_attr=0)
+    g.add_edge(2, 3, edge_attr=0)
+
+    # second connected_component
+    g.add_node(4, node_attr=1)
+    g.add_node(5, node_attr=1)
+    g.add_node(6, node_attr=1)
+    g.add_node(7, node_attr=1)
+    g.add_edge(4, 5, edge_attr=1)
+    g.add_edge(4, 6, edge_attr=1)
+    g.add_edge(4, 7, edge_attr=1)
+    g.add_edge(5, 6, edge_attr=1)
+    g.add_edge(5, 7, edge_attr=1)
+    g.add_edge(6, 7, edge_attr=1)
+
+    return g
+
+
+@pytest.mark.parametrize(
+        "sort_type, attribute_name",
+        [
+            ("node_count", None),
+            ("degree", None),
+            ("edge_attribute", "edge_attr"),
+            ("node_attribute", "node_attr")])
+def test_bin_graph(graph_to_bin, sort_type, attribute_name):
+    binned_graphs, bins = sorting.bin_graph(graph_to_bin,
+                                            bins=2,
+                                            sort_type=sort_type,
+                                            attribute_name=attribute_name)
+    assert bins.size == 3
+    assert len(binned_graphs) == 2
+    for v in binned_graphs.values():
+        assert isinstance(v, nx.Graph)
+    assert len(binned_graphs[1]) == 3
+    assert len(binned_graphs[1].edges) == 3
+    assert len(binned_graphs[2]) == 4
+    assert len(binned_graphs[2].edges) == 6


### PR DESCRIPTION
allows to bin the connected components of a graph (i.e. the unconnected segmentation outputs) into separate graphs according to a specified metric and via numpy-style histogram binning.