### PR TITLE
Segmentation/refactor/plotting

### DIFF
--- a/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
@@ -330,7 +330,7 @@ class FeatureVectorSegmenter(object):
         self._filter_fraction = filter_fraction
         self.rng = np.random.RandomState(11923141)
         self._graph_img = graph_to_img(graph_input,
-                                       attribute=attribute)
+                                       attribute_name=attribute)
 
         with h5py.File(self._video_input, 'r') as in_file:
             self._movie_data = in_file['data'][()]
@@ -481,7 +481,7 @@ class FeatureVectorSegmenter(object):
         t0 = time.time()
 
         img_data = graph_to_img(self._graph_input,
-                                attribute=self._attribute)
+                                attribute_name=self._attribute)
 
         logger.info(f'read in image data from {str(self._graph_input)}')
 

--- a/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
@@ -14,7 +14,8 @@ from ophys_etl.modules.segmentation.graph_utils.feature_vector_rois import (
     PearsonFeatureROI)
 
 from ophys_etl.modules.segmentation.graph_utils.plotting import (
-    create_roi_plot)
+    create_roi_plot,
+    graph_to_img)
 
 import logging
 
@@ -34,38 +35,6 @@ class ROISeed(TypedDict):
     center: Tuple[int, int]
     rows: Tuple[int, int]
     cols: Tuple[int, int]
-
-
-def graph_to_img(graph_path: pathlib.Path,
-                 attribute: str = 'filtered_hnc_Gaussian') -> np.ndarray:
-    """
-    Convert a graph into a np.ndarray image
-
-    Parameters
-    ----------
-    graph_path: pathlib.Path
-        Path to graph pickle file
-
-    attribute: str
-        Name of the attribute used to create the image
-        (default = 'filtered_hnc_Gaussian')
-
-    Returns
-    -------
-    np.ndarray
-        An image in which the value of each pixel is the
-        sum of the edge weights connected to that node in
-        the graph.
-    """
-    graph = nx.read_gpickle(graph_path)
-    node_coords = np.array(graph.nodes).T
-    row_max = node_coords[0].max()
-    col_max = node_coords[1].max()
-    img = np.zeros((row_max+1, col_max+1), dtype=float)
-    for node in graph.nodes:
-        vals = [graph[node][i][attribute] for i in graph.neighbors(node)]
-        img[node[0], node[1]] = np.sum(vals)
-    return img
 
 
 def find_a_peak(img_masked: np.ma.core.MaskedArray,

--- a/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
@@ -1,5 +1,4 @@
 from typing import Optional, List, Tuple
-import networkx as nx
 import numpy as np
 import multiprocessing
 import multiprocessing.managers

--- a/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
@@ -111,3 +111,35 @@ def create_roi_plot(plot_path: pathlib.Path,
     fig.tight_layout()
     fig.savefig(plot_path)
     return None
+
+
+def graph_to_img(graph_path: pathlib.Path,
+                 attribute: str = 'filtered_hnc_Gaussian') -> np.ndarray:
+    """
+    Convert a graph into a np.ndarray image
+
+    Parameters
+    ----------
+    graph_path: pathlib.Path
+        Path to graph pickle file
+
+    attribute: str
+        Name of the attribute used to create the image
+        (default = 'filtered_hnc_Gaussian')
+
+    Returns
+    -------
+    np.ndarray
+        An image in which the value of each pixel is the
+        sum of the edge weights connected to that node in
+        the graph.
+    """
+    graph = nx.read_gpickle(graph_path)
+    node_coords = np.array(graph.nodes).T
+    row_max = node_coords[0].max()
+    col_max = node_coords[1].max()
+    img = np.zeros((row_max+1, col_max+1), dtype=float)
+    for node in graph.nodes:
+        vals = [graph[node][i][attribute] for i in graph.neighbors(node)]
+        img[node[0], node[1]] = np.sum(vals)
+    return img

--- a/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
@@ -114,7 +114,7 @@ def create_roi_plot(plot_path: pathlib.Path,
 
 
 def graph_to_img(graph: Union[pathlib.Path, nx.Graph],
-                 attribute: str = 'filtered_hnc_Gaussian') -> np.ndarray:
+                 attribute_name: str = 'filtered_hnc_Gaussian') -> np.ndarray:
     """
     Convert a graph into a np.ndarray image
 
@@ -124,7 +124,7 @@ def graph_to_img(graph: Union[pathlib.Path, nx.Graph],
         Either a networkx.Graph or the path to a pickle file
         containing the graph
 
-    attribute: str
+    attribute_name: str
         Name of the attribute used to create the image
         (default = 'filtered_hnc_Gaussian')
 
@@ -148,7 +148,8 @@ def graph_to_img(graph: Union[pathlib.Path, nx.Graph],
     col_max = node_coords[1].max()
     img = np.zeros((row_max+1, col_max+1), dtype=float)
     for node in graph.nodes:
-        vals = [graph[node][i][attribute] for i in graph.neighbors(node)]
+        vals = [graph[node][i][attribute_name]
+                for i in graph.neighbors(node)]
         img[node[0], node[1]] = np.sum(vals)
     return img
 
@@ -178,7 +179,7 @@ def draw_graph_img(figure: figure.Figure,
 
     """
     img = graph_to_img(graph,
-                       attribute=attribute_name)
+                       attribute_name=attribute_name)
     shape = img.shape
 
     img = axis.imshow(img, cmap='plasma')

--- a/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/plotting.py
@@ -1,6 +1,6 @@
 import networkx as nx
 import numpy as np
-from typing import List
+from typing import List, Union
 import pathlib
 from matplotlib import figure, axes
 from matplotlib.collections import LineCollection
@@ -113,15 +113,16 @@ def create_roi_plot(plot_path: pathlib.Path,
     return None
 
 
-def graph_to_img(graph_path: pathlib.Path,
+def graph_to_img(graph: Union[pathlib.Path, nx.Graph],
                  attribute: str = 'filtered_hnc_Gaussian') -> np.ndarray:
     """
     Convert a graph into a np.ndarray image
 
     Parameters
     ----------
-    graph_path: pathlib.Path
-        Path to graph pickle file
+    graph: Union[pathlib.Path, nx.Graph]
+        Either a networkx.Graph or the path to a pickle file
+        containing the graph
 
     attribute: str
         Name of the attribute used to create the image
@@ -134,7 +135,14 @@ def graph_to_img(graph_path: pathlib.Path,
         sum of the edge weights connected to that node in
         the graph.
     """
-    graph = nx.read_gpickle(graph_path)
+    if isinstance(graph, pathlib.Path):
+        graph = nx.read_gpickle(graph)
+    else:
+        if not isinstance(graph, nx.Graph):
+            msg = "graph must be either a pathlib.Path or "
+            msg += f"a networkx.Graph. You gave {type(graph)}"
+            raise RuntimeError(msg)
+
     node_coords = np.array(graph.nodes).T
     row_max = node_coords[0].max()
     col_max = node_coords[1].max()
@@ -143,3 +151,46 @@ def graph_to_img(graph_path: pathlib.Path,
         vals = [graph[node][i][attribute] for i in graph.neighbors(node)]
         img[node[0], node[1]] = np.sum(vals)
     return img
+
+
+def draw_graph_img(figure: figure.Figure,
+                   axis: axes.Axes,
+                   graph: nx.Graph,
+                   attribute_name: str = "Pearson"):
+    """draws graph as an image where every pixel's intensity is the
+    sum of the edge weights connected to that pixel
+
+    Parameters
+    ----------
+    figure: matplotlib.figure.Figure
+        a matplotlib Figure
+    axis: matplotlib.axes.Axes
+        a matplotlib Axes, part of Figure
+    graph: nx.Graph
+        a networkx graph, assumed to have edges formed like
+        graph.add_edge((0, 1), (0, 2), weight=1.234)
+    attibute_name: str
+        which edge attribute to plot
+
+    Notes
+    -----
+    modifes figure and axis in-place
+
+    """
+    img = graph_to_img(graph,
+                       attribute=attribute_name)
+    shape = img.shape
+
+    img = axis.imshow(img, cmap='plasma')
+    axis.set_aspect("equal")
+    divider = make_axes_locatable(axis)
+    cax = divider.append_axes("right", size="5%", pad=0.05)
+    figure.colorbar(img, ax=axis, cax=cax)
+
+    buffx = 0.02 * shape[1]
+    buffy = 0.02 * shape[0]
+
+    axis.set_xlim(-buffx, shape[1] + buffx)
+    axis.set_ylim(-buffy, shape[0] + buffy)
+
+    axis.set_title(attribute_name)

--- a/src/ophys_etl/modules/segmentation/modules/create_plot.py
+++ b/src/ophys_etl/modules/segmentation/modules/create_plot.py
@@ -19,10 +19,16 @@ class GraphPlot(argschema.ArgSchemaParser):
         graph = nx.read_gpickle(self.args["graph_input"])
         fig = figure.Figure(figsize=(16, 16))
         axis = fig.add_subplot(111)
-        plotting.draw_graph_edges(fig,
-                                  axis,
-                                  graph,
-                                  attribute_name=self.args['attribute'])
+        if self.args['draw_edges']:
+            plotting.draw_graph_edges(fig,
+                                      axis,
+                                      graph,
+                                      attribute_name=self.args['attribute'])
+        else:
+            plotting.draw_graph_img(fig,
+                                    axis,
+                                    graph,
+                                    attribute_name=self.args['attribute'])
         fig.savefig(self.args["plot_output"], dpi=300)
         self.logger.info(f"wrote {self.args['plot_output']}")
 

--- a/src/ophys_etl/modules/segmentation/modules/create_plot.py
+++ b/src/ophys_etl/modules/segmentation/modules/create_plot.py
@@ -19,7 +19,10 @@ class GraphPlot(argschema.ArgSchemaParser):
         graph = nx.read_gpickle(self.args["graph_input"])
         fig = figure.Figure(figsize=(16, 16))
         axis = fig.add_subplot(111)
-        plotting.draw_graph_edges(fig, axis, graph)
+        plotting.draw_graph_edges(fig,
+                                  axis,
+                                  graph,
+                                  attribute_name=self.args['attribute'])
         fig.savefig(self.args["plot_output"], dpi=300)
         self.logger.info(f"wrote {self.args['plot_output']}")
 

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -121,6 +121,12 @@ class GraphPlotInputSchema(argschema.ArgSchema):
     plot_output = argschema.fields.OutputFile(
         required=True,
         description=("destination png for plot"))
+    attribute = argschema.fields.Str(
+        required=False,
+        default="Pearson",
+        validate=OneOf(["Pearson", "filtered_Pearson", "hnc_Gaussian",
+                        "filtered_hnc_Gaussian"]),
+        description="which attribute to use in image")
 
 
 class SegmentV0InputSchema(argschema.ArgSchema):

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -121,6 +121,13 @@ class GraphPlotInputSchema(argschema.ArgSchema):
     plot_output = argschema.fields.OutputFile(
         required=True,
         description=("destination png for plot"))
+    draw_edges = argschema.fields.Boolean(
+        required=False,
+        default=False,
+        description=("If true, draw edges of graph. "
+                     "If false, draw graph as pixel image "
+                     "in which a pixel's intensity is the sum of "
+                     "the edge weights connected to that pixel. "))
     attribute = argschema.fields.Str(
         required=False,
         default="Pearson",

--- a/tests/modules/segmentation/graph_utils/feature_vector_segmentation/test_feature_vector_segmentation.py
+++ b/tests/modules/segmentation/graph_utils/feature_vector_segmentation/test_feature_vector_segmentation.py
@@ -47,7 +47,7 @@ def test_graph_to_img(example_graph):
     smoke test graph_to_img
     """
     img = graph_to_img(example_graph,
-                       attribute='dummy_attribute')
+                       attribute_name='dummy_attribute')
 
     # check that image has expected type and shape
     assert type(img) == np.ndarray

--- a/tests/modules/segmentation/graph_utils/feature_vector_segmentation/test_feature_vector_segmentation.py
+++ b/tests/modules/segmentation/graph_utils/feature_vector_segmentation/test_feature_vector_segmentation.py
@@ -6,10 +6,12 @@ import json
 
 from ophys_etl.types import ExtractROI
 
+from ophys_etl.modules.segmentation.graph_utils.plotting import (
+    graph_to_img)
+
 from ophys_etl.modules.segmentation.\
     graph_utils.feature_vector_segmentation import (
         convert_to_lims_roi,
-        graph_to_img,
         find_peaks,
         FeatureVectorSegmenter)
 


### PR DESCRIPTION
Modifies create_plot.py so that the default is to draw the graph as an image in which each pixel's intensity is the sum of the edge weights connected to that pixel. This produces a smaller image the plotting the individual graph edges (1 MB vs 34 MB). The new option is set as the default behavior of the create_plot module.

