### PR TITLE
adds pca features to FeatureVectorSegmentation architecture

### DIFF
--- a/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_rois.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_rois.py
@@ -683,12 +683,14 @@ def calculate_pca_feature_vectors(
     """
     nframes = sub_video.shape[0]
     data = sub_video.reshape(nframes, -1)
-    if pixel_ignore is not None:
-        mask = np.logical_not(pixel_ignore.flatten())
-        data = data[:, mask]
     pca = PCA(n_components=n_components)
     pca.fit(data)
     features = pca.components_.T
+    if pixel_ignore is not None:
+        mask = np.logical_not(pixel_ignore.flatten())
+    else:
+        mask = np.ones((data.shape[-1])).astype(bool)
+    features = features[mask]
     if scale:
         features = StandardScaler().fit_transform(features)
     return features

--- a/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/graph_utils/feature_vector_segmentation.py
@@ -332,8 +332,7 @@ class FeatureVectorSegmenter(object):
                                        attribute_name=attribute)
 
         with h5py.File(self._video_input, 'r') as in_file:
-            self._movie_data = in_file['data'][()]
-            movie_shape = self._movie_data.shape
+            movie_shape = in_file["data"].shape
             if movie_shape[1:] != self._graph_img.shape:
                 msg = f'movie shape: {movie_shape}\n'
                 msg += f'img shape: {self._graph_img.shape}'

--- a/src/ophys_etl/modules/segmentation/modules/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/modules/feature_vector_segmentation.py
@@ -8,6 +8,12 @@ from ophys_etl.modules.segmentation.graph_utils.\
     feature_vector_segmentation import (
         FeatureVectorSegmenter)
 
+from ophys_etl.modules.segmentation.graph_utils.feature_vector_rois import \
+    PearsonFeatureROI, PCAFeatureROI
+
+ROI_CLASS_MAP = {"PearsonFeatureROI": PearsonFeatureROI,
+                 "PCAFeatureROI": PCAFeatureROI}
+
 
 class FeatureVectorSegmentationRunner(argschema.ArgSchemaParser):
 
@@ -18,10 +24,12 @@ class FeatureVectorSegmentationRunner(argschema.ArgSchemaParser):
         video_input = pathlib.Path(self.args['video_input'])
         n_processors = self.args['n_parallel_workers']
         attr = self.args['attribute']
+        roi_class = ROI_CLASS_MAP[self.args["roi_class"]]
         segmenter = FeatureVectorSegmenter(graph_input,
                                            video_input,
                                            attribute=attr,
-                                           n_processors=n_processors)
+                                           n_processors=n_processors,
+                                           roi_class=roi_class)
 
         if self.args['plot_output'] is not None:
             plot_output = pathlib.Path(self.args['plot_output'])

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -263,6 +263,7 @@ class FeatureVectorSegmentationInputSchema(argschema.ArgSchema):
     plot_output = argschema.fields.OutputFile(
         required=False,
         default=None,
+        allow_none=True,
         description="path to summary plot of segmentation")
 
     seed_output = argschema.fields.OutputFile(
@@ -275,3 +276,9 @@ class FeatureVectorSegmentationInputSchema(argschema.ArgSchema):
         required=False,
         default=1,
         description=("how many multiprocessing workers to use."))
+
+    roi_class = argschema.fields.Str(
+        required=False,
+        default="PearsonFeatureROI",
+        validate=OneOf(["PearsonFeatureROI", "PCAFeatureROI"]),
+        description="which class to use.")


### PR DESCRIPTION
This PR establishes PCA features as a plug-in for the `FeatureVectorSegmenter`.
It did pretty well in extracting areas of high correlation, but, it did so a single pixel at a time. I.e. there was no ROI growth, and the segmentations that resulted are a collection of single-pixel ROIs:
![image](https://user-images.githubusercontent.com/32312979/121065018-24f7ef80-c77d-11eb-9e23-907ae127f883.png)

I submit this PR as "working" in the sense that substituting PCA components in place of the original HNC-style components does seem to function, but, there are some further things to investigate:
* why does the `FeatureVectorSegmenter` fail to grow ROIs with PCA components as feature vectors?
* the dimension of PCA decomposition could be changed. In this implementation, frames are considered samples, and pixels are considered features.  The transpose of this implementation is also possible.