### PR TITLE
Merging qc output

### DIFF
--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_segmentation.py
@@ -7,6 +7,7 @@ import pathlib
 import time
 import json
 import matplotlib
+import datetime
 
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     convert_to_lims_roi)
@@ -476,7 +477,12 @@ class FeatureVectorSegmenter(object):
 
         # log detection to hdf5 QC ouput
         with h5py.File(qc_output, "a") as h5file:
+            if "detect" in list(h5file.keys()):
+                del h5file["detect"]
             group = h5file.create_group("detect")
+            group.create_dataset(
+                    "group_creation_time",
+                    data=str(datetime.datetime.now()).encode("utf-8"))
             group.create_dataset("metric_image", data=self._graph_img)
             group.create_dataset("attribute",
                                  data=self._attribute.encode("utf-8"))

--- a/src/ophys_etl/modules/segmentation/modules/README.rst
+++ b/src/ophys_etl/modules/segmentation/modules/README.rst
@@ -33,7 +33,8 @@ group: "merge"
 potential merging of adjacent ROIs
 
 - group_creation_time: (str) a timestamp for when this group was created.
-- rois: (TBD) how to implement list of ROIs in hdf5
+- merger_ids: N x 2 array of (int) ROI IDs where each row is (dst, src) where
+  src was merged into dst. the src_ID disappears from the rois and dst_ID is retained.
 
 group: "filter"
 ***************

--- a/src/ophys_etl/modules/segmentation/modules/README.rst
+++ b/src/ophys_etl/modules/segmentation/modules/README.rst
@@ -12,6 +12,7 @@ group: "seed"
 *************
 the seeder works in conjunction with the detection algorithm. This group logs what seeds were provided, which were excluded, and the reasons for exclusion.
 
+- group_creation_time: (str) a timestamp for when this group was created.
 - provided_seeds: (row, col) coordinates of seeds served to the segmentation algorithm
 - excluded_seeds: (row, col) coordinates of seeds not served to the segmentation algorithm
 - exclusion_reason: (row, col) (str) reason the seed was not served.
@@ -22,6 +23,7 @@ group: "detect"
 ***************
 the detection by correlation and clustering stage.
 
+- group_creation_time: (str) a timestamp for when this group was created.
 - metric_image: (always same as seeder seed_image?)
 - attribute: (str) the name of the attribute shown in the metric_image
 - rois: (TBD) how to implement list of ROIs in hdf5
@@ -30,10 +32,12 @@ group: "merge"
 **************
 potential merging of adjacent ROIs
 
+- group_creation_time: (str) a timestamp for when this group was created.
 - rois: (TBD) how to implement list of ROIs in hdf5
 
 group: "filter"
 ***************
 post-process filters like size and ...
 
+- group_creation_time: (str) a timestamp for when this group was created.
 - rois: (TBD) how to implement list of ROIs in hdf5

--- a/src/ophys_etl/modules/segmentation/modules/roi_merging.py
+++ b/src/ophys_etl/modules/segmentation/modules/roi_merging.py
@@ -4,6 +4,7 @@ import pathlib
 import h5py
 import json
 import matplotlib
+import datetime
 
 from ophys_etl.modules.segmentation.modules.schemas import \
     RoiMergerSchema
@@ -78,7 +79,12 @@ class RoiMergerEngine(argschema.ArgSchemaParser):
         # log merging to hdf5 QC output
         with h5py.File(self.args['qc_output'], "a") as h5file:
             # TODO: merging should output something to QC
+            if "merge" in list(h5file.keys()):
+                del h5file["merge"]
             group = h5file.create_group("merge")
+            group.create_dataset(
+                    "group_creation_time",
+                    data=str(datetime.datetime.now()).encode("utf-8"))
             group.create_dataset("placeholder", data=[])
 
         write_out_rois(roi_list, self.args['roi_output'])

--- a/src/ophys_etl/modules/segmentation/modules/schemas.py
+++ b/src/ophys_etl/modules/segmentation/modules/schemas.py
@@ -420,6 +420,12 @@ class RoiMergerSchema(argschema.ArgSchema):
         allow_none=True,
         description="path to summary plot of segmentation")
 
+    merge_plot_output = argschema.fields.OutputFile(
+        required=False,
+        default=None,
+        allow_none=True,
+        description="path to plot showing before/after merging")
+
     roi_output = argschema.fields.OutputFile(
         required=True,
         description=("path to JSON file where we will write merged ROIs"))
@@ -458,3 +464,13 @@ class RoiMergerSchema(argschema.ArgSchema):
         default=0.2,
         description=("fraction of timesteps to keep when doing time "
                      "correlations"))
+
+    @post_load
+    def set_merge_plot_path(self, data, **kwargs):
+        if ((data["plot_output"] is not None)
+                & (data["merge_plot_output"] is None)):
+            template = Path(data["plot_output"])
+            merge_plot_path = (template.parent /
+                               f"{template.stem}_merge{template.suffix}")
+            data["merge_plot_output"] = str(merge_plot_path)
+        return data

--- a/src/ophys_etl/modules/segmentation/qc/merge.py
+++ b/src/ophys_etl/modules/segmentation/qc/merge.py
@@ -1,4 +1,3 @@
-import copy
 import numpy as np
 import networkx as nx
 from matplotlib import cm
@@ -6,7 +5,6 @@ from matplotlib.figure import Figure
 from typing import List
 
 from ophys_etl.modules.segmentation.qc_utils import roi_utils
-from ophys_etl.modules.segmentation.utils.roi_utils import convert_roi_keys
 from ophys_etl.types import ExtractROI
 
 
@@ -84,7 +82,7 @@ def roi_ancestor_gallery(figure: Figure,
 
     figure.tight_layout()
 
-    
+
 def roi_merge_plot(figure: Figure,
                    metric_image: np.ndarray,
                    attribute: str,
@@ -119,7 +117,10 @@ def roi_merge_plot(figure: Figure,
 
     # define colors for the different mergers
     cmap = cm.plasma
-    color_indices = np.linspace(start=0, stop=cmap.N, num=len(subgraphs), dtype=int)
+    color_indices = np.linspace(start=0,
+                                stop=cmap.N,
+                                num=len(subgraphs),
+                                dtype=int)
     rng = np.random.default_rng(seed)
     rng.shuffle(color_indices)
 

--- a/src/ophys_etl/modules/segmentation/qc/merge.py
+++ b/src/ophys_etl/modules/segmentation/qc/merge.py
@@ -14,7 +14,9 @@ def roi_ancestor_gallery(figure: Figure,
                          original_roi_list: List[ExtractROI],
                          merged_roi_list: List[ExtractROI],
                          merger_ids: np.ndarray,
-                         merged_id: int) -> None:
+                         merged_id: int,
+                         full_fov: bool = False,
+                         plot_buffer: int = 5) -> None:
     """creates a figure that shows an ROI and all its pre-merge ancestors
 
     Parameters
@@ -33,6 +35,12 @@ def roi_ancestor_gallery(figure: Figure,
         n_merge x 2 array, each row listing the IDs of a single merge.
     merged_id: int
         the ID in the merged list for which to show ancestors
+    full_fov: bool
+        whether to display the ROIs and ancestors in the full FOV (true)
+        or to zoom to a bounding box around the merged ROI
+    plot_buffer: int
+        if full_fov is False, adds a buffer to the zoomed plot around
+        the merged ROI bounding box
 
     """
 
@@ -79,6 +87,16 @@ def roi_ancestor_gallery(figure: Figure,
                                    roi,
                                    metric_image.shape)
         axes[-1].set_title(f"ancestor ROI {ancestor}")
+
+    if not full_fov:
+        xlim = (max(0, merged[0]["x"] - plot_buffer),
+                min(merged[0]["x"] + merged[0]["width"] + plot_buffer,
+                    metric_image.shape[1]))
+        ylim = (max(0, merged[0]["y"] - plot_buffer),
+                min(merged[0]["y"] + merged[0]["height"] + plot_buffer,
+                    metric_image.shape[0]))
+        a0.set_xlim(xlim)
+        a0.set_ylim(ylim[::-1])
 
     figure.tight_layout()
 

--- a/src/ophys_etl/modules/segmentation/qc/merge.py
+++ b/src/ophys_etl/modules/segmentation/qc/merge.py
@@ -7,7 +7,6 @@ from typing import List
 
 from ophys_etl.modules.segmentation.qc_utils import roi_utils
 from ophys_etl.modules.segmentation.utils.roi_utils import convert_roi_keys
-from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 from ophys_etl.types import ExtractROI
 
 
@@ -28,9 +27,9 @@ def roi_ancestor_gallery(figure: Figure,
         the metric to plot and use for calculating average metric
     attribute: str
         the name of the metric, displayed in a plot title
-    original_roi_list: List[OphysROI]
+    original_roi_list: List[ExtractROI]
         the unmerged ROI list
-    merged_roi_list: List[OphysROI]
+    merged_roi_list: List[ExtractROI]
         the merged ROI list
     merger_ids: np.ndarray
         n_merge x 2 array, each row listing the IDs of a single merge.

--- a/src/ophys_etl/modules/segmentation/qc/merge.py
+++ b/src/ophys_etl/modules/segmentation/qc/merge.py
@@ -1,0 +1,159 @@
+import copy
+import numpy as np
+import networkx as nx
+from matplotlib import cm
+from matplotlib.figure import Figure
+from typing import List
+
+from ophys_etl.modules.segmentation.qc_utils import roi_utils
+from ophys_etl.modules.segmentation.utils.roi_utils import convert_roi_keys
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+from ophys_etl.types import ExtractROI
+
+
+def roi_ancestor_gallery(figure: Figure,
+                         metric_image: np.ndarray,
+                         attribute: str,
+                         original_roi_list: List[ExtractROI],
+                         merged_roi_list: List[ExtractROI],
+                         merger_ids: np.ndarray,
+                         merged_id: int) -> None:
+    """creates a figure that shows an ROI and all its pre-merge ancestors
+
+    Parameters
+    ----------
+    figure: matplotlib.figure.Figure
+        the figure to write into
+    metric_image: np.ndarray
+        the metric to plot and use for calculating average metric
+    attribute: str
+        the name of the metric, displayed in a plot title
+    original_roi_list: List[OphysROI]
+        the unmerged ROI list
+    merged_roi_list: List[OphysROI]
+        the merged ROI list
+    merger_ids: np.ndarray
+        n_merge x 2 array, each row listing the IDs of a single merge.
+    merged_id: int
+        the ID in the merged list for which to show ancestors
+
+    """
+
+    # create a graph to separate ancestors
+    graph = nx.from_edgelist(merger_ids)
+    subgraphs = list(nx.connected_components(graph))
+    subgraph = None
+
+    for s in subgraphs:
+        if merged_id in s:
+            subgraph = s
+
+    # if uninvolved in mergers, ancestor is itself
+    if subgraph is None:
+        subgraph = {merged_id}
+
+    # approximate grid for number of plots
+    n_plots = len(subgraph) + 1
+    n_row = int(np.ceil(np.sqrt(n_plots)))
+    n_col = n_row
+    while (n_row * n_col - n_plots) > n_col:
+        n_row -= 1
+    plot_index = 1
+
+    # merged ROI
+    a0 = figure.add_subplot(n_row, n_col, plot_index)
+    a0.imshow(metric_image)
+    merged = [i for i in merged_roi_list if i['id'] == merged_id]
+    roi_utils.add_rois_to_axes(a0,
+                               merged,
+                               metric_image.shape)
+    a0.set_title(f"metric: {attribute}\nmerged ROI {merged_id}")
+
+    axes = []
+    # ancestor ROIs
+    for ancestor in subgraph:
+        plot_index += 1
+        roi = [i for i in original_roi_list if i['id'] == ancestor]
+        axes.append(
+                figure.add_subplot(n_row, n_col, plot_index,
+                                   sharex=a0, sharey=a0))
+        axes[-1].imshow(metric_image)
+        roi_utils.add_rois_to_axes(axes[-1],
+                                   roi,
+                                   metric_image.shape)
+        axes[-1].set_title(f"ancestor ROI {ancestor}")
+
+    figure.tight_layout()
+
+    
+def roi_merge_plot(figure: Figure,
+                   metric_image: np.ndarray,
+                   attribute: str,
+                   original_roi_list: List[ExtractROI],
+                   merged_roi_list: List[ExtractROI],
+                   merger_ids: np.ndarray,
+                   seed: int = 32) -> None:
+    """creates a QC plot showing which ROIs were merged
+
+    Parameters
+    ----------
+    figure: matplotlib.figure.Figure
+        the figure to write into
+    metric_image: np.ndarray
+        the metric to plot and use for calculating average metric
+    attribute: str
+        the name of the metric, displayed in a plot title
+    original_roi_list: List[ExtractROI]
+        the unmerged ROI list
+    merged_roi_list: List[ExtractROI]
+        the merged ROI list
+    merger_ids: np.ndarray
+        n_merge x 2 array, each row listing the IDs of a single merge.
+    seed: int
+        seed for random generation of colors for mergers
+
+    """
+
+    # separate out mergers with different resulting ROIs
+    graph = nx.from_edgelist(merger_ids)
+    subgraphs = list(nx.connected_components(graph))
+
+    # define colors for the different mergers
+    cmap = cm.plasma
+    color_indices = np.linspace(start=0, stop=cmap.N, num=len(subgraphs), dtype=int)
+    rng = np.random.default_rng(seed)
+    rng.shuffle(color_indices)
+
+    ax00 = figure.add_subplot(1, 2, 1)
+    ax01 = figure.add_subplot(1, 2, 2)
+    ax00.imshow(metric_image, cmap="gray")
+    ax01.imshow(metric_image, cmap="gray")
+
+    for subgraph, color_index in zip(subgraphs, color_indices):
+        originals = [i for i in original_roi_list
+                     if i["id"] in subgraph]
+        merged = [i for i in merged_roi_list
+                  if i["id"] in subgraph]
+        if len(merged) != 1:
+            raise ValueError("Expected a single ROI in merging graph "
+                             f"{subgraph} to be in the merged ROI list "
+                             f"but got {len(merged)} ROIs: {merged}")
+        color = cmap(color_index)
+        roi_utils.add_rois_to_axes(ax00,
+                                   originals,
+                                   metric_image.shape,
+                                   rgba=color)
+        roi_utils.add_rois_to_axes(ax01,
+                                   merged,
+                                   metric_image.shape,
+                                   rgba=color)
+
+    # plot in gray ROIs that were not part of merging
+    untouched = [i for i in original_roi_list if i["id"] not in graph]
+    for ax in [ax00, ax01]:
+        roi_utils.add_rois_to_axes(ax,
+                                   untouched,
+                                   metric_image.shape,
+                                   rgba=(0.5, 0.5, 0.5, 1.0))
+    ax00.set_title(f"metric: {attribute}\nunmerged")
+    ax01.set_title(f"metric: {attribute}\nmerged")

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -726,16 +726,29 @@ class ROIExaminer(object):
         return None
 
 
-def add_rois_to_axes(axes, roi_list, shape, rgba=(1.0, 0.0, 0.0, 1.0)):
+def add_rois_to_axes(axes: matplotlib.axes.Axes,
+                     roi_list: List[ExtractROI],
+                     shape: Tuple[int, int],
+                     rgb: Tuple[int, int, int] = (255, 0, 0),
+                     alpha: float = 1.0) -> None:
     """
 
     Parameters
     ----------
-    color: Tuple
-        RGBA float values for outline. color[3] = 1.0 is opaque
+    axes: matplotlib.axes.Axes
+        the axes to add to
+    roi_list: List[ExtractROI]
+        the ROIs to add
+    shape: Tuple[int, int]
+        shape of the FOV
+    rgb: Tuple[int, int, int]
+        0-255 RGB values for the outlines
+    alpha: float
+        transparencey value 0.0-1.0
 
     """
-    bdry_pixels = np.zeros((*shape, 4), dtype=float)
+    bdry_pixels = np.zeros((*shape, 4), dtype=int)
+    rgba = list(rgb) + [int(alpha * 255)]
     for roi in roi_list:
         ophys_roi = OphysROI(
                         roi_id=0,

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -726,11 +726,12 @@ class ROIExaminer(object):
         return None
 
 
-def add_rois_to_axes(axes: matplotlib.axes.Axes,
-                     roi_list: List[ExtractROI],
-                     shape: Tuple[int, int],
-                     rgb: Tuple[int, int, int] = (255, 0, 0),
-                     alpha: float = 1.0) -> None:
+def add_rois_to_axes(
+        axes: matplotlib.axes.Axes,
+        roi_list: List[ExtractROI],
+        shape: Tuple[int, int],
+        rgba: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 1.0)
+        ) -> None:
     """
 
     Parameters
@@ -741,14 +742,11 @@ def add_rois_to_axes(axes: matplotlib.axes.Axes,
         the ROIs to add
     shape: Tuple[int, int]
         shape of the FOV
-    rgb: Tuple[int, int, int]
-        0-255 RGB values for the outlines
-    alpha: float
-        transparencey value 0.0-1.0
+    rgba: Tuple[float, float, float, float]
+        0.0 - 1.0  RGBA values for the outlines
 
     """
-    bdry_pixels = np.zeros((*shape, 4), dtype=int)
-    rgba = list(rgb) + [int(alpha * 255)]
+    bdry_pixels = np.zeros((*shape, 4), dtype=float)
     for roi in roi_list:
         ophys_roi = OphysROI(
                         roi_id=0,

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -726,8 +726,16 @@ class ROIExaminer(object):
         return None
 
 
-def add_rois_to_axes(axes, roi_list, shape):
-    bdry_pixels = np.zeros(shape, dtype=int)
+def add_rois_to_axes(axes, roi_list, shape, rgba=(1.0, 0.0, 0.0, 1.0)):
+    """
+
+    Parameters
+    ----------
+    color: Tuple
+        RGBA float values for outline. color[3] = 1.0 is opaque
+
+    """
+    bdry_pixels = np.zeros((*shape, 4), dtype=float)
     for roi in roi_list:
         ophys_roi = OphysROI(
                         roi_id=0,
@@ -743,11 +751,8 @@ def add_rois_to_axes(axes, roi_list, shape):
             for ic in range(ophys_roi.width):
                 if bdry[ir, ic]:
                     bdry_pixels[ir+ophys_roi.y0,
-                                ic+ophys_roi.x0] = 1
-
-    bdry_pixels = np.ma.masked_where(bdry_pixels == 0,
-                                     bdry_pixels)
-    axes.imshow(bdry_pixels, cmap='autumn', alpha=1.0)
+                                ic+ophys_roi.x0] = rgba
+    axes.imshow(bdry_pixels)
 
 
 def create_roi_plot(plot_path: pathlib.Path,

--- a/src/ophys_etl/modules/segmentation/seed/seeder.py
+++ b/src/ophys_etl/modules/segmentation/seed/seeder.py
@@ -1,4 +1,5 @@
 import h5py
+import datetime
 import numpy as np
 from typing import Tuple, Optional, List, Set
 from collections.abc import Iterator
@@ -237,7 +238,13 @@ class ImageMetricSeeder(SeederBase):
             seed["exclusion_reason"] = "never considered"
             self._excluded_seeds.append(seed)
 
+        if group_name in list(h5file.keys()):
+            del h5file[group_name]
+
         group = h5file.create_group(group_name)
+        group.create_dataset(
+                "group_creation_time",
+                data=str(datetime.datetime.now()).encode("utf-8"))
         group.create_dataset(
                 "provided_seeds",
                 data=np.array([i['coordinates']

--- a/tests/modules/segmentation/merge/test_roi_merging.py
+++ b/tests/modules/segmentation/merge/test_roi_merging.py
@@ -171,11 +171,12 @@ def test_do_roi_merger(roi_and_video_dataset):
 
     img_data = np.mean(roi_and_video_dataset['video'], axis=0)
     assert img_data.shape == roi_and_video_dataset['video'].shape[1:]
-    new_roi_list = do_roi_merger(roi_and_video_dataset['roi_list'],
-                                 roi_and_video_dataset['video'],
-                                 3,
-                                 2.0,
-                                 filter_fraction=0.2)
+    new_roi_list, merger_ids = do_roi_merger(
+            roi_and_video_dataset['roi_list'],
+            roi_and_video_dataset['video'],
+            3,
+            2.0,
+            filter_fraction=0.2)
 
     # test that some mergers were performed
     assert len(new_roi_list) > 0


### PR DESCRIPTION
### Contents
* adds timestamps into QC hdf5 groups, and, allows overwriting of groups.
* tracks mergers by ROI IDs and outputs that information to the QC hdf5
* adds a QC plot (called from the module) which shows the FOV before/after of merging. see below.
* adds a plot utility (not called from the module) where a gallery of ancestors for any particular merged ROI can be shown.

Below: comparing the ancestors (left) and merged (right) ROIs. Merged ROIs have distinct colors. Gray outlines are not involved in any merges. (in this example, some ROIs are combined which we did not expect, but, this plotting code is correct and has revealed an improvement area elsewhere)
![fig1](https://user-images.githubusercontent.com/32312979/127574943-fbba42de-27f9-44e5-b4ba-714f72ae7f65.png)


Below: gallery of ancestors for a single merged ROI.
![fig2](https://user-images.githubusercontent.com/32312979/127574870-5b45a4ec-cd30-4a8a-a61d-430602abcd1b.png)

An example of how to create the latter plot:
```
from ophys_etl.modules.segmentation.qc import merge
import json, h5py
import matplotlib.pyplot as plt

with open(<merged path>, "r") as f:
    merged = json.load(f)

with open(<unmerged path>, "r") as f:
    original = json.load(f)

with h5py.File(<qc path>, "r") as f:
    mi = f["detect"]["metric_image"][()]
    at = f["detect"]["attribute"][()]
    mids = f["merge"]["merger_ids"][()]


fig  = plt.figure(1, clear=True, figsize=(10, 10))
merge.roi_ancestor_gallery(
           figure=fig,
           metric_image=mi,
           attribute=at,
           original_roi_list=original,
           merged_roi_list=merged,
           merger_ids=mids,
           merged_id=0)
```