### PR TITLE
adds chunking to denoising outputs, for roi-like access speed

### DIFF
--- a/src/ophys_etl/modules/segmentation/modules/pca_denoise.py
+++ b/src/ophys_etl/modules/segmentation/modules/pca_denoise.py
@@ -32,7 +32,10 @@ class PCADenoise(argschema.ArgSchemaParser):
         # reconstruct from the fitted components
         frame_counter = 0
         with h5py.File(self.args["video_output"], "w") as f:
-            output = f.create_dataset("data", shape=dshape, dtype=data.dtype)
+            output = f.create_dataset("data",
+                                      shape=dshape,
+                                      dtype=data.dtype,
+                                      chunks=self.args["h5_chunk_shape"])
             for chunk in split_data:
                 output[frame_counter: (frame_counter + chunk.shape[0])] = \
                         ipca.inverse_transform(ipca.transform(chunk)).reshape(

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -158,8 +158,7 @@ class SegmentV0InputSchema(argschema.ArgSchema):
         description="if provided, will write subgraphs to json as ROIs")
 
 
-class PCADenoiseInputSchema(argschema.ArgSchema):
-    log_level = argschema.fields.LogLevel(default="INFO")
+class DenoiseBaseSchema(argschema.schemas.DefaultSchema):
     video_path = argschema.fields.InputFile(
         required=True,
         description=("path to hdf5 video with movie stored "
@@ -167,6 +166,14 @@ class PCADenoiseInputSchema(argschema.ArgSchema):
     video_output = argschema.fields.OutputFile(
         required=True,
         description="destination path to filtered hdf5 video ")
+    h5_chunk_shape = argschema.fields.Tuple(
+        (Int(), Int(), (Int())),
+        default=(100, 64, 64),
+        description="passed to h5py.File.create_dataset(chunks=)")
+
+
+class PCADenoiseInputSchema(argschema.ArgSchema, DenoiseBaseSchema):
+    log_level = argschema.fields.LogLevel(default="INFO")
     n_components = argschema.fields.Int(
         required=True,
         description=("number of principal components to keep. "
@@ -196,15 +203,8 @@ class PCADenoiseInputSchema(argschema.ArgSchema):
         return data
 
 
-class SimpleDenoiseInputSchema(argschema.ArgSchema):
+class SimpleDenoiseInputSchema(argschema.ArgSchema, DenoiseBaseSchema):
     log_level = argschema.fields.LogLevel(default="INFO")
-    video_path = argschema.fields.InputFile(
-        required=True,
-        description=("path to hdf5 video with movie stored "
-                     "in dataset 'data' nframes x nrow x ncol"))
-    video_output = argschema.fields.OutputFile(
-        required=True,
-        description="destination path to filtered hdf5 video ")
     size = argschema.fields.Float(
         required=True,
         description=("filter size for the time axis. "

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -168,7 +168,7 @@ class DenoiseBaseSchema(argschema.schemas.DefaultSchema):
         description="destination path to filtered hdf5 video ")
     h5_chunk_shape = argschema.fields.Tuple(
         (Int(), Int(), (Int())),
-        default=(100, 64, 64),
+        default=(50, 32, 32),
         description="passed to h5py.File.create_dataset(chunks=)")
 
 

--- a/src/ophys_etl/modules/segmentation/modules/simple_denoise.py
+++ b/src/ophys_etl/modules/segmentation/modules/simple_denoise.py
@@ -41,7 +41,9 @@ class SimpleDenoise(argschema.ArgSchemaParser):
             output = output.reshape(*dshape)
 
         with h5py.File(self.args["video_output"], "w") as f:
-            f.create_dataset("data", data=output)
+            f.create_dataset("data",
+                             data=output,
+                             chunks=self.args["h5_chunk_shape"])
         self.logger.info(f"wrote {self.args['video_output']}")
 
 


### PR DESCRIPTION
Looking towards a notebook that can access ROI traces quickly from a movie, I was seeing that isilon-hosted hdf5 files written with default parameters were very slow to access slices in the spatial dimensions (i.e. what one would want to get the traces for a rectangular bounding box). This was less of an issue on local disks, but, since we'll probably have isilon as a common storage for backing the notebooks, this change of adding chunking seems to help:

trying out chunks of (100, 64, 64) compared to previous not chunked h5 access:
```
not chunked: read chunk of shape (40, 512, 512) in 0.97 seconds
not chunked: read chunk of shape (21610, 23, 22) in 461.63 seconds
chunked: read chunk of shape (40, 512, 512) in 1.87 seconds
chunked: read chunk of shape (21610, 23, 22) in 13.85 seconds
```
I saw even better performance with chunks like (50, 32, 32) which is very close to the recommended chunk size of 1MiB:
https://docs.h5py.org/en/stable/high/dataset.html#chunked-storage.
I made this the default.

from:
```
import h5py
import time

p0 = "/allen/programs/braintv/workgroups/nc-ophys/danielk/deepinterpolation/experiments/ophys_experiment_785569447/pca_100_denoised.h5"
p1 = "/allen/programs/braintv/workgroups/nc-ophys/danielk/deepinterpolation/experiments/ophys_experiment_785569447/pca_100_denoised_chunked.h5"

for p, name in zip([p0, p1], ["not chunked", "chunked"]):
    t0 = time.time()
    with h5py.File(p, "r") as f:
        data = f["data"][380:420]
    delta = time.time() - t0
    print(f"{name}: read chunk of shape {data.shape} in {delta:.2f} seconds")

    t0 = time.time()
    with h5py.File(p, "r") as f:
        data = f["data"][:, 45:68, 110:132]
    delta = time.time() - t0
    print(f"{name}: read chunk of shape {data.shape} in {delta:.2f} seconds")
```