### PR TITLE
Segmentation qc output

### DIFF
--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -410,7 +410,7 @@ class FeatureVectorSegmenter(object):
 
     def run(self,
             roi_output: pathlib.Path,
-            qc_output: Optional[pathlib.Path] = None,
+            qc_output: pathlib.Path,
             plot_output: Optional[pathlib.Path] = None,
             seed_plot_output: Optional[pathlib.Path] = None,
             ) -> None:
@@ -422,9 +422,8 @@ class FeatureVectorSegmenter(object):
         roi_output: pathlib.Path
             Path to the JSON file where discovered ROIs will be recorded
 
-        qc_output: Optional[pathlib.Path]
-            If not None, the path where the qc results will be written
-            (default: None)
+        qc_output: pathlib.Path
+            the path where the qc results will be written
 
         plot_output: Optional[pathlib.Path]
             If not None, the path where a plot comparing the seed image
@@ -466,8 +465,7 @@ class FeatureVectorSegmenter(object):
             video_data = in_file['data'][()]
         logger.info(f'read in video data from {str(self._video_input)}')
 
-        if qc_output is not None:
-            seed_record = {}
+        seed_record = {}
 
         # list of discovered ROIs
         self.roi_list = []
@@ -505,8 +503,7 @@ class FeatureVectorSegmenter(object):
             msg += f'{len(self.roi_list)} valid ROIs ({n_valid_pix}) pixels'
             logger.info(msg)
 
-            if qc_output is not None:
-                seed_record[i_iteration] = roi_seeds
+            seed_record[i_iteration] = roi_seeds
 
             i_iteration += 1
 

--- a/src/ophys_etl/modules/segmentation/modules/README.rst
+++ b/src/ophys_etl/modules/segmentation/modules/README.rst
@@ -1,0 +1,38 @@
+Segmentation Steps
+==================
+- Detect (feature_vector_segmentation.py)
+- Merge (roi_merging.py)
+- Filter (TBD)
+
+Segmentation QC hdf5 output description
+=======================================
+
+group: "seed"
+*************
+the seeder works in conjunction with the detection algorithm. This groups logs what seeds were provided, which were excluded, and the reasons for exclusion.
+
+- provided_seeds: (row, col) coordinates of seeds served to the segmentation algorithm
+- excluded_seeds: (row, col) coordinates of seeds not served to the segmentation algorithm
+- exclusion_reason: (row, col) (str) reason the seed was not served.
+- seed_image: (2D array) the image used for generating the seeds.
+- attribute: (str) TBD - does not actually exist yet.
+
+group: "detect"
+***************
+the detection by correlation and clustering stage.
+
+- metric_image: (always same as seeder seed_image?)
+- attribute: (str) the name of the attribute shown in the metric_image
+- rois: (TBD) how to implement list of ROIs in hdf5
+
+group: "merge"
+**************
+potential merging of adjacent ROIs
+
+- rois: (TBD) how to implement list of ROIs in hdf5
+
+group: "filter"
+***************
+post-process filters like size and ...
+
+- rois: (TBD) how to implement list of ROIs in hdf5

--- a/src/ophys_etl/modules/segmentation/modules/README.rst
+++ b/src/ophys_etl/modules/segmentation/modules/README.rst
@@ -1,6 +1,7 @@
 Segmentation Steps
 ==================
 - Detect (feature_vector_segmentation.py)
+- Pre-merge filter (TBD)
 - Merge (roi_merging.py)
 - Filter (TBD)
 
@@ -9,7 +10,7 @@ Segmentation QC hdf5 output description
 
 group: "seed"
 *************
-the seeder works in conjunction with the detection algorithm. This groups logs what seeds were provided, which were excluded, and the reasons for exclusion.
+the seeder works in conjunction with the detection algorithm. This group logs what seeds were provided, which were excluded, and the reasons for exclusion.
 
 - provided_seeds: (row, col) coordinates of seeds served to the segmentation algorithm
 - excluded_seeds: (row, col) coordinates of seeds not served to the segmentation algorithm

--- a/src/ophys_etl/modules/segmentation/modules/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/modules/feature_vector_segmentation.py
@@ -38,7 +38,7 @@ class FeatureVectorSegmentationRunner(argschema.ArgSchemaParser):
         else:
             plot_output = None
         segmenter.run(roi_output=self.args['roi_output'],
-                      seed_output=pathlib.Path(self.args['seed_output']),
+                      qc_output=pathlib.Path(self.args['qc_output']),
                       plot_output=plot_output,
                       seed_plot_output=self.args['seed_plot_output'])
 

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -274,11 +274,10 @@ class FeatureVectorSegmentationInputSchema(argschema.ArgSchema):
         allow_none=True,
         description="path to summary plot of segmentation")
 
-    seed_output = argschema.fields.OutputFile(
-        required=False,
+    qc_output = argschema.fields.OutputFile(
+        required=True,
         default=None,
-        description=("path to json file where seed points "
-                     "will be saved"))
+        description=("path to hdf5 QC output"))
 
     seed_plot_output = argschema.fields.OutputFile(
         required=False,
@@ -409,6 +408,17 @@ class RoiMergerSchema(argschema.ArgSchema):
     roi_input = argschema.fields.InputFile(
         required=True,
         description=("path to JSON file with ROIs to merge"))
+
+    qc_output = argschema.fields.OutputFile(
+        required=True,
+        default=None,
+        description=("path to hdf5 QC output"))
+
+    plot_output = argschema.fields.OutputFile(
+        required=False,
+        default=None,
+        allow_none=True,
+        description="path to summary plot of segmentation")
 
     roi_output = argschema.fields.OutputFile(
         required=True,

--- a/src/ophys_etl/modules/segmentation/qc/detect.py
+++ b/src/ophys_etl/modules/segmentation/qc/detect.py
@@ -1,0 +1,80 @@
+import numpy as np
+from typing import List
+from matplotlib.figure import Figure
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+from ophys_etl.modules.segmentation.qc_utils import roi_utils
+from ophys_etl.types import ExtractROI
+
+
+def roi_metric_qc_plot(
+        figure: Figure,
+        metric_image: np.ndarray,
+        attribute: str,
+        roi_list: List[ExtractROI]) -> None:
+    """creates a QC plot given some ROIs and a metric image
+
+    Parameters
+    ----------
+    figure: matplotlib.figure.Figure
+        the figure to write into
+    metric_image: np.ndarray
+        the metric to plot and use for calculating average metric
+    attribute: str
+        the name of the metric, displayed in a plot title
+    roi_list: List[ExtractROI]
+        the list of ROIs to plot and from which to compute average metric
+
+
+    Notes
+    -----
+    upper left: metric as an image
+    upper right: same as upper left, with ROI outlines superimposed
+    lower left: scatter plot of n pixels vs average metric per ROI
+    lower right: histogram of average metric
+
+    """
+    # show the metric image with and without ROIs
+    ax00 = figure.add_subplot(2, 2, 1)
+    ax00.imshow(metric_image)
+    ax01 = figure.add_subplot(2, 2, 2)
+    plt_im = ax01.imshow(metric_image)
+    roi_utils.add_rois_to_axes(ax01, roi_list, metric_image.shape)
+    for ax in [ax00, ax01]:
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="5%", pad=0.05)
+        figure.colorbar(plt_im, cax=cax)
+    ax00.set_title(f"metric: {attribute}")
+    ax01.set_title("with ROIs")
+
+    # compute simple measurements of ROIs
+    avg_metric_dict = roi_utils.roi_average_metric(roi_list,
+                                                   metric_image)
+    avg_metric = np.array([avg_metric_dict[i["id"]]
+                           for i in roi_list])
+    npix = [np.count_nonzero(i["mask"]) for i in roi_list]
+
+    # scatter plot of size vs. avg metric
+    ax10 = figure.add_subplot(2, 2, 3)
+    ax10.scatter(avg_metric,
+                 npix, marker="o",
+                 color=plt_im.cmap(avg_metric),
+                 edgecolors=None)
+    ax10.set_xlabel("average metric per ROI")
+    ax10.set_ylabel("n pixels per ROI")
+
+    # histogram of average metric
+    ax11 = figure.add_subplot(2, 2, 4)
+    if (avg_metric.min() > 0.0) & (avg_metric.max() < 1.0):
+        bins = np.linspace(0, 1.0, 50)
+    else:
+        bins = np.linspace(avg_metric.min(), avg_metric.max(), 50)
+    _, _, patches = ax11.hist(avg_metric, bins=bins)
+    for patch in patches:
+        center = patch.get_bbox().intervalx.mean()
+        patch.set_color(plt_im.cmap(center))
+    ax11.set_xlabel("average metric per ROI")
+    ax11.set_ylabel("n ROIs")
+    ax10.set_xlim(ax11.get_xlim())
+
+    figure.tight_layout()

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -702,6 +702,7 @@ def create_roi_plot(plot_path: pathlib.Path,
     Returns
     -------
     None
+
     """
     fig = figure.Figure(figsize=(40, 20))
     axes = [fig.add_subplot(1, 2, i) for i in [1, 2]]
@@ -711,6 +712,35 @@ def create_roi_plot(plot_path: pathlib.Path,
     fig.tight_layout()
     fig.savefig(plot_path)
     return None
+
+
+def roi_average_metric(roi_list: List[ExtractROI],
+                       metric_image: np.ndarray) -> Dict[int, float]:
+    """calculate the average metric for a list of ROIs
+    given an image representation of the metric
+
+    Parameters
+    ----------
+    roi_list: List[ExtractROI]
+        the list of ROIs
+    metric_image: np.ndarray
+        a 2D array of values from which to calculate the average
+        metric, from each ROI mask
+
+    Returns
+    -------
+    average_metric: Dict[int, float]
+        keys: roi[i]["id"]
+        values: average metric within roi[i]["mask"]
+
+    """
+    average_metric: Dict[int, float] = dict()
+    for roi in roi_list:
+        sub_image = metric_image[roi["y"]: (roi["y"] + roi["height"]),
+                                 roi["x"]: (roi["x"] + roi["width"])]
+        average_metric[roi["id"]] = sub_image[np.array(roi["mask"])].mean()
+
+    return average_metric
 
 
 class HNC_ROI(TypedDict):

--- a/src/ophys_etl/modules/segmentation/seed/seeder.py
+++ b/src/ophys_etl/modules/segmentation/seed/seeder.py
@@ -218,7 +218,7 @@ class ImageMetricSeeder(SeederBase):
 
     def log_to_h5_group(self,
                         h5file: h5py.File,
-                        group_name: str = "seeding"):
+                        group_name: str = "seed"):
         """records some attributes of this seeder to an hdf5 group for
         inspection purposes.
 

--- a/tests/modules/segmentation/detect/test_feature_vector_segmentation.py
+++ b/tests/modules/segmentation/detect/test_feature_vector_segmentation.py
@@ -96,18 +96,18 @@ def test_segmenter(tmpdir, example_graph, example_video, seeder_args):
 
     dir_path = pathlib.Path(tmpdir)
     roi_path = dir_path / 'roi.json'
-    seed_path = dir_path / 'seed.json'
+    qc_path = dir_path / 'qc.h5'
     plot_path = dir_path / 'plot.png'
     assert not roi_path.exists()
-    assert not seed_path.exists()
+    assert not qc_path.exists()
     assert not plot_path.exists()
 
     segmenter.run(roi_output=roi_path,
-                  seed_output=seed_path,
+                  qc_output=qc_path,
                   plot_output=plot_path)
 
     assert roi_path.is_file()
-    assert seed_path.is_file()
+    assert qc_path.is_file()
     assert plot_path.is_file()
 
     # check that some ROIs got written
@@ -116,21 +116,21 @@ def test_segmenter(tmpdir, example_graph, example_video, seeder_args):
     assert len(roi_data) > 0
 
     # test that it can handle not receiving a
-    # seed_path or plot_path
+    # qc_path or plot_path
     roi_path.unlink()
-    seed_path.unlink()
+    qc_path.unlink()
     plot_path.unlink()
 
     assert not roi_path.exists()
-    assert not seed_path.exists()
+    assert not qc_path.exists()
     assert not plot_path.exists()
 
     segmenter.run(roi_output=roi_path,
-                  seed_output=None,
+                  qc_output=qc_path,
                   plot_output=None)
 
     assert roi_path.is_file()
-    assert not seed_path.exists()
+    assert qc_path.exists()
     assert not plot_path.exists()
 
 
@@ -147,7 +147,9 @@ def test_segmenter_blank(tmpdir, blank_graph, blank_video, seeder_args):
                                        seeder_args=seeder_args)
     dir_path = pathlib.Path(tmpdir)
     roi_path = dir_path / 'roi.json'
-    segmenter.run(roi_output=roi_path)
+    qc_path = tmpdir / "qc.h5"
+    segmenter.run(roi_output=roi_path,
+                  qc_output=qc_path)
 
 
 def test_is_roi_at_edge():

--- a/tests/modules/segmentation/qc/test_qc_seed.py
+++ b/tests/modules/segmentation/qc/test_qc_seed.py
@@ -25,7 +25,7 @@ def seed_h5_group(tmp_path):
         sb.log_to_h5_group(f)
 
     with h5py.File(h5path, "r") as f:
-        yield f["seeding"]
+        yield f["seed"]
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
@@ -9,18 +9,18 @@ from ophys_etl.types import ExtractROI
 @pytest.fixture
 def roi_list(request):
     rois: List[ExtractROI] = list()
-    for id, full_mask in zip(request.param["full_roi_masks"],
-                               request.param["ids"]):
+    for full_mask, roi_id in zip(request.param["full_roi_masks"],
+                                 request.param["ids"]):
         coords = np.argwhere(full_mask)
         rowmin, colmin = coords.min(axis=0)
         height, width = np.apply_along_axis(func1d=lambda x: x + 1,
                                             axis=0,
                                             arr=coords.ptp(axis=0))
-        mask = [[entry == True for entry in row[colmin: (colmin + width)]]
+        mask = [[bool(entry) for entry in row[colmin: (colmin + width)]]
                 for row in full_mask[rowmin: (rowmin + height)]]
         rois.append(
                 ExtractROI(
-                    id=id,
+                    id=roi_id,
                     x=colmin,
                     y=rowmin,
                     width=width,

--- a/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
@@ -1,0 +1,63 @@
+import pytest
+import numpy as np
+from typing import List
+
+from ophys_etl.modules.segmentation.qc_utils import roi_utils
+from ophys_etl.types import ExtractROI
+
+
+@pytest.fixture
+def roi_list(request):
+    rois: List[ExtractROI] = list()
+    for i, full_mask in enumerate(request.param["full_roi_masks"]):
+        coords = np.argwhere(full_mask)
+        rowmin, colmin = coords.min(axis=0)
+        height, width = np.apply_along_axis(func1d=lambda x: x + 1,
+                                            axis=0,
+                                            arr=coords.ptp(axis=0))
+        mask = [[entry is True for entry in row[colmin: (colmin + width)]]
+                for row in full_mask[rowmin: (rowmin + height)]]
+        rois.append(
+                ExtractROI(
+                    id=i,
+                    x=colmin,
+                    y=rowmin,
+                    width=width,
+                    height=height,
+                    valid=True,
+                    mask=mask))
+    return rois
+
+
+@pytest.mark.parametrize(
+        "metric_image, roi_list, expected",
+        [
+            (
+                np.array([[0.0, 1.0, 2.0, 3.0],
+                          [1.0, 2.0, 3.0, 0.0],
+                          [3.0, 4.0, 4.0, 5.0],
+                          [2.0, 3.0, 4.0, 0.0]]),
+                {
+                    "full_roi_masks":
+                    [
+                        [[1, 1, 0, 0],
+                         [1, 1, 0, 0],
+                         [0, 0, 0, 0],
+                         [0, 0, 0, 0]],
+                        [[0, 0, 0, 0],
+                         [0, 1, 1, 0],
+                         [0, 1, 1, 0],
+                         [0, 0, 1, 0]],
+                        [[0, 0, 0, 0],
+                         [0, 0, 0, 0],
+                         [0, 0, 0, 0],
+                         [1, 1, 1, 1]],
+                        ]},
+                [1.0, 17.0 / 5, 9.0 / 4]),
+            ], indirect=["roi_list"])
+def test_roi_average_metric(roi_list, metric_image, expected):
+    average_metric = roi_utils.roi_average_metric(roi_list=roi_list,
+                                                  metric_image=metric_image)
+    assert len(average_metric) == len(expected)
+    for roi_id, value in enumerate(expected):
+        np.testing.assert_allclose(average_metric[roi_id], value)

--- a/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
@@ -9,17 +9,18 @@ from ophys_etl.types import ExtractROI
 @pytest.fixture
 def roi_list(request):
     rois: List[ExtractROI] = list()
-    for i, full_mask in enumerate(request.param["full_roi_masks"]):
+    for id, full_mask in zip(request.param["full_roi_masks"],
+                               request.param["ids"]):
         coords = np.argwhere(full_mask)
         rowmin, colmin = coords.min(axis=0)
         height, width = np.apply_along_axis(func1d=lambda x: x + 1,
                                             axis=0,
                                             arr=coords.ptp(axis=0))
-        mask = [[entry is True for entry in row[colmin: (colmin + width)]]
+        mask = [[entry == True for entry in row[colmin: (colmin + width)]]
                 for row in full_mask[rowmin: (rowmin + height)]]
         rois.append(
                 ExtractROI(
-                    id=i,
+                    id=id,
                     x=colmin,
                     y=rowmin,
                     width=width,
@@ -38,6 +39,7 @@ def roi_list(request):
                           [3.0, 4.0, 4.0, 5.0],
                           [2.0, 3.0, 4.0, 0.0]]),
                 {
+                    "ids": [0, 1, 2],
                     "full_roi_masks":
                     [
                         [[1, 1, 0, 0],
@@ -53,11 +55,11 @@ def roi_list(request):
                          [0, 0, 0, 0],
                          [1, 1, 1, 1]],
                         ]},
-                [1.0, 17.0 / 5, 9.0 / 4]),
+                    {0: 1.0, 1: 17.0 / 5, 2: 9.0 / 4}),
             ], indirect=["roi_list"])
 def test_roi_average_metric(roi_list, metric_image, expected):
     average_metric = roi_utils.roi_average_metric(roi_list=roi_list,
                                                   metric_image=metric_image)
     assert len(average_metric) == len(expected)
-    for roi_id, value in enumerate(expected):
+    for roi_id, value in expected.items():
         np.testing.assert_allclose(average_metric[roi_id], value)

--- a/tests/modules/segmentation/seed/test_seeder.py
+++ b/tests/modules/segmentation/seed/test_seeder.py
@@ -138,8 +138,8 @@ def test_ImageMetricSeeder_log(tmpdir):
         sb.log_to_h5_group(f)
 
     with h5py.File(h5path, "r") as f:
-        assert "seeding" in f
-        group = f["seeding"]
+        assert "seed" in f
+        group = f["seed"]
         for k in ["provided_seeds", "excluded_seeds",
                   "exclusion_reason", "seed_image"]:
             assert k in group


### PR DESCRIPTION
PR: addresses #269
starts/improves some QC frameworks, though more to be done.

### Contents
* feature_vector_segmentation now requires `qc_output` rather than the optional `seed_output`
* same for `roi_merging`
* proto README regarding the in-development hdf5 QC output file
* augmented plot output of segmentation with new calculation of average metric for each ROI
* merging makes same plot (workflow should name differently)
* renamed seeding hdf5 group from gerund to verb ("seeding" to "seed"), to match detect and merge

example new plot for a small cropped movie:
![image](https://user-images.githubusercontent.com/32312979/126399917-9518134a-537e-451b-b497-777137f29341.png)


### TODO items from development and discussion of this PR:
(will not be covered by this PR)
* move ROIs into hdf5 output ... TBD exactly how. It is not nice to have the jsons separate.
* add some substantive QC output to the merging stage. likely a map of the parent/child relationships of mergers.
* notebook working with QC hdf5 outputs.