### PR TITLE
Segmentation/color/map

### DIFF
--- a/src/ophys_etl/modules/decrosstalk/ophys_plane.py
+++ b/src/ophys_etl/modules/decrosstalk/ophys_plane.py
@@ -144,7 +144,7 @@ class OphysROI(object):
                                       for r, c in valid])
 
         self._global_pixel_array = np.array([[r+self._y0, c+self._x0]
-                                              for r, c in valid])
+                                             for r, c in valid])
 
     @property
     def global_pixel_set(self) -> Set[Tuple[int, int]]:

--- a/src/ophys_etl/modules/decrosstalk/ophys_plane.py
+++ b/src/ophys_etl/modules/decrosstalk/ophys_plane.py
@@ -85,6 +85,7 @@ class OphysROI(object):
         self._boundary_mask = None
         self._area = None
         self._global_pixel_set = None
+        self._global_pixel_array = None
 
         height_match = (self._mask_matrix.shape[0] == self._height)
         width_match = (self._mask_matrix.shape[1] == self._width)
@@ -138,9 +139,12 @@ class OphysROI(object):
         Create the set of (row, col) tuples in
         global coordinates that make up this ROI
         """
+        valid = np.argwhere(self._mask_matrix)
         self._global_pixel_set = set([(r+self._y0, c+self._x0)
-                                      for r, c
-                                      in np.argwhere(self._mask_matrix)])
+                                      for r, c in valid])
+
+        self._global_pixel_array = np.array([[r+self._y0, c+self._x0]
+                                              for r, c in valid])
 
     @property
     def global_pixel_set(self) -> Set[Tuple[int, int]]:
@@ -151,6 +155,16 @@ class OphysROI(object):
         if self._global_pixel_set is None:
             self._create_global_pixel_set()
         return self._global_pixel_set
+
+    @property
+    def global_pixel_array(self) -> np.ndarray:
+        """
+        np.ndarray of pixels in global (row, col) coordinates
+        that are set to True for this ROI
+        """
+        if self._global_pixel_array is None:
+            self._create_global_pixel_set()
+        return self._global_pixel_array
 
     @property
     def area(self) -> int:

--- a/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
@@ -92,8 +92,6 @@ class ROIComparisonEngine(argschema.ArgSchemaParser):
 
     def run(self):
 
-        invalid_color = (235, 52, 52)
-
         bckgd_paths = [pathlib.Path(p)
                        for p in self.args['background_paths']]
 
@@ -105,7 +103,6 @@ class ROIComparisonEngine(argschema.ArgSchemaParser):
                     self.args['background_names'],
                     roi_paths,
                     self.args['roi_names'],
-                    invalid_color=invalid_color,
                     attribute_name=self.args['attribute_name'],
                     figsize_per=self.args['figsize_per'])
 

--- a/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_comparison.py
@@ -92,12 +92,6 @@ class ROIComparisonEngine(argschema.ArgSchemaParser):
 
     def run(self):
 
-        # colors that showup reasonably well against our
-        # grayscale background images
-        color_list = [(0, 255, 0),
-                      (51, 153, 55),
-                      (51, 255, 255)]
-
         invalid_color = (235, 52, 52)
 
         bckgd_paths = [pathlib.Path(p)
@@ -111,7 +105,6 @@ class ROIComparisonEngine(argschema.ArgSchemaParser):
                     self.args['background_names'],
                     roi_paths,
                     self.args['roi_names'],
-                    color_list,
                     invalid_color=invalid_color,
                     attribute_name=self.args['attribute_name'],
                     figsize_per=self.args['figsize_per'])

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -11,7 +11,7 @@ from ophys_etl.modules.segmentation.graph_utils.conversion import (
     graph_to_img)
 
 from ophys_etl.modules.segmentation.qc_utils.roi_utils import (
-    add_roi_boundaries_to_img)
+    add_list_of_roi_boundaries_to_img)
 
 from ophys_etl.modules.segmentation.qc_utils.video_utils import (
     scale_video_to_uint8)
@@ -204,12 +204,14 @@ def create_roi_v_background_grid(
             if i_bckgd == 0:
                 axis.set_title(roi_names[i_roi], fontsize=fontsize)
 
-            img = add_roi_boundaries_to_img(background_array,
+            img = add_list_of_roi_boundaries_to_img(
+                                            background_array,
                                             invalid_roi_list,
                                             color=invalid_color,
                                             alpha=1.0)
 
-            img = add_roi_boundaries_to_img(img,
+            img = add_list_of_roi_boundaries_to_img(
+                                            img,
                                             valid_roi_list,
                                             color=this_color,
                                             alpha=1.0)

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -132,7 +132,6 @@ def create_roi_v_background_grid(
         background_names: Union[str, List[str]],
         roi_paths: Union[pathlib.Path, List[pathlib.Path]],
         roi_names: Union[str, List[str]],
-        invalid_color: Tuple[int, int, int] = (255, 0, 0),
         attribute_name: str = 'filtered_hnc_Gaussian',
         figsize_per: int = 10) -> mplt_fig.Figure:
     """
@@ -158,10 +157,6 @@ def create_roi_v_background_grid(
     roi_names: Union[str, List[str]]
         The names of the ROI sets as they will appear in te plot
         (there must be an equal number of roi_names as roi_paths)
-
-    invalid_color: Tuple[int, int, int]
-        RGB color to use for invalid ROIs.
-        (default = (255, 0, 0))
 
     attribute_name: str
         The name of the attribute to use in constructing the background
@@ -286,7 +281,7 @@ def create_roi_v_background_grid(
                 invalid_img = add_roi_boundary_to_img(
                                  invalid_img,
                                  roi,
-                                 invalid_color,
+                                 this_color_map[roi.roi_id],
                                  1.0)
 
             valid_axis.imshow(valid_img)

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -24,6 +24,45 @@ else:
     from typing_extensions import TypedDict
 
 
+def add_roi_mask_to_img(
+        img: np.ndarray,
+        roi: OphysROI,
+        color: Tuple[int],
+        alpha: float) -> np.ndarray:
+    """
+    Add colored ROI mask to an image
+
+    Parameters
+    ----------
+    img: np.ndarray
+        RGB representation of image
+
+    roi: OphysROI
+
+    color: Tuple[int]
+        RGB color of ROI
+
+    alpha: float
+
+    Returns
+    -------
+    img: np.ndarray
+
+    Note
+    ----
+    While this function does return an image, it also operates
+    on img in place
+    """
+    rows = roi.global_pixel_array[:, 0]
+    cols = roi.global_pixel_array[:, 1]
+    for ic in range(3):
+        old_vals = img[rows, cols, ic]
+        new_vals = np.round(alpha*color[ic]+(1.0-alpha)*old_vals).astype(int)
+        img[rows, cols, ic] = new_vals
+    img = np.where(img >= 255, 255, img)
+    return img
+
+
 def add_list_of_roi_boundaries_to_img(
         img: np.ndarray,
         roi_list: Union[List[OphysROI], List[Dict]],

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -63,6 +63,47 @@ def add_roi_mask_to_img(
     return img
 
 
+def add_roi_boundary_to_img(
+        img: np.ndarray,
+        roi: OphysROI,
+        color: Tuple[int],
+        alpha: float) -> np.ndarray:
+    """
+    Add colored ROI boundary to an image
+
+    Parameters
+    ----------
+    img: np.ndarray
+        RGB representation of image
+
+    roi: OphysROI
+
+    color: Tuple[int]
+        RGB color of ROI
+
+    alpha: float
+
+    Returns
+    -------
+    img: np.ndarray
+
+    Note
+    ----
+    While this function does return an image, it also operates
+    on img in place
+    """
+    bdry = roi.boundary_mask
+    valid = np.argwhere(bdry)
+    rows = np.array([r+roi.y0 for r in valid[:, 0]])
+    cols = np.array([c+roi.x0 for c in valid[:, 1]])
+    for ic in range(3):
+        old_vals = img[rows, cols, ic]
+        new_vals = np.round(alpha*color[ic]+(1.0-alpha)*old_vals).astype(int)
+        img[rows, cols, ic] = new_vals
+    img = np.where(img >= 255, 255, img)
+    return img
+
+
 def add_list_of_roi_boundaries_to_img(
         img: np.ndarray,
         roi_list: Union[List[OphysROI], List[Dict]],
@@ -101,20 +142,11 @@ def add_list_of_roi_boundaries_to_img(
                     for roi in roi_list]
 
     for roi in roi_list:
-        bdry = roi.boundary_mask
-        for icol in range(roi.width):
-            for irow in range(roi.height):
-                if not bdry[irow, icol]:
-                    continue
-                yy = roi.y0 + irow
-                xx = roi.x0 + icol
-                for ic in range(3):
-                    old_val = np.round(img[yy, xx, ic]*(1.0-alpha)).astype(int)
-                    new_img[yy, xx, ic] = old_val
-                    new_val = np.round(alpha*color[ic]).astype(int)
-                    new_img[yy, xx, ic] += new_val
-
-    new_img = np.where(new_img <= 255, new_img, 255)
+        new_img = add_roi_boundary_to_img(
+                      new_img,
+                      roi,
+                      color,
+                      alpha)
     return new_img
 
 

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -24,10 +24,11 @@ else:
     from typing_extensions import TypedDict
 
 
-def add_roi_boundaries_to_img(img: np.ndarray,
-                              roi_list: Union[List[OphysROI], List[Dict]],
-                              color: Tuple[int] = (255, 0, 0),
-                              alpha: float = 0.25) -> np.ndarray:
+def add_list_of_roi_boundaries_to_img(
+        img: np.ndarray,
+        roi_list: Union[List[OphysROI], List[Dict]],
+        color: Tuple[int] = (255, 0, 0),
+        alpha: float = 0.25) -> np.ndarray:
     """
     Add colored ROI boundaries to an image
 
@@ -236,7 +237,8 @@ def roi_thumbnail(movie: OphysMovie,
                        valid_roi=True,
                        roi_id=-999)
 
-    thumbnail = add_roi_boundaries_to_img(thumbnail,
+    thumbnail = add_list_of_roi_boundaries_to_img(
+                                          thumbnail,
                                           roi_list=[new_roi],
                                           color=roi_color,
                                           alpha=alpha)
@@ -354,7 +356,8 @@ class ROIExaminer(object):
         """
         output_img = self.ophys_movie.get_max_rgb()
         for obj in rois_and_colors:
-            output_img = add_roi_boundaries_to_img(output_img,
+            output_img = add_list_of_roi_boundaries_to_img(
+                                                   output_img,
                                                    roi_list=obj['rois'],
                                                    alpha=alpha,
                                                    color=obj['color'])

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -141,40 +141,6 @@ def _do_rois_abut(array_0: np.ndarray,
     return False
 
 
-def _get_pixel_array(roi: OphysROI) -> np.ndarray:
-    """
-    get Nx2 array of pixels (in global coordinates)
-    that are in the ROI
-
-    Parameters
-    ----------
-    OphysROI
-
-    Returns
-    -------
-    np.ndarray
-    """
-    mask = roi.mask_matrix
-    npix = mask.sum()
-    roi_array = -1*np.ones((npix, 2), dtype=int)
-    i_pix = 0
-    for ir in range(roi.height):
-        row = ir+roi.y0
-        for ic in range(roi.width):
-            col = ic+roi.x0
-            if not mask[ir, ic]:
-                continue
-
-            roi_array[i_pix, 0] = row
-            roi_array[i_pix, 1] = col
-            i_pix += 1
-
-    if roi_array.min() < 0:
-        raise RuntimeError("did not assign all pixels")
-
-    return roi_array
-
-
 def do_rois_abut(roi0: OphysROI,
                  roi1: OphysROI,
                  pixel_distance: float = np.sqrt(2)) -> bool:
@@ -202,11 +168,9 @@ def do_rois_abut(roi0: OphysROI,
     that corresponds to pixel_distance=1; pixel_distance=2 corresponds
     to 1 blank pixel between ROIs
     """
-    array_0 = _get_pixel_array(roi0)
-    array_1 = _get_pixel_array(roi1)
 
-    return _do_rois_abut(array_0,
-                         array_1,
+    return _do_rois_abut(roi0.global_pixel_array,
+                         roi1.global_pixel_array,
                          pixel_distance=pixel_distance)
 
 

--- a/tests/modules/segmentation/qc_utils/conftest.py
+++ b/tests/modules/segmentation/qc_utils/conftest.py
@@ -1,0 +1,88 @@
+import pytest
+import pathlib
+import numpy as np
+import json
+import PIL.Image
+import networkx as nx
+from itertools import combinations, product
+
+from ophys_etl.types import ExtractROI
+
+
+@pytest.fixture(scope='session')
+def list_of_roi():
+    """
+    A list of ExtractROIs
+    """
+    output = []
+    rng = np.random.default_rng(11231)
+    for ii in range(10):
+        x0 = int(rng.integers(0, 30))
+        y0 = int(rng.integers(0, 30))
+        width = int(rng.integers(4, 10))
+        height = int(rng.integers(4, 10))
+        mask = rng.integers(0, 2, size=(height, width)).astype(bool)
+
+        # because np.ints are not JSON serializable
+        real_mask = []
+        for row in mask:
+            this_row = []
+            for el in row:
+                if el:
+                    this_row.append(True)
+                else:
+                    this_row.append(False)
+            real_mask.append(this_row)
+
+        if ii % 2 == 0:
+            valid_roi = True
+        else:
+            valid_roi = False
+        roi = ExtractROI(x=x0, width=width,
+                         y=y0, height=height,
+                         valid_roi=valid_roi,
+                         mask=real_mask,
+                         id=ii)
+        output.append(roi)
+    return output
+
+
+@pytest.fixture(scope='session')
+def roi_file(tmpdir_factory, list_of_roi):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('roi_reading'))
+    file_path = tmpdir/'list_of_rois.json'
+    with open(file_path, 'w') as out_file:
+        json.dump(list_of_roi, out_file)
+    yield file_path
+
+
+@pytest.fixture(scope='session')
+def background_png(tmpdir_factory):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('background_png'))
+    rng = np.random.default_rng(887123)
+    image_array = rng.integers(0, 255, size=(50, 50)).astype(np.uint8)
+    image = PIL.Image.fromarray(image_array)
+    file_path = tmpdir/'background.png'
+    image.save(file_path)
+    yield file_path
+
+
+@pytest.fixture(scope='session')
+def background_pkl(tmpdir_factory):
+    tmpdir = pathlib.Path(tmpdir_factory.mktemp('background_pkl'))
+    graph = nx.Graph()
+    rng = np.random.default_rng(543221)
+    coords = np.arange(0, 50)
+    for xx, yy in combinations(coords, 2):
+        minx = max(0, xx-1)
+        miny = max(0, yy-1)
+        maxx = min(xx+2, 50)
+        maxy = min(yy+2, 50)
+        xx_other = np.arange(minx, maxx)
+        yy_other = np.arange(miny, maxy)
+        for x1, y1 in product(xx_other, yy_other):
+            graph.add_edge((xx, yy), (x1, y1), dummy_value=rng.random())
+
+    file_path = tmpdir/'background_graph.pkl'
+    nx.write_gpickle(graph, file_path)
+    yield file_path

--- a/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_qc_roi_utils.py
@@ -67,6 +67,48 @@ def test_roi_average_metric(roi_list, metric_image, expected):
 
 
 @pytest.mark.parametrize('alpha', [0.2, 0.3, 0.4])
+def test_add_roi_boundary_to_img(alpha):
+    img = 100*np.ones((64, 64, 3), dtype=int)
+
+    height = 7
+    width = 12
+
+    mask = np.zeros((height, width), dtype=bool)
+    mask[1, 5:7] = True
+    mask[2, 4:8] = True
+    mask[3, 3:9] = True
+    mask[4, 2:10] = True
+    mask[5, 3:9] = True
+
+    bdry_pixels = set([(1, 5), (1, 6), (2, 4), (2, 7),
+                       (3, 3), (3, 8), (4, 2), (4, 9),
+                       (5, 3), (5, 4), (5, 5), (5, 6),
+                       (5, 7), (5, 8)])
+
+    roi = OphysROI(x0=20, width=width,
+                   y0=15, height=height,
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+
+    color = (22, 33, 44)
+    img = roi_utils.add_roi_boundary_to_img(
+                      img,
+                      roi,
+                      color,
+                      alpha)
+
+    for row in range(height):
+        for col in range(width):
+            for ic in range(3):
+                if (row, col) not in bdry_pixels:
+                    assert img[15+row, 20+col, ic] == 100
+                else:
+                    expected = np.round(alpha*color[ic]
+                                        + (1.0-alpha)*100).astype(int)
+                    assert img[15+row, 20+col, ic] == expected
+
+
+@pytest.mark.parametrize('alpha', [0.2, 0.3, 0.4])
 def test_add_roi_mask_to_img(alpha):
     rng = np.random.default_rng(634212)
     img = 100*np.ones((64, 64, 3), dtype=int)

--- a/tests/modules/segmentation/qc_utils/test_roi_coloring.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_coloring.py
@@ -1,0 +1,64 @@
+import pytest
+import numpy as np
+
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+
+from ophys_etl.modules.segmentation.utils.roi_utils import do_rois_abut
+
+from ophys_etl.modules.segmentation.qc_utils.roi_comparison_utils import (
+    get_roi_color_map)
+
+
+@pytest.fixture(scope='session')
+def roi_list():
+    """
+    List of OphysROI
+    """
+    output = []
+
+    # construct an image with a bunch of connected
+    # ROIs
+    full_field = np.zeros((64, 64), dtype=int)
+    full_field[32:49, 32:40] = 1
+    full_field[20:34, 20:35] = 2
+    full_field[34:38, 20:35] = 3
+    full_field[32:37, 40:45] = 4
+    full_field[32:37, 45:50] = 5
+    full_field[10:17, 39:50] = 6
+    full_field[10:17, 37:39] = 7
+    full_field[5:10, 37:39] = 8
+    full_field[34:46, 34:37] = 9
+
+    for roi_id in range(1, 10, 1):
+        valid = np.argwhere(full_field == roi_id)
+        min_row = valid[:, 0].min()
+        min_col = valid[:, 1].min()
+        max_row = valid[:, 0].max()
+        max_col = valid[:, 1].max()
+        height = max_row-min_row+1
+        width = max_col-min_col+1
+        mask = np.zeros((height, width), dtype=bool)
+        mask[valid[:, 0]-min_row, valid[:, 1]-min_col] = True
+        roi = OphysROI(x0=int(min_col), width=int(width),
+                       y0=int(min_row), height=int(height),
+                       mask_matrix=mask,
+                       roi_id=roi_id, valid_roi=True)
+        output.append(roi)
+    return output
+
+
+def test_roi_coloring(roi_list):
+    color_map = get_roi_color_map(roi_list)
+    for roi in roi_list:
+        assert roi.roi_id in color_map
+    assert len(color_map) == len(roi_list)
+    pairs = 0
+    for ii in range(len(roi_list)):
+        roi0 = roi_list[ii]
+        for jj in range(ii+1, len(roi_list)):
+            roi1 = roi_list[jj]
+            if do_rois_abut(roi0, roi1):
+                pairs += 1
+                assert color_map[roi0.roi_id] != color_map[roi1.roi_id]
+    assert pairs > 0
+    assert len(set(color_map.values())) < len(roi_list)

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_module.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_module.py
@@ -2,7 +2,8 @@ import pytest
 import pathlib
 
 from ophys_etl.modules.segmentation.modules.roi_comparison import (
-    ROIComparisonSchema)
+    ROIComparisonSchema,
+    ROIComparisonEngine)
 
 
 def test_roi_comparison_schema(tmpdir):
@@ -69,3 +70,26 @@ def test_roi_comparison_schema(tmpdir):
                 'plot_output': str(tmpdir_path/'junk.png')}
 
         roi_schema.load(data)
+
+
+@pytest.mark.parametrize('roi_names, background_names',
+                         [(None, None), (['ROIs'], ['pkl', 'png'])])
+def test_roi_comparison_engine(tmpdir,
+                               roi_file,
+                               background_pkl,
+                               background_png,
+                               roi_names,
+                               background_names):
+
+    plot_path = pathlib.Path(tmpdir)/'output_plot.png'
+    data = {'roi_paths': [str(roi_file)],
+            'roi_names': roi_names,
+            'background_paths': [str(background_pkl), str(background_png)],
+            'background_names': background_names,
+            'attribute_name': 'dummy_value',
+            'figsize_per': 3,
+            'plot_output': str(plot_path)}
+
+    engine = ROIComparisonEngine(input_data=data, args=[])
+    engine.run()
+    assert plot_path.is_file()

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
@@ -1,95 +1,9 @@
 import pytest
 import pathlib
-import numpy as np
-import json
-import PIL.Image
-import networkx as nx
-from itertools import combinations, product
-
-from ophys_etl.types import ExtractROI
 
 from ophys_etl.modules.segmentation.qc_utils.roi_comparison_utils import (
     _validate_paths_v_names,
     create_roi_v_background_grid)
-
-
-@pytest.fixture(scope='session')
-def list_of_roi():
-    """
-    A list of ExtractROIs
-    """
-    output = []
-    rng = np.random.default_rng(11231)
-    for ii in range(10):
-        x0 = int(rng.integers(0, 30))
-        y0 = int(rng.integers(0, 30))
-        width = int(rng.integers(4, 10))
-        height = int(rng.integers(4, 10))
-        mask = rng.integers(0, 2, size=(height, width)).astype(bool)
-
-        # because np.ints are not JSON serializable
-        real_mask = []
-        for row in mask:
-            this_row = []
-            for el in row:
-                if el:
-                    this_row.append(True)
-                else:
-                    this_row.append(False)
-            real_mask.append(this_row)
-
-        if ii % 2 == 0:
-            valid_roi = True
-        else:
-            valid_roi = False
-        roi = ExtractROI(x=x0, width=width,
-                         y=y0, height=height,
-                         valid_roi=valid_roi,
-                         mask=real_mask,
-                         id=ii)
-        output.append(roi)
-    return output
-
-
-@pytest.fixture(scope='session')
-def roi_file(tmpdir_factory, list_of_roi):
-    tmpdir = pathlib.Path(tmpdir_factory.mktemp('roi_reading'))
-    file_path = tmpdir/'list_of_rois.json'
-    with open(file_path, 'w') as out_file:
-        json.dump(list_of_roi, out_file)
-    yield file_path
-
-
-@pytest.fixture(scope='session')
-def background_png(tmpdir_factory):
-    tmpdir = pathlib.Path(tmpdir_factory.mktemp('background_png'))
-    rng = np.random.default_rng(887123)
-    image_array = rng.integers(0, 255, size=(50, 50)).astype(np.uint8)
-    image = PIL.Image.fromarray(image_array)
-    file_path = tmpdir/'background.png'
-    image.save(file_path)
-    yield file_path
-
-
-@pytest.fixture(scope='session')
-def background_pkl(tmpdir_factory):
-    tmpdir = pathlib.Path(tmpdir_factory.mktemp('background_pkl'))
-    graph = nx.Graph()
-    rng = np.random.default_rng(543221)
-    coords = np.arange(0, 50)
-    for xx, yy in combinations(coords, 2):
-        minx = max(0, xx-1)
-        miny = max(0, yy-1)
-        maxx = min(xx+2, 50)
-        maxy = min(yy+2, 50)
-        xx_other = np.arange(minx, maxx)
-        yy_other = np.arange(miny, maxy)
-        for x1, y1 in product(xx_other, yy_other):
-            graph.add_edge((xx, yy), (x1, y1), dummy_value=rng.random())
-
-    file_path = tmpdir/'background_graph.pkl'
-    nx.write_gpickle(graph, file_path)
-    yield file_path
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_comparison_utils.py
@@ -159,7 +159,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             ['png', 'pkl'],
             [roi_file, roi_file, roi_file],
             ['a', 'b', 'c'],
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     # one background; many ROIs
@@ -168,7 +167,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             'png',
             [roi_file, roi_file, roi_file],
             ['a', 'b', 'c'],
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     # one background; one ROI
@@ -177,7 +175,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             'png',
             roi_file,
             'a',
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     # many backgrounds; one ROIs
@@ -186,7 +183,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             ['png', 'pkl'],
             roi_file,
             'a',
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     # different combinations of singleton/1-element list inputs
@@ -195,7 +191,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             ['png'],
             [roi_file, roi_file, roi_file],
             ['a', 'b', 'c'],
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     create_roi_v_background_grid(
@@ -203,7 +198,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             ['png', 'pkl'],
             roi_file,
             ['a'],
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     create_roi_v_background_grid(
@@ -211,7 +205,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             'png',
             [roi_file, roi_file, roi_file],
             ['a', 'b', 'c'],
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     create_roi_v_background_grid(
@@ -219,7 +212,6 @@ def test_create_roi_v_background(tmpdir, background_png,
             ['png', 'pkl'],
             [roi_file],
             'a',
-            [(255, 0, 0), (0, 255, 0)],
             attribute_name='dummy_value')
 
     # test that error is raised when an unknown background file type
@@ -230,7 +222,6 @@ def test_create_roi_v_background(tmpdir, background_png,
                 ['png', 'junk'],
                 [roi_file],
                 ['a'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')
 
     # test that errors are raised when paths and shapes are of
@@ -241,7 +232,6 @@ def test_create_roi_v_background(tmpdir, background_png,
                 ['png'],
                 [roi_file, roi_file, roi_file],
                 ['a', 'b', 'c'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')
 
     with pytest.raises(RuntimeError, match='These must be the same shape'):
@@ -250,7 +240,6 @@ def test_create_roi_v_background(tmpdir, background_png,
                 'png',
                 [roi_file, roi_file, roi_file],
                 ['a', 'b', 'c'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')
 
     with pytest.raises(RuntimeError, match='These must be the same shape'):
@@ -259,7 +248,6 @@ def test_create_roi_v_background(tmpdir, background_png,
                 ['png', 'pkl'],
                 [roi_file, roi_file, roi_file],
                 ['a', 'b', 'c'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')
 
     with pytest.raises(RuntimeError, match='These must be the same shape'):
@@ -268,7 +256,6 @@ def test_create_roi_v_background(tmpdir, background_png,
                 ['png', 'pkl'],
                 [roi_file, roi_file, roi_file],
                 ['a', 'b'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')
 
     with pytest.raises(RuntimeError, match='These must be the same shape'):
@@ -277,7 +264,6 @@ def test_create_roi_v_background(tmpdir, background_png,
                 ['png', 'pkl'],
                 [roi_file, roi_file],
                 ['a', 'b', 'c'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')
 
     with pytest.raises(RuntimeError, match='These must be the same shape'):
@@ -286,5 +272,4 @@ def test_create_roi_v_background(tmpdir, background_png,
                 ['png', 'pkl'],
                 roi_file,
                 ['a', 'b', 'c'],
-                [(255, 0, 0), (0, 255, 0)],
                 attribute_name='dummy_value')


### PR DESCRIPTION
This PR addresses ticket #300, plotting full field of view ROIs in such away that adjacent ROIs appear in distinct colors.

Note: this PR relies on `networkx`'s greedy coloring algorithm, which does not find a simple 4 color solution in most cases. Without going into too much detail, the problem appears to be that the connectedness graphs of our ROIs violate planarity (running `networkx.check_planarity` on the graph representation of an example ROI field returned `False`). I haven't thought too hard about why that might be, but this solution seems to accomplish the desired visualization. See ticket #300 for validation plots.