### PR TITLE
Segmentation/order/seed/plot

### DIFF
--- a/src/ophys_etl/modules/segmentation/qc/seed.py
+++ b/src/ophys_etl/modules/segmentation/qc/seed.py
@@ -33,24 +33,43 @@ def add_seeds_to_axes(
                              f"np.ndarray|str not {type(image_background)}")
         axes.imshow(image, cmap="gray")
 
-    # plot the seeds
-    provided = seed_h5_group["provided_seeds"][()]
-    if len(provided) != 0:
-        axes.scatter(provided[:, 1], provided[:, 0],
-                     marker="o", label="provided seeds")
-
+    # figure out how many reasons there are to exclude pixels
     excluded = seed_h5_group["excluded_seeds"][()]
+    n_exclusion_reasons = 0
     if len(excluded) != 0:
         exclusion_reason = np.array(
                 [i.decode("utf-8")
                  for i in seed_h5_group["exclusion_reason"][()]])
-        reasons = np.unique(exclusion_reason)
-        for reason in reasons:
+        unique_reasons = np.unique(exclusion_reason)
+        n_exclusion_reasons = len(unique_reasons)
+
+    # plot the provided seeds, using zorder to make sure
+    # they end up on top of the excluded pixels
+    provided = seed_h5_group["provided_seeds"][()]
+    if len(provided) != 0:
+        axes.scatter(provided[:, 1], provided[:, 0],
+                     marker="o", label="provided seeds",
+                     zorder=n_exclusion_reasons+2)
+
+    if len(excluded) != 0:
+        # order exclusion reasons in descending order of "population"
+        # so we plot the least numerous excluded pixels on top of the
+        # most numerous excluded pixels
+        ct_per_reason = np.array([len(np.where(exclusion_reason==i)[0])
+                                  for i in unique_reasons])
+        sorted_index = np.argsort(-1*ct_per_reason)
+        unique_reasons = unique_reasons[sorted_index]
+        for i_reason, reason in enumerate(unique_reasons):
             index = np.array([i == reason for i in exclusion_reason])
+
+            # note: zorder=i_reason+1 to keep marks on top of the
+            # background image
             axes.scatter(excluded[index, 1],
                          excluded[index, 0],
                          marker="x",
-                         label=reason)
+                         label=reason,
+                         zorder=i_reason+1,
+                         alpha=0.5)
 
     axes.legend(bbox_to_anchor=(1.05, 1))
     figure.tight_layout()


### PR DESCRIPTION
The current seed plot generation code does not order the populations of excluded seeds based on their population, this causes the provided seeds and seeds excluded by ROIs to be hidden beneath a sea of seeds excluded by fraction
![baseline_seed](https://user-images.githubusercontent.com/1682854/127532166-1dbd3a15-5622-4c95-a80c-ee1d39a7804e.png)

This PR plots the seed populations in ascending order of population, using matplotlib's `zorder` parameter to make sure that less numerous populations get plotted on top of more populous populations. The PR also sets `alpha=0.5` for excluded seeds to make the underlying background image a little more visible. Here is the same thumbnail plotted after this PR

![test_seed](https://user-images.githubusercontent.com/1682854/127532367-6614fd39-6e79-42bd-ac33-c63e8cda558f.png)
