### PR TITLE
Full/fov/movies

### DIFF
--- a/notebooks/segmentation/segmentation_inspection.ipynb
+++ b/notebooks/segmentation/segmentation_inspection.ipynb
@@ -433,6 +433,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Display full field of view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "full_fov = video_generator.get_thumbnail_video(origin=(0,0), frame_shape=None, quality=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "Video(**display_generator.display_video(full_fov, width=512, height=512))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Get and display a random thumbnail by hand"
    ]
   },
@@ -443,8 +470,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "thumbnail = video_generator.get_thumbnail_video(origin=(100, 200), frame_shape=(64, 64),\n",
-    "                                          quality=5)"
+    "by_hand_thumbnail = video_generator.get_thumbnail_video(origin=(100, 200), frame_shape=(64, 64),\n",
+    "                                                        quality=5)"
    ]
   },
   {
@@ -454,7 +481,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "Video(**display_generator.display_video(thumbnail))"
+    "Video(**display_generator.display_video(by_hand_thumbnail))"
    ]
   },
   {
@@ -521,7 +548,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "roi_thumbnail = video_generator.get_thumbnail_video_from_roi(roi, padding=20, roi_color=(255,0,0), quality=9)"
+    "padded_roi_thumbnail = video_generator.get_thumbnail_video_from_roi(roi, padding=20, roi_color=(255,0,0), quality=7)"
    ]
   },
   {
@@ -531,7 +558,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "Video(**display_generator.display_video(roi_thumbnail, width=512, height=512))"
+    "Video(**display_generator.display_video(padded_roi_thumbnail, width=512, height=512))"
    ]
   },
   {

--- a/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
@@ -54,7 +54,7 @@ def example_unnormalized_rgb_video():
 @pytest.fixture
 def chunked_video_path(tmpdir):
     fname = tempfile.mkstemp(dir=tmpdir,
-                             prefix='example_large_video_',
+                             prefix='example_large_video_chunked_',
                              suffix='.h5')[1]
     rng = np.random.RandomState(22312)
     with h5py.File(fname, 'w') as out_file:
@@ -70,6 +70,23 @@ def chunked_video_path(tmpdir):
             dataset[chunk] = arr
 
     yield pathlib.Path(fname)
+
+
+@pytest.fixture
+def unchunked_video_path(tmpdir):
+    fname = tempfile.mkstemp(dir=tmpdir,
+                             prefix='example_large_video_unchunked_',
+                             suffix='.h5')[1]
+    rng = np.random.RandomState(714432)
+    with h5py.File(fname, 'w') as out_file:
+        data = rng.randint(0, 65536, size=(1014, 115, 127)).astype(np.uint16)
+        dataset = out_file.create_dataset('data',
+                                          data=data,
+                                          chunks=None,
+                                          dtype=np.uint16)
+
+    yield pathlib.Path(fname)
+
 
 
 @pytest.mark.parametrize("data_fixture", ["example_video",

--- a/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
@@ -680,12 +680,41 @@ def test_video_bounds_from_ROI(padding, x0, y0, height, width):
 @pytest.mark.parametrize(
          'normalization, geometry',
          product(({'quantiles': None, 'min_max': (10, 5000)},
-                  {'quantiles': (0.1, 0.9), 'min_max': None}),
+                  {'quantiles': (0.1, 0.9), 'min_max': None},
+                  {'quantiles': None, 'min_max': None},
+                  {'quantiles': (0.1, 0.9), 'min_max': (10, 5000)}),
                  ({'origin': (0, 0), 'frame_shape': (115, 127)},
                   {'origin': (50, 50), 'frame_shape': (30, 42)})))
 def test_read_and_scale_all_at_once(chunked_video_path,
                                     normalization,
                                     geometry):
+
+    if normalization['quantiles'] is None and normalization['min_max'] is None:
+        with pytest.raises(RuntimeError,
+                           match='must specify either quantiles'):
+
+            actual = _read_and_scale_all_at_once(
+                        chunked_video_path,
+                        geometry['origin'],
+                        geometry['frame_shape'],
+                        quantiles=normalization['quantiles'],
+                        min_max=normalization['min_max'])
+        return
+
+    elif (normalization['quantiles'] is not None
+          and normalization['min_max'] is not None):
+
+        with pytest.raises(RuntimeError,
+                           match='cannot specify both quantiles'):
+
+            actual = _read_and_scale_all_at_once(
+                        chunked_video_path,
+                        geometry['origin'],
+                        geometry['frame_shape'],
+                        quantiles=normalization['quantiles'],
+                        min_max=normalization['min_max'])
+        return
+
     with h5py.File(chunked_video_path, 'r') as in_file:
         full_data = in_file['data'][()]
         if normalization['quantiles'] is not None:
@@ -712,12 +741,47 @@ def test_read_and_scale_all_at_once(chunked_video_path,
 @pytest.mark.parametrize(
          'normalization, geometry',
          product(({'quantiles': None, 'min_max': (10, 5000)},
-                  {'quantiles': (0.1, 0.9), 'min_max': None}),
+                  {'quantiles': (0.1, 0.9), 'min_max': None},
+                  {'quantiles': None, 'min_max': None},
+                  {'quantiles': (0.1, 0.9), 'min_max': (10, 5000)}),
                  ({'origin': (0, 0), 'frame_shape': (115, 127)},
                   {'origin': (50, 50), 'frame_shape': (30, 42)})))
 def test_read_and_scale_by_chunks(chunked_video_path,
                                   normalization,
                                   geometry):
+    if normalization['quantiles'] is None and normalization['min_max'] is None:
+        with pytest.raises(RuntimeError,
+                           match='must specify either quantiles'):
+
+            actual = _read_and_scale_by_chunks(
+                        chunked_video_path,
+                        geometry['origin'],
+                        geometry['frame_shape'],
+                        quantiles=normalization['quantiles'],
+                        min_max=normalization['min_max'])
+        return
+
+    elif (normalization['quantiles'] is not None
+          and normalization['min_max'] is not None):
+
+        with pytest.raises(RuntimeError,
+                           match='cannot specify both quantiles'):
+
+            actual = _read_and_scale_by_chunks(
+                        chunked_video_path,
+                        geometry['origin'],
+                        geometry['frame_shape'],
+                        quantiles=normalization['quantiles'],
+                        min_max=normalization['min_max'])
+        return
+
+    actual = _read_and_scale_by_chunks(
+                    chunked_video_path,
+                    geometry['origin'],
+                    geometry['frame_shape'],
+                    quantiles=normalization['quantiles'],
+                    min_max=normalization['min_max'])
+
     with h5py.File(chunked_video_path, 'r') as in_file:
         full_data = in_file['data'][()]
         if normalization['quantiles'] is not None:
@@ -731,25 +795,47 @@ def test_read_and_scale_by_chunks(chunked_video_path,
     full_data = full_data[:, r0:r1, c0:c1]
     expected = scale_video_to_uint8(full_data, min_max[0], min_max[1])
 
-    actual = _read_and_scale_by_chunks(
-                    chunked_video_path,
-                    geometry['origin'],
-                    geometry['frame_shape'],
-                    quantiles=normalization['quantiles'],
-                    min_max=normalization['min_max'])
-
     np.testing.assert_array_equal(actual, expected)
 
 
 @pytest.mark.parametrize(
          'normalization, geometry',
          product(({'quantiles': None, 'min_max': (10, 5000)},
-                  {'quantiles': (0.1, 0.9), 'min_max': None}),
+                  {'quantiles': (0.1, 0.9), 'min_max': None},
+                  {'quantiles': None, 'min_max': None},
+                  {'quantiles': (0.1, 0.9), 'min_max': (10, 5000)}),
                  ({'origin': (0, 0), 'frame_shape': (115, 127)},
                   {'origin': (50, 50), 'frame_shape': (30, 42)})))
 def test_read_and_scale(chunked_video_path,
                         normalization,
                         geometry):
+
+    if normalization['quantiles'] is None and normalization['min_max'] is None:
+        with pytest.raises(RuntimeError,
+                           match='must specify either quantiles'):
+
+            actual = read_and_scale(
+                        chunked_video_path,
+                        geometry['origin'],
+                        geometry['frame_shape'],
+                        quantiles=normalization['quantiles'],
+                        min_max=normalization['min_max'])
+        return
+
+    elif (normalization['quantiles'] is not None
+          and normalization['min_max'] is not None):
+
+        with pytest.raises(RuntimeError,
+                           match='cannot specify both quantiles'):
+
+            actual = read_and_scale(
+                        chunked_video_path,
+                        geometry['origin'],
+                        geometry['frame_shape'],
+                        quantiles=normalization['quantiles'],
+                        min_max=normalization['min_max'])
+        return
+
     with h5py.File(chunked_video_path, 'r') as in_file:
         full_data = in_file['data'][()]
         if normalization['quantiles'] is not None:


### PR DESCRIPTION
#247 has as one of its validation criteria "embed webm artifacts in notebook"

I naively tried that. The playback was not smooth. The webm artifact I tried was about 200 MB, which looks like it might be near a threshold beyond which `IPython.display.Video` starts to have trouble.

In the past, `video_utils.py` was able to produce thumbnails of the full field of view, but the process of scaling the videos to uint8 took up many tens of GB of memory. This PR adds a function which, if the field of view is too large, scales the video one chunk at a time. Now the memory requirement to generate a full field of view mp4 is a few GB.

Using this infrastructure lets us get around the clunky playback by setting the `quality` kwarg that gets passed to ffmpeg to something lower than perfect (7 seems to give good results). I propose we use this method to incorporate full field of view videos into the QC notebook.

This PR adds cells to the notebook to play appropriately scaled full field of view videos.