### PR TITLE
Added new suite2p motion correction arguments to the schema

### DIFF
--- a/src/ophys_etl/modules/suite2p_wrapper/schemas.py
+++ b/src/ophys_etl/modules/suite2p_wrapper/schemas.py
@@ -44,6 +44,23 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
             default=0.2,
             description=("max allowed registration shift, as a fraction of "
                          "frame max(width and height)"))
+    nimg_init = argschema.fields.Int(
+        default=200,
+        description=("How many frames to use to compute reference "
+                     "image for registration"))
+    smooth_sigma = argschema.fields.Float(
+        default=1.15,
+        description=("Standard deviation in pixels of the gaussian used "
+                     "to smooth the phase correlation between the reference "
+                     "image and the frame which is being registered. A "
+                     "value of >4 is recommended for one-photon "
+                     "recordings (with a 512x512 pixel FOV)."))
+    smooth_sigma_time = argschema.fields.Float(
+        default=0,
+        description=("Standard deviation in time frames of the gaussian "
+                     "used to smooth the data before phase correlation is "
+                     "computed. Might need this to be set to 1 or 2 for "
+                     "low SNR data."))
     # s2p cell detection settings
     roidetect = argschema.fields.Bool(
             default=True,


### PR DESCRIPTION
I have added three new arguments (nimg_init, smooth_sigma, and smooth_sigma_time) as optional arguments in the suite2p motion correction schema.

These were required for issue #268 and may be used in production in the future.