### PR TITLE
adds check for repeated planes

### DIFF
--- a/src/ophys_etl/modules/mesoscope_splitting/__main__.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/__main__.py
@@ -269,7 +269,8 @@ def main():
                           output_schema_type=OutputSchema)
 
     # check for repeated z value
-    checks.check_for_repeated_planes(Path(mod.args["timeseries_tif"]))
+    ts_mesoscope_tiff = MesoscopeTiff(mod.args["timeseries_tif"])
+    checks.check_for_repeated_planes(ts_mesoscope_tiff)
 
     # check consistency between input json and tiff headers
     check_list = []
@@ -339,7 +340,6 @@ def main():
                                          experiments,
                                          "depth")
 
-    ts_mesoscope_tiff = MesoscopeTiff(mod.args["timeseries_tif"])
     ts_outs, ts_meta = split_timeseries(ts_mesoscope_tiff,
                                         experiments)
 

--- a/src/ophys_etl/modules/mesoscope_splitting/__main__.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/__main__.py
@@ -13,8 +13,7 @@ from ophys_etl.modules.mesoscope_splitting.conversion_utils import (
 from ophys_etl.modules.mesoscope_splitting.metadata import SI_stringify_floats
 from ophys_etl.modules.mesoscope_splitting.schemas import (
     InputSchema, OutputSchema)
-from ophys_etl.modules.mesoscope_splitting.checks import (
-        ConsistencyInput, splitting_consistency_check)
+from ophys_etl.modules.mesoscope_splitting import checks
 
 
 def mock_h5(*args, **kwargs):
@@ -269,6 +268,9 @@ def main():
     mod = ArgSchemaParser(schema_type=InputSchema,
                           output_schema_type=OutputSchema)
 
+    # check for repeated z value
+    checks.check_for_repeated_planes(Path(mod.args["timeseries_tif"]))
+
     # check consistency between input json and tiff headers
     check_list = []
     for plane_group in mod.args["plane_groups"]:
@@ -276,8 +278,10 @@ def main():
         roi_index = list({i["roi_index"]
                           for i in plane_group["ophys_experiments"]})
         check_list.append(
-            ConsistencyInput(tiff=pg_tiff, roi_index=roi_index))
-    splitting_consistency_check(check_list)
+            checks.ConsistencyInput(tiff=pg_tiff, roi_index=roi_index))
+    checks.splitting_consistency_check(check_list)
+
+    # end checks
 
     if mod.args['test_mode']:
         global volume_to_h5, volume_to_tif

--- a/src/ophys_etl/modules/mesoscope_splitting/checks.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/checks.py
@@ -1,9 +1,11 @@
 import sys
 import numpy as np
+import pandas as pd
 from typing import List
 from pathlib import Path
 
 from ophys_etl.modules.mesoscope_splitting.tiff import tiff_header_data
+from ophys_etl.modules.mesoscope_splitting.tiff import MesoscopeTiff
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -73,3 +75,16 @@ def splitting_consistency_check(check_list: List[ConsistencyInput]):
         raise errors[0]
     else:
         raise MultiException(errors)
+
+
+def check_for_repeated_planes(timeseries_tiff_path: Path):
+    """
+    """
+    mt = MesoscopeTiff(timeseries_tiff_path)
+    u_plane_scans, counts = np.unique(mt.plane_scans, return_counts=True)
+    if mt.plane_scans.size != u_plane_scans.size:
+        result = [{"z_value": z, "count": c}
+                  for z, c in zip(u_plane_scans, counts)]
+        dframe = pd.DataFrame.from_records(result).set_index("z_value")
+        raise ValueError(f"{timeseries_tiff_path} has a repeated plane z "
+                         f"value:\n {dframe}")

--- a/src/ophys_etl/modules/mesoscope_splitting/checks.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/checks.py
@@ -77,14 +77,27 @@ def splitting_consistency_check(check_list: List[ConsistencyInput]):
         raise MultiException(errors)
 
 
-def check_for_repeated_planes(timeseries_tiff_path: Path):
+def check_for_repeated_planes(timeseries_tiff: MesoscopeTiff):
+    """checks that the timeseries tiff has unique z values for all
+    recorded z planes.
+
+    Parameters
+    ----------
+    timeseries_tiff: MesoscopeTiff
+        an instance created from a session timeseries tiff - a tiff
+        with the multiplexed experiment frames interleaved.
+
+    Raises
+    ------
+    ValueError
+        if there are repeated z values
+
     """
-    """
-    mt = MesoscopeTiff(timeseries_tiff_path)
-    u_plane_scans, counts = np.unique(mt.plane_scans, return_counts=True)
-    if mt.plane_scans.size != u_plane_scans.size:
+    u_plane_scans, counts = np.unique(timeseries_tiff.plane_scans,
+                                      return_counts=True)
+    if timeseries_tiff.plane_scans.size != u_plane_scans.size:
         result = [{"z_value": z, "count": c}
                   for z, c in zip(u_plane_scans, counts)]
         dframe = pd.DataFrame.from_records(result).set_index("z_value")
-        raise ValueError(f"{timeseries_tiff_path} has a repeated plane z "
+        raise ValueError(f"{timeseries_tiff._source} has a repeated plane z "
                          f"value:\n {dframe}")

--- a/tests/modules/mesoscope_splitting/test_checks.py
+++ b/tests/modules/mesoscope_splitting/test_checks.py
@@ -1,5 +1,7 @@
 import json
 import pytest
+import numpy as np
+from pathlib import Path
 from contextlib import nullcontext
 
 import ophys_etl.modules.mesoscope_splitting.checks as checks
@@ -83,3 +85,20 @@ def test_splitting_consistency_check(mock_tiff_list, roi_indices,
               for tiff, roi_index in zip(mock_tiff_list, roi_indices)]
     with context:
         checks.splitting_consistency_check(mylist)
+
+
+class MockMesoscopeTiff():
+    def __init__(self, path):
+        return
+
+    @property
+    def plane_scans(self):
+        return np.array([-25, 15, 80, 90, 15, 120, 130, 180])
+
+
+def test_check_for_repeated_planes(monkeypatch, tmpdir):
+    placeholder = Path(tmpdir / "tmp.tiff")
+    monkeypatch.setattr(checks, "MesoscopeTiff", MockMesoscopeTiff)
+    with pytest.raises(ValueError,
+                       match=f"{placeholder.name} has a repeated*"):
+        checks.check_for_repeated_planes(placeholder)

--- a/tests/modules/mesoscope_splitting/test_checks.py
+++ b/tests/modules/mesoscope_splitting/test_checks.py
@@ -89,6 +89,7 @@ def test_splitting_consistency_check(mock_tiff_list, roi_indices,
 
 class MockMesoscopeTiff():
     def __init__(self, path):
+        self._source = path
         return
 
     @property
@@ -96,9 +97,8 @@ class MockMesoscopeTiff():
         return np.array([-25, 15, 80, 90, 15, 120, 130, 180])
 
 
-def test_check_for_repeated_planes(monkeypatch, tmpdir):
+def test_check_for_repeated_planes(tmpdir):
     placeholder = Path(tmpdir / "tmp.tiff")
-    monkeypatch.setattr(checks, "MesoscopeTiff", MockMesoscopeTiff)
     with pytest.raises(ValueError,
                        match=f"{placeholder.name} has a repeated*"):
-        checks.check_for_repeated_planes(placeholder)
+        checks.check_for_repeated_planes(MockMesoscopeTiff(placeholder))


### PR DESCRIPTION
When a mesoscope timeseries tiff has a repeated z-plane, the mesoscope splitting code calculates an incorrect stride through the image stack. The resulting experiment video files then improperly sample frames from multiple imaging planes, instead of distinct ones.
The operators have been instructed not to do this. This PR establishes a check for this mistaken setting and raises an exception with an informative message, for quick comprehension of the problem and feedback to the imaging team.
```
ValueError: /allen/aibs/informatics/waynew/mesoscope/1107373623_timeseries.tiff has a repeated plane z value:
          count
z_value       
-25          1
 15          2
 80          1
 90          1
 120         1
 130         1
 180         1
```