### PR TITLE
Segmentation/comparison/utils

### DIFF
--- a/src/ophys_etl/modules/decrosstalk/ophys_plane.py
+++ b/src/ophys_etl/modules/decrosstalk/ophys_plane.py
@@ -143,7 +143,7 @@ class OphysROI(object):
                                       in np.argwhere(self._mask_matrix)])
 
     @property
-    def pixel_set(self) -> Set[Tuple[int, int]]:
+    def global_pixel_set(self) -> Set[Tuple[int, int]]:
         """
         Set of pixels in global (row, col) coordinates
         that are set to True for this ROI
@@ -256,8 +256,8 @@ def intersection_over_union(roi0: OphysROI,
     -------
     iou: float
         """
-    pix0 = roi0.pixel_set
-    pix1 = roi1.pixel_set
+    pix0 = roi0.global_pixel_set
+    pix1 = roi1.global_pixel_set
     ii = len(pix0.intersection(pix1))
     uu = len(pix0.union(pix1))
     return float(ii)/float(uu)

--- a/src/ophys_etl/modules/decrosstalk/ophys_plane.py
+++ b/src/ophys_etl/modules/decrosstalk/ophys_plane.py
@@ -244,7 +244,7 @@ def intersection_over_union(roi0: OphysROI,
                             roi1: OphysROI) -> float:
     """
     Return the intersection over union of two ROIs relative
-    to each oterh
+    to each other
 
     Parameters
     ----------

--- a/src/ophys_etl/modules/decrosstalk/ophys_plane.py
+++ b/src/ophys_etl/modules/decrosstalk/ophys_plane.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union, Tuple
+from typing import List, Dict, Union, Tuple, Set
 import itertools
 import h5py
 import copy
@@ -84,6 +84,7 @@ class OphysROI(object):
         self._mask_matrix = np.array(mask_matrix, dtype=bool)
         self._boundary_mask = None
         self._area = None
+        self._global_pixel_set = None
 
         height_match = (self._mask_matrix.shape[0] == self._height)
         width_match = (self._mask_matrix.shape[1] == self._width)
@@ -131,6 +132,25 @@ class OphysROI(object):
                    height=schema_dict['height'],
                    valid_roi=schema_dict['valid_roi'],
                    mask_matrix=schema_dict['mask_matrix'])
+
+    def _create_global_pixel_set(self):
+        """
+        Create the set of (row, col) tuples in
+        global coordinates that make up this ROI
+        """
+        self._global_pixel_set = set([(r+self._y0, c+self._x0)
+                                      for r, c
+                                      in np.argwhere(self._mask_matrix)])
+
+    @property
+    def pixel_set(self) -> Set[Tuple[int, int]]:
+        """
+        Set of pixels in global (row, col) coordinates
+        that are set to True for this ROI
+        """
+        if self._global_pixel_set is None:
+            self._create_global_pixel_set()
+        return self._global_pixel_set
 
     @property
     def area(self) -> int:
@@ -218,6 +238,29 @@ class OphysROI(object):
         if self._boundary_mask is None:
             self._construct_boundary_mask()
         return np.copy(self._boundary_mask)
+
+
+def intersection_over_union(roi0: OphysROI,
+                            roi1: OphysROI) -> float:
+    """
+    Return the intersection over union of two ROIs relative
+    to each oterh
+
+    Parameters
+    ----------
+    roi0: OphysROI
+
+    roi1: OphysROI
+
+    Returns
+    -------
+    iou: float
+        """
+    pix0 = roi0.pixel_set
+    pix1 = roi1.pixel_set
+    ii = len(pix0.intersection(pix1))
+    uu = len(pix0.union(pix1))
+    return float(ii)/float(uu)
 
 
 class OphysMovie(object):

--- a/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
@@ -17,9 +17,12 @@ class ROIComparisonSchema(argschema.ArgSchema):
     background_names = argschema.fields.List(
             argschema.fields.String,
             cli_as_single_argument=True,
-            required=True,
+            required=False,
+            default=None,
+            allow_none=True,
             description=("names of background images as they are to appear "
-                         "in plot"))
+                         "in plot (if None, will use the basenames "
+                         "from the roi_paths)"))
 
     roi_paths = argschema.fields.List(
             argschema.fields.InputFile,
@@ -30,9 +33,12 @@ class ROIComparisonSchema(argschema.ArgSchema):
     roi_names = argschema.fields.List(
             argschema.fields.String,
             cli_as_single_argument=True,
-            required=True,
+            required=False,
+            default=None,
+            allow_none=True,
             description=("names of ROI sets as they are to appear "
-                         "in plot"))
+                         "in plot (if None, will use the basenames "
+                         "from the roi_paths)"))
 
     plot_output = argschema.fields.OutputFile(
             required=True,
@@ -47,6 +53,14 @@ class ROIComparisonSchema(argschema.ArgSchema):
 
     @post_load
     def verify_names_and_paths(self, data, **kwargs):
+
+        if data['roi_names'] is None:
+            data['roi_names'] = [str(pathlib.Path(pth).name)
+                                 for pth in data['roi_paths']]
+
+        if data['background_names'] is None:
+            data['background_names'] = [str(pathlib.Path(pth).name)
+                                        for pth in data['background_paths']]
         msg = ''
         is_valid = True
         if len(data['roi_names']) != len(data['roi_paths']):

--- a/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
@@ -1,5 +1,6 @@
 import pathlib
 import argschema
+from marshmallow import post_load
 
 from ophys_etl.modules.segmentation.qc_utils.roi_comparison_utils import (
     create_roi_v_background_grid)
@@ -43,6 +44,24 @@ class ROIComparisonSchema(argschema.ArgSchema):
             required=False,
             default='filtered_hnc_Gaussian',
             description=("name of attribute to plot in a background image"))
+
+    @post_load
+    def verify_names_and_paths(self, data, **kwargs):
+        msg = ''
+        is_valid = True
+        if len(data['roi_names']) != len(data['roi_paths']):
+            is_valid = False
+            msg += f"{len(data['roi_names'])} roi_names, but "
+            msg += f"{len(data['roi_paths'])} roi_paths; "
+            msg += "should be the same length\n"
+        if len(data['background_names']) != len(data['background_paths']):
+            is_valid = False
+            msg += f"{len(data['background_names'])} background_names, but "
+            msg += f"{len(data['background_paths'])} background_paths; "
+            msg += "should be the same length\n"
+        if not is_valid:
+            raise RuntimeError(msg)
+        return data
 
 
 class ROIComparisonEngine(argschema.ArgSchemaParser):

--- a/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
@@ -63,7 +63,6 @@ class ROIComparisonEngine(argschema.ArgSchemaParser):
 
         roi_paths = [pathlib.Path(p)
                      for p in self.args['roi_paths']]
-               
 
         fig = create_roi_v_background_grid(
                     bckgd_paths,

--- a/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
@@ -1,0 +1,81 @@
+import pathlib
+import argschema
+
+from ophys_etl.modules.segmentation.qc_utils.roi_comparison_utils import (
+    create_roi_v_background_grid)
+
+
+class ROIComparisonSchema(argschema.ArgSchema):
+
+    background_paths = argschema.fields.List(
+            argschema.fields.InputFile,
+            cli_as_single_argument=True,
+            required=True,
+            description=("list of paths to pkl or png background images"))
+
+    background_names = argschema.fields.List(
+            argschema.fields.String,
+            cli_as_single_argument=True,
+            required=True,
+            description=("names of background images as they are to appear "
+                         "in plot"))
+
+    roi_paths = argschema.fields.List(
+            argschema.fields.InputFile,
+            cli_as_single_argument=True,
+            required=True,
+            description=("list of paths to json files with ROIs to compare"))
+
+    roi_names = argschema.fields.List(
+            argschema.fields.String,
+            cli_as_single_argument=True,
+            required=True,
+            description=("names of ROI sets as they are to appear "
+                         "in plot"))
+
+    plot_output = argschema.fields.OutputFile(
+            required=True,
+            default=None,
+            allow_none=False,
+            description=("Where to save the output plot"))
+
+    attribute_name = argschema.fields.Str(
+            required=False,
+            default='filtered_hnc_Gaussian',
+            description=("name of attribute to plot in a background image"))
+
+
+class ROIComparisonEngine(argschema.ArgSchemaParser):
+
+    default_schema = ROIComparisonSchema
+
+    def run(self):
+
+        # colors that showup reasonably well against our
+        # grayscale background images
+        color_list = [(0, 255, 0),
+                      (255, 128, 0),
+                      (51, 255, 255),
+                      (255, 51, 255)]
+
+        bckgd_paths = [pathlib.Path(p)
+                       for p in self.args['background_paths']]
+
+        roi_paths = [pathlib.Path(p)
+                     for p in self.args['roi_paths']]
+               
+
+        fig = create_roi_v_background_grid(
+                    bckgd_paths,
+                    self.args['background_names'],
+                    roi_paths,
+                    self.args['roi_names'],
+                    color_list,
+                    attribute_name=self.args['attribute_name'])
+
+        fig.savefig(self.args['plot_output'])
+
+
+if __name__ == "__main__":
+    comparison_engine = ROIComparisonEngine()
+    comparison_engine.run()

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -272,9 +272,15 @@ def create_roi_v_background_grid(
             raise RuntimeError('Do not know how to parse background image file '
                                f'{this_bckgd}; must be either .png or .pkl')
 
+        if this_bckgd.suffix == '.png':
+            qtiles = np.quantile(background_array, (0.1, 0.999))
+        else:
+            qtiles = (0, background_array.max())
         background_array = scale_video_to_uint8(background_array,
-                                                0,
-                                                background_array.max())
+                                                qtiles[0],
+                                                qtiles[1])
+                                                #0,
+                                                #background_array.max())
 
         background_rgb = np.zeros((background_array.shape[0],
                                    background_array.shape[1],

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -192,10 +192,12 @@ def create_roi_summary_fig(
                                            fontsize=fontsize)
         axes[2*n_columns+i_column].imshow(matches_img)
         axes[2*n_columns+i_column].set_title(
-                 f'matches at iou={iou_threshold:.2f}', fontsize=fontsize)
+                 f'{roi_name} matches at iou={iou_threshold:.2f}',
+                 fontsize=fontsize)
         axes[3*n_columns+i_column].imshow(misses_img)
         axes[3*n_columns+i_column].set_title(
-                f'misses at iou={iou_threshold:.2f}', fontsize=fontsize)
+                f'{roi_name} misses at iou={iou_threshold:.2f}',
+                fontsize=fontsize)
 
     for ii in range(0,
                     background_array.shape[0],

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -1,0 +1,197 @@
+from typing import List, Dict, Union
+import matplotlib.figure as mplt_fig
+import pathlib
+import numpy as np
+import PIL.Image
+import json
+import copy
+
+from ophys_etl.modules.decrosstalk.ophys_plane import (
+    OphysROI,
+    intersection_over_union)
+
+from ophys_etl.modules.segmentation.graph_utils.conversion import (
+    graph_to_img)
+
+from ophys_etl.modules.segmentation.qc_utils.roi_utils import (
+    add_roi_boundaries_to_img,
+    convert_keys)
+
+from ophys_etl.modules.segmentation.qc_utils.video_utils import (
+    scale_video_to_uint8)
+
+
+def find_iou_roi_matches(baseline_roi_list: List[OphysROI],
+                         test_roi_list: List[OphysROI],
+                         iou_threshold: float) -> Dict[str, List[OphysROI]]:
+    """
+    Parameters
+    ----------
+    baseline_roi_list: List[OphysROI]
+
+    test_roi_list: List[OphysROI]
+
+    iou_threshold: float
+
+    Returns
+    -------
+    dict
+        'unmatched_baseline'
+        'unmatched_test'
+        'matched_baseline'
+        'matched_test'
+    """
+    print('finding matches')
+
+    baseline = copy.deepcopy(baseline_roi_list)
+    test = copy.deepcopy(test_roi_list)
+
+    matched_test = []
+    matched_baseline = []
+    unmatched_baseline = []
+
+    for baseline_roi in baseline:
+        candidate_indexes = []
+        candidate_iou = []
+        for ii, test_roi in enumerate(test):
+            iou = intersection_over_union(baseline_roi, test_roi)
+            if iou > iou_threshold:
+                candidate_iou.append(iou)
+                candidate_indexes.append(ii)
+        if len(candidate_iou) > 0:
+            best = np.argmax(candidate_iou)
+            matched_test.append(test.pop(candidate_indexes[best]))
+            matched_baseline.append(baseline_roi)
+        else:
+            unmatched_baseline.append(baseline_roi)
+
+    print('done')
+    return {'matched_test': matched_test,
+            'matched_baseline': matched_baseline,
+            'unmatched_test': test,
+            'unmatched_baseline': unmatched_baseline}
+
+
+def read_roi_list(file_path: pathlib.Path) -> List[OphysROI]:
+    output_list = []
+    with open(file_path, 'rb') as in_file:
+        roi_data_list = json.load(in_file)
+        roi_data_list = convert_keys(roi_data_list)
+        for roi_data in roi_data_list:
+            roi = OphysROI.from_schema_dict(roi_data)
+            output_list.append(roi)
+    return output_list
+
+
+def create_roi_summary_fig(
+        background_path: pathlib.Path,
+        baseline_roi_path: pathlib.Path,
+        test_roi_path: Union[pathlib.Path, List[pathlib.Path]],
+        iou_threshold: float,
+        attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
+
+
+    if background_path.suffix == '.png':
+        background_array = np.array(PIL.Image.open(background_path, 'r'))
+    elif background_path.suffix == '.pkl':
+        background_array = graph_to_img(background_path,
+                                        attribute_name=attribute_name)
+    else:
+        raise RuntimeError('Do not know how to parse background image file '
+                           f'{background}; must be either .png or .pkl')
+
+    background_array = scale_video_to_uint8(background_array,
+                                            0,
+                                            background_array.max())
+
+    background_rgb = np.zeros((background_array.shape[0],
+                               background_array.shape[1],
+                               3), dtype=np.uint8)
+    for ic in range(3):
+        background_rgb[:, :, ic] = background_array
+    background_array = background_rgb
+    del background_rgb
+
+    if isinstance(test_roi_path, pathlib.Path):
+        test_roi_path = [test_roi_path]
+
+    n_columns = len(test_roi_path)
+    n_rows = 4
+
+    fontsize = 20
+    figure = mplt_fig.Figure(figsize=(10*n_columns, 10*n_rows))
+    axes = [figure.add_subplot(n_rows, n_columns, ii)
+            for ii in range(1, 1+n_rows*n_columns, 1)]
+
+    baseline_color = (0, 255, 0)
+    this_color = (255, 128, 0)
+
+
+    baseline_roi = read_roi_list(baseline_roi_path)
+    baseline_img = add_roi_boundaries_to_img(background_array,
+                                             baseline_roi,
+                                             color=baseline_color,
+                                             alpha=1.0)
+
+    for i_column, roi_path in enumerate(test_roi_path):
+        these_roi = read_roi_list(roi_path)
+
+        comparison = find_iou_roi_matches(baseline_roi,
+                                          these_roi,
+                                          iou_threshold)
+
+        just_these_img = add_roi_boundaries_to_img(background_array,
+                                                   these_roi,
+                                                   color=this_color,
+                                                   alpha=1.0)
+        both_img = add_roi_boundaries_to_img(baseline_img,
+                                             these_roi,
+                                             color=this_color,
+                                             alpha=1.0)
+
+        matches_img = add_roi_boundaries_to_img(
+                          background_array,
+                          comparison['matched_baseline'],
+                          color=baseline_color,
+                          alpha=1.0)
+
+        matches_img = add_roi_boundaries_to_img(
+                          matches_img,
+                          comparison['matched_test'],
+                          color=this_color,
+                          alpha=1.0)
+
+        misses_img = add_roi_boundaries_to_img(
+                         background_array,
+                         comparison['unmatched_baseline'],
+                         color=baseline_color,
+                         alpha=1.0)
+
+        misses_img = add_roi_boundaries_to_img(
+                         misses_img,
+                         comparison['unmatched_test'],
+                         color=this_color,
+                         alpha=1.0)
+
+        axes[i_column].imshow(just_these_img)
+        axes[n_columns+i_column].imshow(both_img)
+        axes[2*n_columns+i_column].imshow(matches_img)
+        axes[2*n_columns+i_column].set_title(
+                 f'matches at iou={iou_threshold:.2f}', fontsize=fontsize)
+        axes[3*n_columns+i_column].imshow(misses_img)
+        axes[3*n_columns+i_column].set_title(
+                f'misses at iou={iou_threshold:.2f}', fontsize=fontsize)
+
+
+    for ii in range(0,
+                    background_array.shape[0],
+                    background_array.shape[0]//4):
+        for ax in axes:
+            ax.axhline(ii, color='w', alpha=0.25)
+    for ii in range(0,
+                    background_array.shape[1],
+                    background_array.shape[1]//4):
+        for ax in axes:
+            ax.axvline(ii, color='w', alpha=0.25)
+    figure.tight_layout()
+    return figure

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -20,7 +20,7 @@ from ophys_etl.modules.segmentation.qc_utils.video_utils import (
     scale_video_to_uint8)
 
 
-def read_roi_list(file_path: pathlib.Path) -> List[OphysROI]:
+def roi_list_from_file(file_path: pathlib.Path) -> List[OphysROI]:
     output_list = []
     with open(file_path, 'rb') as in_file:
         roi_data_list = json.load(in_file)
@@ -75,7 +75,7 @@ def create_roi_v_background_grid(
 
     roi_lists = []
     for this_roi_path in roi_path:
-        roi = read_roi_list(this_roi_path)
+        roi = roi_list_from_file(this_roi_path)
         roi_lists.append(roi)
 
     for i_bckgd in range(n_bckgd):

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -159,10 +159,6 @@ def create_roi_summary_fig(
                                                    these_roi,
                                                    color=this_color,
                                                    alpha=1.0)
-        both_img = add_roi_boundaries_to_img(baseline_img,
-                                             these_roi,
-                                             color=this_color,
-                                             alpha=1.0)
 
         matches_img = add_roi_boundaries_to_img(
                           background_array,
@@ -191,8 +187,8 @@ def create_roi_summary_fig(
         axes[i_column].imshow(just_these_img)
         axes[i_column].set_title(roi_name,
                                  fontsize=fontsize)
-        axes[n_columns+i_column].imshow(both_img)
-        axes[n_columns+i_column].set_title('plotted over baseline',
+        axes[n_columns+i_column].imshow(baseline_img)
+        axes[n_columns+i_column].set_title('baseline',
                                            fontsize=fontsize)
         axes[2*n_columns+i_column].imshow(matches_img)
         axes[2*n_columns+i_column].set_title(

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -251,8 +251,8 @@ def create_roi_v_background_grid(
     fontsize = 30
     figure = mplt_fig.Figure(figsize=(10*n_roi, 10*n_bckgd))
 
-    axes = [figure.add_subplot(n_bckgd, n_roi, ii)
-            for ii in range(1, 1+n_bckgd*n_roi, 1)]
+    axes = [figure.add_subplot(n_bckgd, n_roi+1, ii)
+            for ii in range(1, 1+n_bckgd*(n_roi+1), 1)]
 
     roi_lists = []
     for this_roi_path in roi_path:
@@ -282,11 +282,19 @@ def create_roi_v_background_grid(
         background_array = background_rgb
         del background_rgb
 
+        axis = axes[i_bckgd*(n_roi+1)]
+        img = background_array
+        axis.imshow(img)
+        for ii in range(0, img.shape[0], img.shape[0]//4):
+            axis.axhline(ii, color='w', alpha=0.25)
+        for ii in range(0, img.shape[1], img.shape[1]//4):
+            axis.axvline(ii, color='w', alpha=0.25)
+
         for i_roi in range(n_roi):
             i_color = i_roi%len(color_list)
             this_color = color_list[i_color]
             this_roi = roi_lists[i_roi]
-            axis = axes[i_bckgd*n_roi+i_roi]
+            axis = axes[i_bckgd*(n_roi+1)+i_roi+1]
             if i_bckgd == 0:
                 axis.set_title(roi_names[i_roi], fontsize=fontsize)
             img = add_roi_boundaries_to_img(background_array,

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -249,7 +249,7 @@ def create_roi_v_background_grid(
     n_bckgd = len(background_path)  # rows
     n_roi = len(roi_path)    # columns
     fontsize = 30
-    figure = mplt_fig.Figure(figsize=(10*n_roi, 10*n_bckgd))
+    figure = mplt_fig.Figure(figsize=(10*(n_roi+1), 10*n_bckgd))
 
     axes = [figure.add_subplot(n_bckgd, n_roi+1, ii)
             for ii in range(1, 1+n_bckgd*(n_roi+1), 1)]

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -1,10 +1,9 @@
-from typing import List, Dict, Union, Tuple
+from typing import List, Union, Tuple
 import matplotlib.figure as mplt_fig
 import pathlib
 import numpy as np
 import PIL.Image
 import json
-import copy
 
 from ophys_etl.modules.decrosstalk.ophys_plane import (
     OphysROI)
@@ -132,6 +131,11 @@ def create_roi_v_background_grid(
     -------
     matplotlib.figure.Figure
 
+    Notes
+    -----
+    PNG background images will be clipped at the 0.1 and 0.999
+    brightness quantiles.
+
     Raises
     ------
     RuntimeError if number of paths and names mismatch, either for ROIs
@@ -169,8 +173,10 @@ def create_roi_v_background_grid(
             background_array = graph_to_img(this_bckgd,
                                             attribute_name=attribute_name)
         else:
-            raise RuntimeError('Do not know how to parse background image file '
-                               f'{this_bckgd}; must be either .png or .pkl')
+            raise RuntimeError('Do not know how to parse '
+                               'background image file '
+                               f'{this_bckgd}; must be '
+                               'either .png or .pkl')
 
         if this_bckgd.suffix == '.png':
             qtiles = np.quantile(background_array, (0.1, 0.999))
@@ -179,8 +185,6 @@ def create_roi_v_background_grid(
         background_array = scale_video_to_uint8(background_array,
                                                 qtiles[0],
                                                 qtiles[1])
-                                                #0,
-                                                #background_array.max())
 
         background_rgb = np.zeros((background_array.shape[0],
                                    background_array.shape[1],
@@ -200,7 +204,7 @@ def create_roi_v_background_grid(
             axis.axvline(ii, color='w', alpha=0.25)
 
         for i_roi in range(n_roi):
-            i_color = i_roi%len(color_list)
+            i_color = i_roi % len(color_list)
             this_color = color_list[i_color]
             this_roi = roi_lists[i_roi]
             axis = axes[i_bckgd*(n_roi+1)+i_roi+1]

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -37,6 +37,7 @@ def _validate_paths_v_names(
         raise RuntimeError(msg)
     return paths, names
 
+
 def roi_list_from_file(file_path: pathlib.Path) -> List[OphysROI]:
     output_list = []
     with open(file_path, 'rb') as in_file:

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -20,6 +20,23 @@ from ophys_etl.modules.segmentation.qc_utils.video_utils import (
     scale_video_to_uint8)
 
 
+def _validate_paths_v_names(
+        paths: Union[pathlib.Path, List[pathlib.Path]],
+        names: Union[str, List[str]]) -> Tuple[List[pathlib.Path],
+                                               List[str]]:
+
+    if isinstance(paths, pathlib.Path):
+        paths = [paths]
+    if isinstance(names, str):
+        names = [str]
+
+    if len(paths) != len(names):
+        msg = f'paths: {paths}\n'
+        msg += f'names: {names}\n'
+        msg += 'These must be the same shape'
+        raise RuntimeError(msg)
+    return paths, names
+
 def roi_list_from_file(file_path: pathlib.Path) -> List[OphysROI]:
     output_list = []
     with open(file_path, 'rb') as in_file:
@@ -39,27 +56,13 @@ def create_roi_v_background_grid(
         color_list: List[Tuple[int, int, int]],
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
 
-    if isinstance(roi_paths, pathlib.Path):
-        roi_paths = [roi_paths]
-        if not isinstance(roi_names, str):
-            raise RuntimeError('roi_paths was a single path; '
-                               'roi_names must be a single str; '
-                               f'got {roi_names} instead')
-        roi_names = [roi_names]
-    elif not isinstance(roi_names, list):
-        raise RuntimeError('You passed in a list of ROI paths, but '
-                           f'roi_names is {roi_names} '
-                           f'of type {type(roi_names)}. '
-                           'This must also be a list.')
+    (roi_paths,
+     roi_names) = _validate_paths_v_names(roi_paths,
+                                          roi_names)
 
-    if len(roi_names) != len(roi_paths):
-        raise RuntimeError(f'{len(roi_paths)} roi paths, but '
-                           f'{len(roi_names)} roi names. '
-                           'These numbers must be equal.')
-
-    if isinstance(background_paths, pathlib.Path):
-        background_paths = [background_paths]
-        background_names = [background_names]
+    (background_paths,
+     background_names) = _validate_paths_v_names(background_paths,
+                                                 background_names)
 
     n_bckgd = len(background_paths)  # rows
     n_roi = len(roi_paths)    # columns

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Tuple
 import matplotlib.figure as mplt_fig
 import pathlib
 import numpy as np
@@ -36,12 +36,8 @@ def create_roi_v_background_grid(
         background_names: Union[str, List[str]],
         roi_paths: Union[pathlib.Path, List[pathlib.Path]],
         roi_names: Union[str, List[str]],
+        color_list: List[Tuple[int, int, int]],
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
-
-    color_list = ((0, 255, 0),
-                  (255, 128, 0),
-                  (51, 255, 255),
-                  (255, 51, 255))
 
     if isinstance(roi_paths, pathlib.Path):
         roi_paths = [roi_paths]

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -189,7 +189,6 @@ def create_roi_summary_fig(
         axes[3*n_columns+i_column].set_title(
                 f'misses at iou={iou_threshold:.2f}', fontsize=fontsize)
 
-
     for ii in range(0,
                     background_array.shape[0],
                     background_array.shape[0]//4):

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -7,8 +7,7 @@ import json
 import copy
 
 from ophys_etl.modules.decrosstalk.ophys_plane import (
-    OphysROI,
-    intersection_over_union)
+    OphysROI)
 
 from ophys_etl.modules.segmentation.graph_utils.conversion import (
     graph_to_img)
@@ -21,55 +20,6 @@ from ophys_etl.modules.segmentation.qc_utils.video_utils import (
     scale_video_to_uint8)
 
 
-def find_iou_roi_matches(baseline_roi_list: List[OphysROI],
-                         test_roi_list: List[OphysROI],
-                         iou_threshold: float) -> Dict[str, List[OphysROI]]:
-    """
-    Parameters
-    ----------
-    baseline_roi_list: List[OphysROI]
-
-    test_roi_list: List[OphysROI]
-
-    iou_threshold: float
-
-    Returns
-    -------
-    dict
-        'unmatched_baseline'
-        'unmatched_test'
-        'matched_baseline'
-        'matched_test'
-    """
-
-    baseline = copy.deepcopy(baseline_roi_list)
-    test = copy.deepcopy(test_roi_list)
-
-    matched_test = []
-    matched_baseline = []
-    unmatched_baseline = []
-
-    for baseline_roi in baseline:
-        candidate_indexes = []
-        candidate_iou = []
-        for ii, test_roi in enumerate(test):
-            iou = intersection_over_union(baseline_roi, test_roi)
-            if iou > iou_threshold:
-                candidate_iou.append(iou)
-                candidate_indexes.append(ii)
-        if len(candidate_iou) > 0:
-            best = np.argmax(candidate_iou)
-            matched_test.append(test.pop(candidate_indexes[best]))
-            matched_baseline.append(baseline_roi)
-        else:
-            unmatched_baseline.append(baseline_roi)
-
-    return {'matched_test': matched_test,
-            'matched_baseline': matched_baseline,
-            'unmatched_test': test,
-            'unmatched_baseline': unmatched_baseline}
-
-
 def read_roi_list(file_path: pathlib.Path) -> List[OphysROI]:
     output_list = []
     with open(file_path, 'rb') as in_file:
@@ -79,138 +29,6 @@ def read_roi_list(file_path: pathlib.Path) -> List[OphysROI]:
             roi = OphysROI.from_schema_dict(roi_data)
             output_list.append(roi)
     return output_list
-
-
-def create_roi_summary_fig(
-        background_path: pathlib.Path,
-        baseline_roi_path: pathlib.Path,
-        test_roi_path: Union[pathlib.Path, List[pathlib.Path]],
-        test_roi_names: Union[str, List[str]],
-        iou_threshold: float,
-        attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
-
-
-    if isinstance(test_roi_path, pathlib.Path):
-        test_roi_path = [test_roi_path]
-        if not isinstance(test_roi_names, str):
-            raise RuntimeError('test_roi_path was a single path; '
-                               'test_roi_names must be a single str; '
-                               f'got {test_roi_names} instead')
-        test_roi_names = [test_roi_names]
-    elif not isinstance(test_roi_names, list):
-        raise RuntimeError('You passed in a list of ROI paths, but '
-                           f'test_roi_names is {test_roi_names} '
-                           f'of type {type(test_roi_names)}. '
-                           'This must also be a list.')
-
-    if len(test_roi_names) != len(test_roi_path):
-        raise RuntimeError(f'{len(test_roi_path)} roi paths, but '
-                           f'{len(test_roi_names)} roi names. '
-                           'These numbers must be equal.')
-
-    if background_path.suffix == '.png':
-        background_array = np.array(PIL.Image.open(background_path, 'r'))
-    elif background_path.suffix == '.pkl':
-        background_array = graph_to_img(background_path,
-                                        attribute_name=attribute_name)
-    else:
-        raise RuntimeError('Do not know how to parse background image file '
-                           f'{background_path}; must be either .png or .pkl')
-
-    background_array = scale_video_to_uint8(background_array,
-                                            0,
-                                            background_array.max())
-
-    background_rgb = np.zeros((background_array.shape[0],
-                               background_array.shape[1],
-                               3), dtype=np.uint8)
-    for ic in range(3):
-        background_rgb[:, :, ic] = background_array
-    background_array = background_rgb
-    del background_rgb
-
-    n_columns = len(test_roi_path)
-    n_rows = 4
-
-    fontsize = 30
-    figure = mplt_fig.Figure(figsize=(10*n_columns, 10*n_rows))
-    axes = [figure.add_subplot(n_rows, n_columns, ii)
-            for ii in range(1, 1+n_rows*n_columns, 1)]
-
-    baseline_color = (0, 255, 0)
-    this_color = (255, 128, 0)
-
-
-    baseline_roi = read_roi_list(baseline_roi_path)
-    baseline_img = add_roi_boundaries_to_img(background_array,
-                                             baseline_roi,
-                                             color=baseline_color,
-                                             alpha=1.0)
-
-    for i_column, (roi_path, roi_name) in enumerate(zip(test_roi_path,
-                                                        test_roi_names)):
-        these_roi = read_roi_list(roi_path)
-
-        comparison = find_iou_roi_matches(baseline_roi,
-                                          these_roi,
-                                          iou_threshold)
-
-        just_these_img = add_roi_boundaries_to_img(background_array,
-                                                   these_roi,
-                                                   color=this_color,
-                                                   alpha=1.0)
-
-        matches_img = add_roi_boundaries_to_img(
-                          background_array,
-                          comparison['matched_baseline'],
-                          color=baseline_color,
-                          alpha=1.0)
-
-        matches_img = add_roi_boundaries_to_img(
-                          matches_img,
-                          comparison['matched_test'],
-                          color=this_color,
-                          alpha=1.0)
-
-        misses_img = add_roi_boundaries_to_img(
-                         background_array,
-                         comparison['unmatched_baseline'],
-                         color=baseline_color,
-                         alpha=1.0)
-
-        misses_img = add_roi_boundaries_to_img(
-                         misses_img,
-                         comparison['unmatched_test'],
-                         color=this_color,
-                         alpha=1.0)
-
-        axes[i_column].imshow(just_these_img)
-        axes[i_column].set_title(roi_name,
-                                 fontsize=fontsize)
-        axes[n_columns+i_column].imshow(baseline_img)
-        axes[n_columns+i_column].set_title('baseline',
-                                           fontsize=fontsize)
-        axes[2*n_columns+i_column].imshow(matches_img)
-        axes[2*n_columns+i_column].set_title(
-                 f'{roi_name} matches at iou={iou_threshold:.2f}',
-                 fontsize=fontsize)
-        axes[3*n_columns+i_column].imshow(misses_img)
-        axes[3*n_columns+i_column].set_title(
-                f'{roi_name} misses at iou={iou_threshold:.2f}',
-                fontsize=fontsize)
-
-    for ii in range(0,
-                    background_array.shape[0],
-                    background_array.shape[0]//4):
-        for ax in axes:
-            ax.axhline(ii, color='w', alpha=0.25)
-    for ii in range(0,
-                    background_array.shape[1],
-                    background_array.shape[1]//4):
-        for ax in axes:
-            ax.axvline(ii, color='w', alpha=0.25)
-    figure.tight_layout()
-    return figure
 
 
 def create_roi_v_background_grid(

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -32,9 +32,9 @@ def roi_list_from_file(file_path: pathlib.Path) -> List[OphysROI]:
 
 
 def create_roi_v_background_grid(
-        background_path: Union[pathlib.Path, List[pathlib.Path]],
+        background_paths: Union[pathlib.Path, List[pathlib.Path]],
         background_names: Union[str, List[str]],
-        roi_path: Union[pathlib.Path, List[pathlib.Path]],
+        roi_paths: Union[pathlib.Path, List[pathlib.Path]],
         roi_names: Union[str, List[str]],
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
 
@@ -43,10 +43,10 @@ def create_roi_v_background_grid(
                   (51, 255, 255),
                   (255, 51, 255))
 
-    if isinstance(roi_path, pathlib.Path):
-        roi_path = [roi_path]
+    if isinstance(roi_paths, pathlib.Path):
+        roi_paths = [roi_paths]
         if not isinstance(roi_names, str):
-            raise RuntimeError('roi_path was a single path; '
+            raise RuntimeError('roi_paths was a single path; '
                                'roi_names must be a single str; '
                                f'got {roi_names} instead')
         roi_names = [roi_names]
@@ -56,17 +56,17 @@ def create_roi_v_background_grid(
                            f'of type {type(roi_names)}. '
                            'This must also be a list.')
 
-    if len(roi_names) != len(roi_path):
-        raise RuntimeError(f'{len(roi_path)} roi paths, but '
+    if len(roi_names) != len(roi_paths):
+        raise RuntimeError(f'{len(roi_paths)} roi paths, but '
                            f'{len(roi_names)} roi names. '
                            'These numbers must be equal.')
 
-    if isinstance(background_path, pathlib.Path):
-        background_path = [background_path]
+    if isinstance(background_paths, pathlib.Path):
+        background_paths = [background_paths]
         background_names = [background_names]
 
-    n_bckgd = len(background_path)  # rows
-    n_roi = len(roi_path)    # columns
+    n_bckgd = len(background_paths)  # rows
+    n_roi = len(roi_paths)    # columns
     fontsize = 30
     figure = mplt_fig.Figure(figsize=(10*(n_roi+1), 10*n_bckgd))
 
@@ -74,12 +74,12 @@ def create_roi_v_background_grid(
             for ii in range(1, 1+n_bckgd*(n_roi+1), 1)]
 
     roi_lists = []
-    for this_roi_path in roi_path:
-        roi = roi_list_from_file(this_roi_path)
+    for this_roi_paths in roi_paths:
+        roi = roi_list_from_file(this_roi_paths)
         roi_lists.append(roi)
 
     for i_bckgd in range(n_bckgd):
-        this_bckgd = background_path[i_bckgd]
+        this_bckgd = background_paths[i_bckgd]
         if this_bckgd.suffix == '.png':
             background_array = np.array(PIL.Image.open(this_bckgd, 'r'))
         elif this_bckgd.suffix == '.pkl':

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -87,6 +87,7 @@ def create_roi_summary_fig(
         background_path: pathlib.Path,
         baseline_roi_path: pathlib.Path,
         test_roi_path: Union[pathlib.Path, List[pathlib.Path]],
+        test_roi_names: Union[str, List[str]],
         iou_threshold: float,
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
 
@@ -114,11 +115,12 @@ def create_roi_summary_fig(
 
     if isinstance(test_roi_path, pathlib.Path):
         test_roi_path = [test_roi_path]
+        test_roi_names = [test_roi_names]
 
     n_columns = len(test_roi_path)
     n_rows = 4
 
-    fontsize = 20
+    fontsize = 30
     figure = mplt_fig.Figure(figsize=(10*n_columns, 10*n_rows))
     axes = [figure.add_subplot(n_rows, n_columns, ii)
             for ii in range(1, 1+n_rows*n_columns, 1)]
@@ -133,7 +135,8 @@ def create_roi_summary_fig(
                                              color=baseline_color,
                                              alpha=1.0)
 
-    for i_column, roi_path in enumerate(test_roi_path):
+    for i_column, (roi_path, roi_name) in enumerate(zip(test_roi_path,
+                                                        test_roi_names)):
         these_roi = read_roi_list(roi_path)
 
         comparison = find_iou_roi_matches(baseline_roi,
@@ -174,7 +177,11 @@ def create_roi_summary_fig(
                          alpha=1.0)
 
         axes[i_column].imshow(just_these_img)
+        axes[i_column].set_title(roi_name,
+                                 fontsize=fontsize)
         axes[n_columns+i_column].imshow(both_img)
+        axes[n_columns+i_column].set_title('plotted over baseline',
+                                           fontsize=fontsize)
         axes[2*n_columns+i_column].imshow(matches_img)
         axes[2*n_columns+i_column].set_title(
                  f'matches at iou={iou_threshold:.2f}', fontsize=fontsize)

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -28,7 +28,7 @@ def _validate_paths_v_names(
     if isinstance(paths, pathlib.Path):
         paths = [paths]
     if isinstance(names, str):
-        names = [str]
+        names = [names]
 
     if len(paths) != len(names):
         msg = f'paths: {paths}\n'

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -41,7 +41,6 @@ def find_iou_roi_matches(baseline_roi_list: List[OphysROI],
         'matched_baseline'
         'matched_test'
     """
-    print('finding matches')
 
     baseline = copy.deepcopy(baseline_roi_list)
     test = copy.deepcopy(test_roi_list)
@@ -65,7 +64,6 @@ def find_iou_roi_matches(baseline_roi_list: List[OphysROI],
         else:
             unmatched_baseline.append(baseline_roi)
 
-    print('done')
     return {'matched_test': matched_test,
             'matched_baseline': matched_baseline,
             'unmatched_test': test,

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -220,8 +220,7 @@ def create_roi_v_background_grid(
         roi_names: Union[str, List[str]],
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
 
-    color_list = ((255, 0, 0),
-                  (0, 255, 0),
+    color_list = ((0, 255, 0),
                   (255, 128, 0),
                   (51, 255, 255),
                   (255, 51, 255))

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -24,6 +24,31 @@ def _validate_paths_v_names(
         paths: Union[pathlib.Path, List[pathlib.Path]],
         names: Union[str, List[str]]) -> Tuple[List[pathlib.Path],
                                                List[str]]:
+    """
+    Validate that you have passed in the same number of file paths
+    and plot names, casting them into lists if they are not already.
+
+    Parameters
+    ----------
+    paths: Union[pathlib.Path, List[pathlib.Path]]
+
+    names: Union[str, List[str]]
+
+    Returns
+    -------
+    path_list: List[pathlib.Path]
+
+    name_list: List[str]
+
+    Notes
+    -----
+    The outputs will be single element lists if the inputs
+    are singletons
+
+    Raises
+    ------
+    RuntimeError if the number of paths and names are mismatched
+    """
 
     if isinstance(paths, pathlib.Path):
         paths = [paths]
@@ -39,6 +64,18 @@ def _validate_paths_v_names(
 
 
 def roi_list_from_file(file_path: pathlib.Path) -> List[OphysROI]:
+    """
+    Read in a JSONized file of ExtractROIs; return a list of
+    OphysROIs
+
+    Parameters
+    ----------
+    file_path: pathlib.Path
+
+    Returns
+    -------
+    List[OphysROI]
+    """
     output_list = []
     with open(file_path, 'rb') as in_file:
         roi_data_list = json.load(in_file)
@@ -56,6 +93,52 @@ def create_roi_v_background_grid(
         roi_names: Union[str, List[str]],
         color_list: List[Tuple[int, int, int]],
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
+    """
+    Create a plot showing a set of ROIs overlaid over a set of
+    different background images. In the final plot, each distinct
+    background image will be a different row of subplots and each
+    distinct set of ROIs will be a diferent column of subplots.
+
+    Parameters
+    ----------
+    background_paths: Union[pathlib.Path, List[pathlib.Path]]
+        Path(s) to file(s) containing background images. May be either
+        PNG images or pkl files containing networkx graphs
+
+    background_names: Union[str, List[str]]
+       The names of the backgrounds as they will appear in the plot
+       (there must be an equal number of background_names as
+       background_paths)
+
+    roi_paths: Union[pathlib.Path, List[pathlib.Path]]
+        Path(s) to file(s) containing JSONized ROIs
+
+    roi_names: Union[str, List[str]]
+        The names of the ROI sets as they will appear in te plot
+        (there must be an equal number of roi_names as roi_paths)
+
+    color_list: List[Tuple[int, int, in]]
+        List of RGB color tuples to cycle through when plotting
+        ROIs. The number of colors does not have to match the
+        number of ROI sets; the code will just cycle through
+        the list of provided colors.
+
+    attribute_name: str
+        The name of the attribute to use in constructing the background
+        image from a networkx graph, if applicable.
+        Default: 'filtered_hnc_Gaussian'
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    Raises
+    ------
+    RuntimeError if number of paths and names mismatch, either for ROIs
+    or backgrounds.
+
+    RuntimeError if a background_path does not end in '.png' or '.pkl'
+    """
 
     (roi_paths,
      roi_names) = _validate_paths_v_names(roi_paths,

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -215,6 +215,7 @@ def create_roi_summary_fig(
 
 def create_roi_v_background_grid(
         background_path: Union[pathlib.Path, List[pathlib.Path]],
+        background_names: Union[str, List[str]],
         roi_path: Union[pathlib.Path, List[pathlib.Path]],
         roi_names: Union[str, List[str]],
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
@@ -245,6 +246,7 @@ def create_roi_v_background_grid(
 
     if isinstance(background_path, pathlib.Path):
         background_path = [background_path]
+        background_names = [background_names]
 
     n_bckgd = len(background_path)  # rows
     n_roi = len(roi_path)    # columns
@@ -285,6 +287,7 @@ def create_roi_v_background_grid(
         axis = axes[i_bckgd*(n_roi+1)]
         img = background_array
         axis.imshow(img)
+        axis.set_title(background_names[i_bckgd], fontsize=fontsize)
         for ii in range(0, img.shape[0], img.shape[0]//4):
             axis.axhline(ii, color='w', alpha=0.25)
         for ii in range(0, img.shape[1], img.shape[1]//4):

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -90,6 +90,24 @@ def create_roi_summary_fig(
         attribute_name: str = 'filtered_hnc_Gaussian') -> mplt_fig.Figure:
 
 
+    if isinstance(test_roi_path, pathlib.Path):
+        test_roi_path = [test_roi_path]
+        if not isinstance(test_roi_names, str):
+            raise RuntimeError('test_roi_path was a single path; '
+                               'test_roi_names must be a single str; '
+                               f'got {test_roi_names} instead')
+        test_roi_names = [test_roi_names]
+    elif not isinstance(test_roi_names, list):
+        raise RuntimeError('You passed in a list of ROI paths, but '
+                           f'test_roi_names is {test_roi_names} '
+                           f'of type {type(test_roi_names)}. '
+                           'This must also be a list.')
+
+    if len(test_roi_names) != len(test_roi_path):
+        raise RuntimeError(f'{len(test_roi_path)} roi paths, but '
+                           f'{len(test_roi_names)} roi names. '
+                           'These numbers must be equal.')
+
     if background_path.suffix == '.png':
         background_array = np.array(PIL.Image.open(background_path, 'r'))
     elif background_path.suffix == '.pkl':
@@ -110,10 +128,6 @@ def create_roi_summary_fig(
         background_rgb[:, :, ic] = background_array
     background_array = background_rgb
     del background_rgb
-
-    if isinstance(test_roi_path, pathlib.Path):
-        test_roi_path = [test_roi_path]
-        test_roi_names = [test_roi_names]
 
     n_columns = len(test_roi_path)
     n_rows = 4

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -59,12 +59,15 @@ def add_roi_boundaries_to_img(img: np.ndarray,
         New image with ROI borders superimposed
     """
 
+    new_img = np.copy(img)
+    if len(roi_list) == 0:
+        return new_img
+
     if not isinstance(roi_list[0], OphysROI):
         roi_list = convert_keys(roi_list)
         roi_list = [OphysROI.from_schema_dict(roi)
                     for roi in roi_list]
 
-    new_img = np.copy(img)
     for roi in roi_list:
         bdry = roi.boundary_mask
         for icol in range(roi.width):

--- a/tests/modules/decrosstalk/test_ophys_plane.py
+++ b/tests/modules/decrosstalk/test_ophys_plane.py
@@ -1,7 +1,9 @@
 import os
 import json
+import numpy as np
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 from ophys_etl.modules.decrosstalk.ophys_plane import DecrosstalkingOphysPlane
+from ophys_etl.modules.decrosstalk.ophys_plane import intersection_over_union
 
 from .utils import get_data_dir
 
@@ -53,3 +55,58 @@ def test_setting_qc_path():
     assert plane.qc_file_path is None
     plane.qc_file_path = 'path/to/a/file'
     assert plane.qc_file_path == 'path/to/a/file'
+
+
+def test_roi_pixel_set():
+    width = 7
+    height = 5
+    mask = np.zeros((height, width), dtype=bool)
+    mask[2, 4] = True
+    mask[3, 6] = True
+    roi = OphysROI(roi_id=1,
+                   x0=100,
+                   y0=200,
+                   width=width,
+                   height=height,
+                   valid_roi=True,
+                   mask_matrix=mask)
+    assert roi.pixel_set == set([(202, 104), (203, 106)])
+
+
+def test_intersection_over_union():
+
+    width = 7
+    height = 5
+    mask = np.ones((height, width), dtype=bool)
+    mask[:, 4:] = False
+    roi0 = OphysROI(roi_id=0,
+                    x0=100,
+                    y0=200,
+                    width=width,
+                    height=height,
+                    valid_roi=True,
+                    mask_matrix=mask)
+
+    width = 4
+    height = 9
+    mask = np.ones((height, width), dtype=bool)
+    mask[:, 0] = False
+    mask[2:, :] = False
+    roi1 = OphysROI(roi_id=0,
+                    x0=101,
+                    y0=201,
+                    width=width,
+                    height=height,
+                    valid_roi=True,
+                    mask_matrix=mask)
+
+    # expected_intersection = 4
+    # expected_union = 22
+
+    expected = 4.0/22.0
+
+    actual = intersection_over_union(roi0, roi1)
+    actual1 = intersection_over_union(roi1, roi0)
+    eps = 1.0e-20
+    assert np.abs(actual-actual1) < eps
+    assert np.abs(actual-expected) < eps

--- a/tests/modules/decrosstalk/test_ophys_plane.py
+++ b/tests/modules/decrosstalk/test_ophys_plane.py
@@ -57,7 +57,7 @@ def test_setting_qc_path():
     assert plane.qc_file_path == 'path/to/a/file'
 
 
-def test_roi_pixel_set():
+def test_roi_global_pixel_set():
     width = 7
     height = 5
     mask = np.zeros((height, width), dtype=bool)
@@ -70,7 +70,7 @@ def test_roi_pixel_set():
                    height=height,
                    valid_roi=True,
                    mask_matrix=mask)
-    assert roi.pixel_set == set([(202, 104), (203, 106)])
+    assert roi.global_pixel_set == set([(202, 104), (203, 106)])
 
 
 def test_intersection_over_union():

--- a/tests/modules/decrosstalk/test_ophys_plane.py
+++ b/tests/modules/decrosstalk/test_ophys_plane.py
@@ -108,5 +108,5 @@ def test_intersection_over_union():
     actual = intersection_over_union(roi0, roi1)
     actual1 = intersection_over_union(roi1, roi0)
     eps = 1.0e-20
-    assert np.abs(actual-actual1) < eps
-    assert np.abs(actual-expected) < eps
+    np.testing.assert_allclose(actual, actual1, rtol=0.0, atol=eps)
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=eps)

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_module.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_module.py
@@ -1,0 +1,47 @@
+import pytest
+import pathlib
+
+from ophys_etl.modules.segmentation.modules.roi_comparison import (
+    ROIComparisonSchema)
+
+
+def test_roi_comparison_schema(tmpdir):
+    tmpdir_path = pathlib.Path(tmpdir)
+    roi_paths = [str(tmpdir_path/'a.json'),
+                 str(tmpdir_path/'b.json')]
+    bckgd_paths = [str(tmpdir_path/'c.png'),
+                   str(tmpdir_path/'d.pkl'),
+                   str(tmpdir_path/'e.jpg')]
+
+    for file_path in bckgd_paths+roi_paths:
+        with open(file_path, 'w') as out_file:
+            out_file.write('junk')
+
+    data = {'background_paths': bckgd_paths[:2],
+            'background_names': ['a', 'b'],
+            'roi_paths': roi_paths,
+            'roi_names': ['aa', 'bb'],
+            'plot_output': str(tmpdir_path/'junk.png')}
+
+    roi_schema = ROIComparisonSchema()
+    roi_schema.load(data)
+
+    with pytest.raises(RuntimeError, match='should be the same length'):
+
+        data = {'background_paths': bckgd_paths[:2],
+                'background_names': ['a', 'b', 'c'],
+                'roi_paths': roi_paths,
+                'roi_names': ['aa', 'bb'],
+                'plot_output': str(tmpdir_path/'junk.png')}
+
+        roi_schema.load(data)
+
+    with pytest.raises(RuntimeError, match='should be the same length'):
+
+        data = {'background_paths': bckgd_paths[:2],
+                'background_names': ['a', 'b'],
+                'roi_paths': roi_paths,
+                'roi_names': ['aa'],
+                'plot_output': str(tmpdir_path/'junk.png')}
+
+        roi_schema.load(data)

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_module.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_module.py
@@ -10,25 +10,49 @@ def test_roi_comparison_schema(tmpdir):
     roi_paths = [str(tmpdir_path/'a.json'),
                  str(tmpdir_path/'b.json')]
     bckgd_paths = [str(tmpdir_path/'c.png'),
-                   str(tmpdir_path/'d.pkl'),
-                   str(tmpdir_path/'e.jpg')]
+                   str(tmpdir_path/'d.pkl')]
 
     for file_path in bckgd_paths+roi_paths:
         with open(file_path, 'w') as out_file:
             out_file.write('junk')
 
-    data = {'background_paths': bckgd_paths[:2],
+    roi_schema = ROIComparisonSchema()
+
+    data = {'background_paths': bckgd_paths,
             'background_names': ['a', 'b'],
             'roi_paths': roi_paths,
             'roi_names': ['aa', 'bb'],
             'plot_output': str(tmpdir_path/'junk.png')}
 
-    roi_schema = ROIComparisonSchema()
     roi_schema.load(data)
+
+    data = {'background_paths': bckgd_paths,
+            'roi_paths': roi_paths,
+            'roi_names': ['aa', 'bb'],
+            'plot_output': str(tmpdir_path/'junk.png')}
+
+    result = roi_schema.load(data)
+    assert result['background_names'] == ['c.png', 'd.pkl']
+
+    data = {'background_paths': bckgd_paths,
+            'background_names': ['a', 'b'],
+            'roi_paths': roi_paths,
+            'plot_output': str(tmpdir_path/'junk.png')}
+
+    result = roi_schema.load(data)
+    assert result['roi_names'] == ['a.json', 'b.json']
+
+    data = {'background_paths': bckgd_paths,
+            'roi_paths': roi_paths,
+            'plot_output': str(tmpdir_path/'junk.png')}
+
+    result = roi_schema.load(data)
+    assert result['roi_names'] == ['a.json', 'b.json']
+    assert result['background_names'] == ['c.png', 'd.pkl']
 
     with pytest.raises(RuntimeError, match='should be the same length'):
 
-        data = {'background_paths': bckgd_paths[:2],
+        data = {'background_paths': bckgd_paths,
                 'background_names': ['a', 'b', 'c'],
                 'roi_paths': roi_paths,
                 'roi_names': ['aa', 'bb'],
@@ -38,7 +62,7 @@ def test_roi_comparison_schema(tmpdir):
 
     with pytest.raises(RuntimeError, match='should be the same length'):
 
-        data = {'background_paths': bckgd_paths[:2],
+        data = {'background_paths': bckgd_paths,
                 'background_names': ['a', 'b'],
                 'roi_paths': roi_paths,
                 'roi_names': ['aa'],

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
@@ -230,6 +230,16 @@ def test_create_roi_v_background(tmpdir, background_png, background_pkl, roi_fil
             [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
+    # test that error is raised when an unknown background file type
+    # is passed in
+    with pytest.raises(RuntimeError, match='must be either .png or .pkl'):
+        create_roi_v_background_grid(
+                [background_png, pathlib.Path('dummy.jpg')],
+                ['png', 'junk'],
+                [roi_file],
+                ['a'],
+                [(255, 0, 0), (0, 255, 0)],
+                attribute_name='dummy_value')
 
     # test that errors are raised when paths and shapes are of
     # mismatched sizes

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
@@ -8,9 +8,6 @@ from itertools import combinations, product
 
 from ophys_etl.types import ExtractROI
 
-from ophys_etl.modules.decrosstalk.ophys_plane import (
-    OphysROI)
-
 from ophys_etl.modules.segmentation.merge.roi_utils import (
     ophys_roi_to_extract_roi)
 
@@ -64,7 +61,7 @@ def list_of_roi():
         y0 = int(rng.integers(0, 30))
         width = int(rng.integers(4, 10))
         height = int(rng.integers(4, 10))
-        mask = rng.integers(0, 2, size=(height,width)).astype(bool)
+        mask = rng.integers(0, 2, size=(height, width)).astype(bool)
 
         # because np.ints are not JSON serializable
         real_mask = []
@@ -102,10 +99,9 @@ def test_roi_list_from_file(roi_file, list_of_roi):
     assert actual == list_of_roi
 
 
-
 @pytest.mark.parametrize(
         'path_input, name_input, path_expected, name_expected, is_valid',
-        [# mismatch
+        [  # mismatch
          (pathlib.Path('a/path.txt'), ['a', 'b'], None, None, False),
 
          # mismatch
@@ -113,7 +109,11 @@ def test_roi_list_from_file(roi_file, list_of_roi):
           'a', None, None, False),
 
          # two singletons
-         (pathlib.Path('a/path.txt'), 'a', [pathlib.Path('a/path.txt')], ['a'], True),
+         (pathlib.Path('a/path.txt'),
+          'a',
+          [pathlib.Path('a/path.txt')],
+          ['a'],
+          True),
 
          # two lists
          ([pathlib.Path('a/path.txt'), pathlib.Path('b/path.txt')],
@@ -154,8 +154,8 @@ def test_validate_paths_v_names(path_input, name_input,
         assert name_expected == name_output
 
 
-
-def test_create_roi_v_background(tmpdir, background_png, background_pkl, roi_file):
+def test_create_roi_v_background(tmpdir, background_png,
+                                 background_pkl, roi_file):
     """
     This is just going to be a smoke test
     """
@@ -186,7 +186,6 @@ def test_create_roi_v_background(tmpdir, background_png, background_pkl, roi_fil
             'a',
             [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
-
 
     # many backgrounds; one ROIs
     create_roi_v_background_grid(

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
@@ -1,0 +1,65 @@
+import pytest
+import pathlib
+import numpy as np
+import json
+
+from ophys_etl.types import ExtractROI
+
+from ophys_etl.modules.decrosstalk.ophys_plane import (
+    OphysROI)
+
+from ophys_etl.modules.segmentation.merge.roi_utils import (
+    ophys_roi_to_extract_roi)
+
+from ophys_etl.modules.segmentation.qc_utils.roi_comparison_utils import (
+    roi_list_from_file)
+
+
+@pytest.fixture(scope='session')
+def list_of_roi():
+    """
+    A list of ExtractROIs
+    """
+    output = []
+    rng = np.random.default_rng(11231)
+    for ii in range(10):
+        x0 = int(rng.integers(0, 1000))
+        y0 = int(rng.integers(0, 1000))
+        width = int(rng.integers(4, 10))
+        height = int(rng.integers(4, 10))
+        mask = rng.integers(0, 2, size=(height,width)).astype(bool)
+
+        # because np.ints are not JSON serializable
+        real_mask = []
+        for row in mask:
+            this_row = []
+            for el in row:
+                if el:
+                    this_row.append(True)
+                else:
+                    this_row.append(False)
+            real_mask.append(this_row)
+
+        roi = ExtractROI(x=x0, width=width,
+                         y=y0, height=height,
+                         valid_roi=True,
+                         mask=real_mask,
+                         id=ii)
+        output.append(roi)
+    return output
+
+
+@pytest.fixture(scope='session')
+def roi_file(tmpdir_factory, list_of_roi):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('roi_reading'))
+    file_path = tmpdir/'list_of_rois.json'
+    with open(file_path, 'w') as out_file:
+        json.dump(list_of_roi, out_file)
+    yield file_path
+
+
+def test_roi_list_from_file(roi_file, list_of_roi):
+    raw_actual = roi_list_from_file(roi_file)
+    actual = [ophys_roi_to_extract_roi(roi)
+              for roi in raw_actual]
+    assert actual == list_of_roi


### PR DESCRIPTION
This PR creates a CLI module that can quickly generate the "multiple ROI sets plotted over multiple background images" plots that were used to validate #236.

The PR also adds some code to allow intersection-over-union comparison of OphysROIs. Even though the plotting code that depended on those utilities was removed, I left the utilities in, since we will eventually want to be able to do that comparison (I think). It is tested, but I am open to the idea that the code should be removed since it is not actually part of any module currently in use.