### PR TITLE
Bugfix/video utils/open files

### DIFF
--- a/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
@@ -36,8 +36,8 @@ def example_video():
 
 
 @pytest.fixture(scope='session')
-def example_video_path(example_video):
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+def example_video_path(tmpdir_factory, example_video):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('example_video'))
     base_fname = tempfile.mkstemp(dir=tmpdir,
                                   prefix='example_video_',
                                   suffix='.h5')[1]
@@ -70,8 +70,9 @@ def example_unnormalized_rgb_video():
 
 @pytest.fixture(scope='session')
 def example_unnormalized_rgb_video_path(
+        tmpdir_factory,
         example_unnormalized_rgb_video):
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('eg_unnorm_rgb_video'))
     # write video to a tempfile
     h5_fname = tempfile.mkstemp(dir=tmpdir,
                                 prefix='example_unnormalized_rgb_video_',
@@ -88,8 +89,8 @@ def example_unnormalized_rgb_video_path(
 
 
 @pytest.fixture(scope='session')
-def chunked_video_path():
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+def chunked_video_path(tmpdir_factory):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('chunked_video'))
     fname = tempfile.mkstemp(dir=tmpdir,
                              prefix='example_large_video_chunked_',
                              suffix='.h5')[1]
@@ -115,8 +116,8 @@ def chunked_video_path():
 
 
 @pytest.fixture(scope='session')
-def unchunked_video_path():
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+def unchunked_video_path(tmpdir_factory):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('unchunked_video'))
     fname = tempfile.mkstemp(dir=tmpdir,
                              prefix='example_large_video_unchunked_',
                              suffix='.h5')[1]

--- a/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
@@ -37,7 +37,7 @@ def example_video():
 
 @pytest.fixture(scope='session')
 def example_video_path(example_video):
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = pathlib.Path(tempfile.mkdtemp())
     base_fname = tempfile.mkstemp(dir=tmpdir,
                                   prefix='example_video_',
                                   suffix='.h5')[1]
@@ -49,6 +49,7 @@ def example_video_path(example_video):
         yield base_fname
     finally:
         base_fname.unlink()
+        tmpdir.rmdir()
 
 
 @pytest.fixture
@@ -70,7 +71,7 @@ def example_unnormalized_rgb_video():
 @pytest.fixture(scope='session')
 def example_unnormalized_rgb_video_path(
         example_unnormalized_rgb_video):
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = pathlib.Path(tempfile.mkdtemp())
     # write video to a tempfile
     h5_fname = tempfile.mkstemp(dir=tmpdir,
                                 prefix='example_unnormalized_rgb_video_',
@@ -83,11 +84,12 @@ def example_unnormalized_rgb_video_path(
         yield h5_fname
     finally:
         h5_fname.unlink()
+        tmpdir.rmdir()
 
 
 @pytest.fixture(scope='session')
 def chunked_video_path():
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = pathlib.Path(tempfile.mkdtemp())
     fname = tempfile.mkstemp(dir=tmpdir,
                              prefix='example_large_video_chunked_',
                              suffix='.h5')[1]
@@ -109,11 +111,12 @@ def chunked_video_path():
         yield fname
     finally:
         fname.unlink()
+        tmpdir.rmdir()
 
 
 @pytest.fixture(scope='session')
 def unchunked_video_path():
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = pathlib.Path(tempfile.mkdtemp())
     fname = tempfile.mkstemp(dir=tmpdir,
                              prefix='example_large_video_unchunked_',
                              suffix='.h5')[1]
@@ -130,6 +133,7 @@ def unchunked_video_path():
         yield fname
     finally:
         fname.unlink()
+        tmpdir.rmdir()
 
 
 @pytest.mark.parametrize("data_fixture", ["example_video",

--- a/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
@@ -45,11 +45,9 @@ def example_video_path(tmpdir_factory, example_video):
         out_file.create_dataset('data',
                                 data=example_video)
     base_fname = pathlib.Path(base_fname)
-    try:
-        yield base_fname
-    finally:
-        base_fname.unlink()
-        tmpdir.rmdir()
+    yield base_fname
+    base_fname.unlink()
+    tmpdir.rmdir()
 
 
 @pytest.fixture
@@ -81,11 +79,9 @@ def example_unnormalized_rgb_video_path(
         out_file.create_dataset('data', data=example_unnormalized_rgb_video)
 
     h5_fname = pathlib.Path(h5_fname)
-    try:
-        yield h5_fname
-    finally:
-        h5_fname.unlink()
-        tmpdir.rmdir()
+    yield h5_fname
+    h5_fname.unlink()
+    tmpdir.rmdir()
 
 
 @pytest.fixture(scope='session')
@@ -108,11 +104,9 @@ def chunked_video_path(tmpdir_factory):
             dataset[chunk] = arr
 
     fname = pathlib.Path(fname)
-    try:
-        yield fname
-    finally:
-        fname.unlink()
-        tmpdir.rmdir()
+    yield fname
+    fname.unlink()
+    tmpdir.rmdir()
 
 
 @pytest.fixture(scope='session')
@@ -130,11 +124,9 @@ def unchunked_video_path(tmpdir_factory):
                                 dtype=np.uint16)
 
     fname = pathlib.Path(fname)
-    try:
-        yield fname
-    finally:
-        fname.unlink()
-        tmpdir.rmdir()
+    yield fname
+    fname.unlink()
+    tmpdir.rmdir()
 
 
 @pytest.mark.parametrize("data_fixture", ["example_video",

--- a/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_segmentation_video_utils.py
@@ -26,13 +26,29 @@ from ophys_etl.modules.segmentation.qc_utils.video_utils import (
     read_and_scale)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def example_video():
     rng = np.random.RandomState(16412)
     data = rng.randint(0, 100, (100, 60, 60)).astype(np.uint8)
     for ii in range(100):
         data[ii, ::, :] = ii
     return data
+
+
+@pytest.fixture(scope='session')
+def example_video_path(example_video):
+    tmpdir = tempfile.mkdtemp()
+    base_fname = tempfile.mkstemp(dir=tmpdir,
+                                  prefix='example_video_',
+                                  suffix='.h5')[1]
+    with h5py.File(base_fname, 'w') as out_file:
+        out_file.create_dataset('data',
+                                data=example_video)
+    base_fname = pathlib.Path(base_fname)
+    try:
+        yield base_fname
+    finally:
+        base_fname.unlink()
 
 
 @pytest.fixture
@@ -44,15 +60,34 @@ def example_rgb_video():
     return data
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def example_unnormalized_rgb_video():
     rng = np.random.RandomState(6125321)
     data = rng.randint(0, 700, (100, 60, 60, 3))
     return data
 
 
-@pytest.fixture
-def chunked_video_path(tmpdir):
+@pytest.fixture(scope='session')
+def example_unnormalized_rgb_video_path(
+        example_unnormalized_rgb_video):
+    tmpdir = tempfile.mkdtemp()
+    # write video to a tempfile
+    h5_fname = tempfile.mkstemp(dir=tmpdir,
+                                prefix='example_unnormalized_rgb_video_',
+                                suffix='.h5')[1]
+    with h5py.File(h5_fname, 'w') as out_file:
+        out_file.create_dataset('data', data=example_unnormalized_rgb_video)
+
+    h5_fname = pathlib.Path(h5_fname)
+    try:
+        yield h5_fname
+    finally:
+        h5_fname.unlink()
+
+
+@pytest.fixture(scope='session')
+def chunked_video_path():
+    tmpdir = tempfile.mkdtemp()
     fname = tempfile.mkstemp(dir=tmpdir,
                              prefix='example_large_video_chunked_',
                              suffix='.h5')[1]
@@ -69,11 +104,16 @@ def chunked_video_path(tmpdir):
                                chunk[2].stop-chunk[2].start))
             dataset[chunk] = arr
 
-    yield pathlib.Path(fname)
+    fname = pathlib.Path(fname)
+    try:
+        yield fname
+    finally:
+        fname.unlink()
 
 
-@pytest.fixture
-def unchunked_video_path(tmpdir):
+@pytest.fixture(scope='session')
+def unchunked_video_path():
+    tmpdir = tempfile.mkdtemp()
     fname = tempfile.mkstemp(dir=tmpdir,
                              prefix='example_large_video_unchunked_',
                              suffix='.h5')[1]
@@ -85,7 +125,11 @@ def unchunked_video_path(tmpdir):
                                 chunks=None,
                                 dtype=np.uint16)
 
-    yield pathlib.Path(fname)
+    fname = pathlib.Path(fname)
+    try:
+        yield fname
+    finally:
+        fname.unlink()
 
 
 @pytest.mark.parametrize("data_fixture", ["example_video",
@@ -405,6 +449,7 @@ def test_thumbnail_from_roi(tmpdir, example_video, timesteps, padding):
                           ])
 def test_thumbnail_from_path(tmpdir,
                              example_unnormalized_rgb_video,
+                             example_unnormalized_rgb_video_path,
                              min_max,
                              quantiles,
                              timesteps):
@@ -412,18 +457,13 @@ def test_thumbnail_from_path(tmpdir,
     Test thumbnail_from_path by comparing output to result
     from thumbnail_from_array
     """
+
     if timesteps is None:
         n_t = example_unnormalized_rgb_video.shape[0]
     else:
         n_t = len(timesteps)
 
-    # write video to a tempfile
-    h5_fname = tempfile.mkstemp(dir=tmpdir, prefix='input_video_',
-                                suffix='.h5')[1]
-    with h5py.File(h5_fname, 'w') as out_file:
-        out_file.create_dataset('data', data=example_unnormalized_rgb_video)
-
-    sub_video = example_unnormalized_rgb_video[:, 18:30, 14:29, :]
+    sub_video = np.copy(example_unnormalized_rgb_video[:, 18:30, 14:29, :])
 
     if quantiles is not None:
         local_min_max = np.quantile(example_unnormalized_rgb_video,
@@ -443,7 +483,7 @@ def test_thumbnail_from_path(tmpdir,
                        timesteps=timesteps)
 
     test_video = thumbnail_video_from_path(
-                     pathlib.Path(h5_fname),
+                     example_unnormalized_rgb_video_path,
                      (18, 14),
                      (12, 15),
                      tmp_dir=pathlib.Path(tmpdir),
@@ -487,6 +527,7 @@ def test_thumbnail_from_path(tmpdir,
                           ])
 def test_thumbnail_from_roi_and_path(tmpdir,
                                      example_unnormalized_rgb_video,
+                                     example_unnormalized_rgb_video_path,
                                      quantiles,
                                      min_max,
                                      roi_color,
@@ -509,11 +550,7 @@ def test_thumbnail_from_roi_and_path(tmpdir,
                      y=18, height=12,
                      mask=[list(i) for i in mask])
 
-    # write video to a tempfile
-    h5_fname = tempfile.mkstemp(dir=tmpdir, prefix='input_video_',
-                                suffix='.h5')[1]
-    with h5py.File(h5_fname, 'w') as out_file:
-        out_file.create_dataset('data', data=example_unnormalized_rgb_video)
+    h5_fname = example_unnormalized_rgb_video_path
 
     if quantiles is not None:
         local_min_max = np.quantile(example_unnormalized_rgb_video,
@@ -521,9 +558,10 @@ def test_thumbnail_from_roi_and_path(tmpdir,
     else:
         local_min_max = min_max
 
-    normalized_video = scale_video_to_uint8(example_unnormalized_rgb_video,
-                                            local_min_max[0],
-                                            local_min_max[1])
+    normalized_video = scale_video_to_uint8(
+                            np.copy(example_unnormalized_rgb_video),
+                            local_min_max[0],
+                            local_min_max[1])
 
     control_video = _thumbnail_video_from_ROI_array(
                        normalized_video,
@@ -534,7 +572,7 @@ def test_thumbnail_from_roi_and_path(tmpdir,
                        timesteps=timesteps)
 
     test_video = _thumbnail_video_from_ROI_path(
-                     pathlib.Path(h5_fname),
+                     h5_fname,
                      roi,
                      padding=padding,
                      roi_color=roi_color,
@@ -566,6 +604,7 @@ def test_thumbnail_from_roi_and_path(tmpdir,
                           (np.arange(22, 56), 10)])
 def test_generic_generation_from_ROI(tmpdir,
                                      example_video,
+                                     example_video_path,
                                      timesteps,
                                      padding):
     """
@@ -603,10 +642,7 @@ def test_generic_generation_from_ROI(tmpdir,
     read_data = imageio.mimread(th.video_path)
     assert len(read_data) == n_t
 
-    base_fname = tempfile.mkstemp(dir=tmpdir, suffix='.h5')[1]
-    with h5py.File(base_fname, 'w') as out_file:
-        out_file.create_dataset('data',
-                                data=example_video)
+    base_fname = example_video_path
 
     th = thumbnail_video_from_ROI(pathlib.Path(base_fname),
                                   roi,

--- a/tests/modules/segmentation/qc_utils/test_video_generator.py
+++ b/tests/modules/segmentation/qc_utils/test_video_generator.py
@@ -16,7 +16,7 @@ from ophys_etl.modules.segmentation.qc_utils.video_display_generator import (
 
 @pytest.fixture(scope='session')
 def example_video():
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = pathlib.Path(tempfile.mkdtemp())
     rng = np.random.RandomState(121311)
     nt = 100
     nrows = 50
@@ -32,6 +32,7 @@ def example_video():
         yield fname
     finally:
         fname.unlink()
+        tmpdir.rmdir()
 
 
 @pytest.fixture

--- a/tests/modules/segmentation/qc_utils/test_video_generator.py
+++ b/tests/modules/segmentation/qc_utils/test_video_generator.py
@@ -28,11 +28,9 @@ def example_video(tmpdir_factory):
     with h5py.File(fname, 'w') as out_file:
         out_file.create_dataset('data', data=data)
     fname = pathlib.Path(fname)
-    try:
-        yield fname
-    finally:
-        fname.unlink()
-        tmpdir.rmdir()
+    yield fname
+    fname.unlink()
+    tmpdir.rmdir()
 
 
 @pytest.fixture

--- a/tests/modules/segmentation/qc_utils/test_video_generator.py
+++ b/tests/modules/segmentation/qc_utils/test_video_generator.py
@@ -14,17 +14,24 @@ from ophys_etl.modules.segmentation.qc_utils.video_display_generator import (
     VideoDisplayGenerator)
 
 
-@pytest.fixture
-def example_video(tmpdir):
+@pytest.fixture(scope='session')
+def example_video():
+    tmpdir = tempfile.mkdtemp()
     rng = np.random.RandomState(121311)
     nt = 100
     nrows = 50
     ncols = 50
     data = rng.randint(0, 1000, (nt, nrows, ncols))
-    fname = tempfile.mkstemp(dir=tmpdir, suffix='.h5')[1]
+    fname = tempfile.mkstemp(dir=tmpdir,
+                             prefix='video_generator_example_video_',
+                             suffix='.h5')[1]
     with h5py.File(fname, 'w') as out_file:
         out_file.create_dataset('data', data=data)
-    yield fname
+    fname = pathlib.Path(fname)
+    try:
+        yield fname
+    finally:
+        fname.unlink()
 
 
 @pytest.fixture
@@ -114,6 +121,10 @@ def test_get_thumbnail_video(tmpdir,
     assert not expected.video_path == thumbnail.video_path
     compare_hashes(expected.video_path, thumbnail.video_path)
 
+    del thumbnail
+    del expected
+    del generator
+
 
 @pytest.mark.parametrize('roi_color, timesteps, padding',
                          product((None, (122, 201, 53)),
@@ -163,6 +174,10 @@ def test_get_thumbnail_video_from_roi(
     assert not expected.video_path == thumbnail.video_path
     compare_hashes(expected.video_path, thumbnail.video_path)
 
+    del thumbnail
+    del expected
+    del generator
+
 
 def test_video_display_generator(tmpdir, example_video, example_roi):
     """
@@ -199,3 +214,6 @@ def test_video_display_generator(tmpdir, example_video, example_roi):
     assert sym_path.resolve() == thumbnail.video_path.resolve()
     assert sym_path.is_symlink()
     assert sym_path.absolute() != thumbnail.video_path.absolute()
+
+    del thumbnail
+    del generator

--- a/tests/modules/segmentation/qc_utils/test_video_generator.py
+++ b/tests/modules/segmentation/qc_utils/test_video_generator.py
@@ -15,8 +15,8 @@ from ophys_etl.modules.segmentation.qc_utils.video_display_generator import (
 
 
 @pytest.fixture(scope='session')
-def example_video():
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+def example_video(tmpdir_factory):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('eg_video'))
     rng = np.random.RandomState(121311)
     nt = 100
     nrows = 50


### PR DESCRIPTION
This fixes the bug in which qc_utils/video tests fail because too many files are open by converting the test data for those tests into session level fixtures, which only have to be created once per test session (as opposed to being recreated each time a test function is run)