### PR TITLE
make sure we don't try to compose_all on an empty list of graphs

### DIFF
--- a/src/ophys_etl/modules/segmentation/graph_utils/community.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/community.py
@@ -201,7 +201,7 @@ def grow_subgraph(graph: nx.Graph,
 def iterative_detection(graph: Union[nx.Graph, Path],
                         attribute_name: str,
                         seed_quantile: int,
-                        n_node_thresh=20) -> Union[nx.Graph, Path]:
+                        n_node_thresh=20) -> Union[nx.Graph, Path, None]:
     """idenitfy seeds, grow out ROIs, repeat
 
     Parameters
@@ -219,6 +219,7 @@ def iterative_detection(graph: Union[nx.Graph, Path],
     -------
     graph: nx.Graph
         a graph consisting of only identified ROIs, or a path to such
+        (note: if no ROIs are identified, returns None)
 
     """
     from_path = None
@@ -252,9 +253,12 @@ def iterative_detection(graph: Union[nx.Graph, Path],
         graph = nx.Graph(graph.subgraph(nodes))
         collected.append(expanded)
 
-    graph = nx.compose_all(collected)
+    if len(collected) > 0:
+        graph = nx.compose_all(collected)
+    else:
+        graph = None
 
-    if from_path is not None:
+    if from_path is not None and graph is not None:
         nx.write_gpickle(graph, from_path)
         graph = from_path
 

--- a/src/ophys_etl/modules/segmentation/modules/community_detection.py
+++ b/src/ophys_etl/modules/segmentation/modules/community_detection.py
@@ -41,7 +41,8 @@ class SegmentV0(argschema.ArgSchemaParser):
                     results = pool.starmap(community.iterative_detection,
                                            args)
                 new_graph = nx.compose_all([nx.read_gpickle(i)
-                                            for i in results])
+                                            for i in results
+                                            if i is not None])
 
         nx.write_gpickle(new_graph, self.args["graph_output"])
         self.logger.info(f"wrote {self.args['graph_output']}")


### PR DESCRIPTION
I was running into a failure mode wherein, if I specified a large number of partitions for community detection, some of those partitions would contain no ROIs and networkx would throw an exception when it tried to run compose_all on an empty list of graphs. This PR fixes that by allowing iterative_growth to return None if there are no ROIs in the partition. This graph then gets skipped in the final compose_all.