### PR TITLE
Danielsf/roi growth dev synthetic data

### DIFF
--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
@@ -5,6 +5,7 @@ from sklearn.preprocessing import StandardScaler
 
 from ophys_etl.utils.array_utils import pairwise_distances
 
+
 def choose_timesteps(
             sub_video: np.ndarray,
             i_seed: int,

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
@@ -1,9 +1,9 @@
 from typing import Optional, Tuple
-from scipy.spatial.distance import cdist
 import numpy as np
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 
+from ophys_etl.utils.array_utils import pairwise_distances
 
 def choose_timesteps(
             sub_video: np.ndarray,
@@ -505,9 +505,7 @@ class PotentialROI(object):
                                      pixel_ignore=pixel_ignore,
                                      rng=rng)
 
-        self.feature_distances = cdist(features,
-                                       features,
-                                       metric='euclidean')
+        self.feature_distances = pairwise_distances(features)
 
     def select_pixels(self) -> bool:
         """

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
@@ -531,11 +531,11 @@ class PotentialROI(object):
 
         3) For every candidate pixel, find the n_roi background pixels that
         are closest to it in feature space (n_roi is the number of pixels
-        currently in the ROI). The median of these distances is the
-        candidate pixel's distance from the background.
+        currently in the ROI).
 
-        4) Any pixel whose background distance is more than twice its
-        ROI distance is added to the ROI
+        4) Any pixel whose distance to the ROI (from step (2)) has a z-score
+        of less than -2 relative to the distribution of its distances from
+        background pixels (from step (3)) is added to the ROI.
         """
         chose_one = False
 

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
@@ -550,9 +550,14 @@ class PotentialROI(object):
         # take the median of the n_roi nearest background distances;
         # hopefully this will limit the effect of outliers
         d_bckgd = np.sort(self.feature_distances[:, background_mask], axis=1)
-        d_bckgd = np.median(d_bckgd[:, :n_roi], axis=1)
+        if n_roi > 20:
+            d_bckgd = d_bckgd[:, :n_roi]
 
-        valid = d_bckgd > 2*d_roi
+        mu_d_bckgd = np.mean(d_bckgd, axis=1)
+        std_d_bckgd = np.std(d_bckgd, axis=1, ddof=1)
+        z_score = (d_roi-mu_d_bckgd)/std_d_bckgd
+
+        valid = z_score <= -2.0
         if valid.sum() > 0:
             self.roi_mask[valid] = True
 

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -322,7 +322,8 @@ class FeatureVectorSegmenter(object):
             roi = convert_to_lims_roi(origin,
                                       mask,
                                       roi_id=roi_id)
-            self.roi_list.append(roi)
+            if mask.sum() > 1:
+                self.roi_list.append(roi)
             for ir in range(mask.shape[0]):
                 rr = origin[0]+ir
                 for ic in range(mask.shape[1]):
@@ -425,7 +426,8 @@ class FeatureVectorSegmenter(object):
 
             msg = f'Completed iteration with {len(roi_seeds)} ROIs '
             msg += f'after {duration:.2f} seconds; '
-            msg += f'{self.roi_pixels.sum()} total ROI pixels'
+            msg += f'{self.roi_pixels.sum()} total ROI pixels; '
+            msg += f'{len(self.roi_list)} valid ROIs'
             logger.info(msg)
 
             if seed_output is not None:

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -291,7 +291,7 @@ class FeatureVectorSegmenter(object):
 
         # in case we end up retrying ROIs, make sure we can
         # grow their available thumbnails
-        seed_to_slop = {}
+        seed_to_slop = dict()
 
         # NOTE: we should rewrite run() and _run() so that they can
         # use the parallel seed iterator like
@@ -323,7 +323,7 @@ class FeatureVectorSegmenter(object):
 
         # lookup from ROI ID to seed and size of ROI
         # thumbnail
-        roi_inputs = {}
+        roi_inputs = dict()
 
         logger.info(f'got {len(seed_list)} seeds')
 
@@ -334,11 +334,7 @@ class FeatureVectorSegmenter(object):
         mgr_dict = mgr.dict()
         for i_seed, seed in enumerate(seed_list):
             self.roi_id += 1
-
-            if seed in seed_to_slop:
-                slop = seed_to_slop[seed]
-            else:
-                slop = default_slop
+            slop = seed_to_slop.get(seed, default_slop)
 
             roi_inputs[self.roi_id] = {'seed': seed,
                                        'slop': slop}

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -423,17 +423,23 @@ class FeatureVectorSegmenter(object):
                 break
 
             duration = time.time()-t0
+            n_valid_pix = 0
+            for roi in self.roi_list:
+                m = np.array(roi['mask'])
+                n_valid_pix += m.sum()
 
             msg = f'Completed iteration with {len(roi_seeds)} ROIs '
             msg += f'after {duration:.2f} seconds; '
             msg += f'{self.roi_pixels.sum()} total ROI pixels; '
-            msg += f'{len(self.roi_list)} valid ROIs'
+            msg += f'{len(self.roi_list)} valid ROIs ({n_valid_pix}) pixels'
             logger.info(msg)
 
             if seed_output is not None:
                 seed_record[i_iteration] = roi_seeds
 
             i_iteration += 1
+            #if i_iteration > 7:
+            #    break
 
         logger.info('finished iterating on ROIs')
 

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -322,6 +322,7 @@ class FeatureVectorSegmenter(object):
                 seed_list = []
 
         default_slop = 20
+        max_slop = 50
 
         # lookup from ROI ID to seed and size of ROI
         # thumbnail
@@ -395,7 +396,7 @@ class FeatureVectorSegmenter(object):
             at_edge = _is_roi_at_edge(origin,
                                       video_data.shape[1:],
                                       mask)
-            if at_edge:
+            if at_edge and roi_inputs[roi_id]['slop'] < max_slop:
                 self.roi_to_retry.append(roi_inputs[roi_id])
                 continue
 

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -310,9 +310,6 @@ class FeatureVectorSegmenter(object):
                 seed_list.append(roi['seed'])
                 seed_to_slop[roi['seed']] = 3*roi['slop']//2
 
-            logger.info(f'retrying rois {self.roi_to_retry}')
-            logger.info(f'retrying rois {seed_to_slop}')
-
             self.roi_to_retry = []
         else:
             # run with new seeds from the seeder

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -322,7 +322,7 @@ class FeatureVectorSegmenter(object):
                 seed_list = []
 
         default_slop = 20
-        max_slop = 50
+        max_slop = 40
 
         # lookup from ROI ID to seed and size of ROI
         # thumbnail

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -102,8 +102,48 @@ def _get_roi(seed_obj: ROISeed,
                     pixel_ignore=pixel_ignore)
 
     final_mask = roi.get_mask()
+
     output_dict[roi_id] = (origin, final_mask)
     return None
+
+
+def _is_roi_at_edge(origin: Tuple[int, int],
+                    fov_shape: Tuple[int, int],
+                    mask: np.ndarray) -> bool:
+    """
+    Check if an ROI grew to the edge of its thumbnail (in which
+    case the ROI should be attempted again with a larger thumbnail)
+
+    Parameters
+    ----------
+    origin: Tuple[int, int]
+        (row, col) coordinates of the ROI thumbnail's origin
+
+    fov_shape: Tuple[int, int]
+        (nrows, ncols) of the full video field of view
+
+    mask: np.ndarray
+        2D array of booleans encoding the ROI's mask
+
+    Returns
+    -------
+    at_edge: boolean
+       True if there are any pixels marked 'True' in the extremal
+       edge of the thumbnail *and* there is room for the thumbnail
+       to grow beyond that extremal edge (i.e. if the origin is at
+       (0, 0) and there are True pixels in the first column, there
+       are no columns available to the left of the origin, so
+       return False). Return False otherwise.
+    """
+
+    shape = mask.shape
+
+    first_row = (origin[0] > 0) & mask[0, :].any()
+    last_row = (origin[0]+shape[0] < fov_shape[0]) & mask[-1, :].any()
+    first_col = (origin[1] > 0) & mask[:, 0].any()
+    last_col = (origin[1]+shape[1] < fov_shape[1]) & mask[:, -1].any()
+
+    return first_row | last_row | first_col | last_col
 
 
 def convert_to_lims_roi(origin: Tuple[int, int],
@@ -249,6 +289,10 @@ class FeatureVectorSegmenter(object):
         appended to self.roi_list.
         """
 
+        # in case we end up retrying ROIs, make sure we can
+        # grow their available thumbnails
+        seed_to_slop = {}
+
         # NOTE: we should rewrite run() and _run() so that they can
         # use the parallel seed iterator like
         # ```
@@ -256,12 +300,32 @@ class FeatureVectorSegmenter(object):
         #     <farm out processes>
         # ```
         # for now:
-        try:
-            seed_list = next(self.seeder)
-        except StopIteration:
-            seed_list = []
 
-        slop = 20
+        if len(self.roi_to_retry) > 0:
+            # if there are ROIs from a previous iteration that filled
+            # their thumbnail, try those again first with a larger
+            # thumbnail
+            seed_list = []
+            for roi in self.roi_to_retry:
+                seed_list.append(roi['seed'])
+                seed_to_slop[roi['seed']] = 3*roi['slop']//2
+
+            logger.info(f'retrying rois {self.roi_to_retry}')
+            logger.info(f'retrying rois {seed_to_slop}')
+
+            self.roi_to_retry = []
+        else:
+            # run with new seeds from the seeder
+            try:
+                seed_list = next(self.seeder)
+            except StopIteration:
+                seed_list = []
+
+        default_slop = 20
+
+        # lookup from ROI ID to seed and size of ROI
+        # thumbnail
+        roi_inputs = {}
 
         logger.info(f'got {len(seed_list)} seeds')
 
@@ -272,6 +336,15 @@ class FeatureVectorSegmenter(object):
         mgr_dict = mgr.dict()
         for i_seed, seed in enumerate(seed_list):
             self.roi_id += 1
+
+            if seed in seed_to_slop:
+                slop = seed_to_slop[seed]
+            else:
+                slop = default_slop
+
+            roi_inputs[self.roi_id] = {'seed': seed,
+                                       'slop': slop}
+
             r0 = int(max(0, seed[0] - slop))
             r1 = int(min(self.movie_shape[0], seed[0] + slop))
             c0 = int(max(0, seed[1] - slop))
@@ -319,6 +392,13 @@ class FeatureVectorSegmenter(object):
         for roi_id in mgr_dict:
             origin = mgr_dict[roi_id][0]
             mask = mgr_dict[roi_id][1]
+            at_edge = _is_roi_at_edge(origin,
+                                      video_data.shape[1:],
+                                      mask)
+            if at_edge:
+                self.roi_to_retry.append(roi_inputs[roi_id])
+                continue
+
             roi = convert_to_lims_roi(origin,
                                       mask,
                                       roi_id=roi_id)
@@ -383,6 +463,9 @@ class FeatureVectorSegmenter(object):
         as pixels are added to the set of ROI pixels, return to (1)
         and continue.
         """
+
+        # list to keep track of ROIs that fill their thumbnail
+        self.roi_to_retry = []
 
         t0 = time.time()
 

--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -438,8 +438,6 @@ class FeatureVectorSegmenter(object):
                 seed_record[i_iteration] = roi_seeds
 
             i_iteration += 1
-            #if i_iteration > 7:
-            #    break
 
         logger.info('finished iterating on ROIs')
 

--- a/src/ophys_etl/modules/segmentation/modules/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/modules/feature_vector_segmentation.py
@@ -30,6 +30,7 @@ class FeatureVectorSegmentationRunner(argschema.ArgSchemaParser):
                 attribute=attr,
                 n_processors=n_processors,
                 roi_class=roi_class,
+                filter_fraction=self.args['filter_fraction'],
                 seeder_args=self.args['seeder_args'])
 
         if self.args['plot_output'] is not None:

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -297,6 +297,11 @@ class FeatureVectorSegmentationInputSchema(argschema.ArgSchema):
         validate=OneOf(["PearsonFeatureROI", "PCAFeatureROI"]),
         description="which class to use.")
 
+    filter_fraction = argschema.fields.Float(
+        required=False,
+        default=0.2,
+        description="fraction of timesteps to use in time correlation")
+
     @post_load
     def plot_outputs(self, data, **kwargs):
         if data['seed_plot_output'] is None:

--- a/src/ophys_etl/utils/array_utils.py
+++ b/src/ophys_etl/utils/array_utils.py
@@ -85,3 +85,34 @@ def normalize_array(
     normalized -= lower_cutoff
     normalized = np.uint8(normalized * 255 / (upper_cutoff - lower_cutoff))
     return normalized
+
+
+def pairwise_distances(points: np.ndarray) -> np.ndarray:
+    """
+    Calculate all of the pairwise distances between the rows
+    in a np.ndarray
+
+    Parameters
+    ----------
+    points: np.ndarray
+        Shape is (n_points, n_dimensions)
+
+    Returns
+    -------
+    distances: np.ndarray
+        A (n_points, n_points) array. The i,jth element
+        is the Euclidean distance between the ith and jth
+        rows of the input points.
+
+    Notes
+    -----
+    As n_points, n_dimensions approach a few thousand, this is
+    several orders of magnitude faster than scipy.distances.cdist
+    """
+    p_dot_p = np.dot(points, points.T)
+    dsq = np.zeros((points.shape[0], points.shape[0]), dtype=float)
+    for ii in range(points.shape[0]):
+        dsq[ii, :] += p_dot_p[ii, ii]
+        dsq[:, ii] += p_dot_p[ii, ii]
+        dsq[ii, :] -= 2.0*p_dot_p[ii, :]
+    return np.sqrt(dsq)

--- a/tests/utils/test_array_utils.py
+++ b/tests/utils/test_array_utils.py
@@ -117,3 +117,16 @@ def test_downsample_exceptions(array, input_fps, output_fps, random_seed,
 def test_normalize_array(array, lower_cutoff, upper_cutoff, expected):
     normalized = au.normalize_array(array, lower_cutoff, upper_cutoff)
     np.testing.assert_array_equal(normalized, expected)
+
+
+def test_pairwise_distance():
+    rng = np.random.default_rng(77123)
+    data = rng.random((20, 72))
+    distances = au.pairwise_distances(data)
+    assert distances.shape == (20, 20)
+    eps = 1.0e-20
+    for ii in range(20):
+        for jj in range(ii, 20, 1):
+            expected = np.sqrt(np.sum((data[ii, :] - data[jj, :])**2))
+            assert np.abs((expected-distances[ii, jj])/(eps+expected)) < 1.0e-6
+            assert np.abs((expected-distances[jj, ii])/(eps+expected)) < 1.0e-6


### PR DESCRIPTION
This PR addresses ticket #279

To demonstrate the improvement, I ran the Feature Vector Segmenter on one of our synthetic data sets (a 3x3 grid of ROIs with monotonically decreasing SNR).  Here is what the results looked like before this PR

![three_by_three_baseline_roi_plot](https://user-images.githubusercontent.com/1682854/125559993-8bfa6764-41db-4d6f-b28d-0421fa3b76b0.png)

Here is what the results look like including the code in this PR

![three_by_three_zscore_roi_plot](https://user-images.githubusercontent.com/1682854/125560013-40cd9e87-726e-471d-8380-c5a6be7a1652.png)

Clearly, something is going on with the seeder, but the ROI growth phase has obviously improved.

Here is what we see running this PR on real data (the lower left quadrant shows the ROIs before merging; the lower right quadrant shows the ROIs after merging).

![795901850_merged_comparison](https://user-images.githubusercontent.com/1682854/125560373-813401e8-441b-4095-ba69-a9903bc718af.png)

The over-segmented ROIs are obviously less fragmented than they used to be. This probably has implications for the merging phase, but that is work to take on in another ticket (either #276 or #277).

Summary of changes in the algorithm:

- When growing ROIs pixels are evaluated based on the z-score of their parameter space distances from the sample of background pixels. If the median distance of the pixel from existing ROI pixels has a z-score of less than -2 relative to the distribution of its parameter space distances from background ROIs, the pixel is added to the ROI.
- ROIs with only one pixel are not added to the final list of found ROIs.
- If an ROI runs up against the edge of its field of potential pixels, it is re-grown with a larger field of potential pixels. Before this modification, there were cases when an ROI's field of potential pixels contained some very large other ROIs, skewing the distribution of background pixels, causing the new ROI grow to include all of the unmasked pixels, see, for instance:

![200_140_roi_plot](https://user-images.githubusercontent.com/1682854/125560977-05f899fd-4ba3-45a4-ae40-bb68c8dd301f.png)


