### PR TITLE
adds EM coregistration planes to notebook

### DIFF
--- a/notebooks/segmentation/segmentation_inspection.ipynb
+++ b/notebooks/segmentation/segmentation_inspection.ipynb
@@ -40,6 +40,8 @@
     "                  788422859, 795901850, 788422825, 795897800, 850517348,\n",
     "                  951980473, 951980484, 795901895, 806862946, 803965468,\n",
     "                  806928824]\n",
+    "# EM coregistration experiments:\n",
+    "experiment_ids += [795012008, 795011996]\n",
     "metadata_files = [basedir / f\"ophys_experiment_{i}\" / \"metadata.csv\" for i in experiment_ids]"
    ]
   },
@@ -650,7 +652,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
2 experiments added to notebook that reflect current EM co-registration efforts.

TODO:
- [x] experiments are deep-denoised
- [x] metadata.csv exists
- [x] projection background images exist
- [x] production ROIs in json on disk
- [ ] new segmentation results