### PR TITLE
Segmentation/disjoint/rois

### DIFF
--- a/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
+++ b/src/ophys_etl/modules/segmentation/detect/feature_vector_rois.py
@@ -4,6 +4,8 @@ from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 
 from ophys_etl.utils.array_utils import pairwise_distances
+from ophys_etl.modules.segmentation.utils.roi_utils import (
+    select_contiguous_region)
 
 
 def choose_timesteps(
@@ -591,6 +593,10 @@ class PotentialROI(object):
                 continue
             p = self.index_to_pixel[i_pixel]
             output_img[p[0], p[1]] = True
+
+        output_img = select_contiguous_region(
+                            self.seed_pt,
+                            output_img)
 
         return output_img
 

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -1,9 +1,8 @@
 from typing import List, Dict, Tuple
-from itertools import product
 import numpy as np
 import pathlib
 import json
-import networkx
+from skimage.measure import label as skimage_label
 from scipy.spatial.distance import cdist
 from ophys_etl.types import ExtractROI
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
@@ -350,30 +349,6 @@ def select_contiguous_region(
     if not input_mask[seed_pt[0], seed_pt[1]]:
         return np.zeros(input_mask.shape, dtype=bool)
 
-    pixel_graph = networkx.Graph()
-    valid_pixels = np.argwhere(input_mask)
-    for pixel in valid_pixels:
-        pixel_graph.add_node((pixel[0], pixel[1]))
-
-    for pixel in valid_pixels:
-        r0 = max(0, pixel[0]-1)
-        r1 = min(input_mask.shape[0], pixel[0]+2)
-        c0 = max(0, pixel[1]-1)
-        c1 = min(input_mask.shape[1], pixel[1]+2)
-        for r, c in product(range(r0, r1), range(c0, c1)):
-            if r == pixel[0] and c == pixel[1]:
-                continue
-            if not input_mask[r, c]:
-                continue
-            pixel_graph.add_edge((pixel[0], pixel[1]), (r, c))
-
-    this_subgraph = None
-    for subgraph in networkx.connected_components(pixel_graph):
-        if seed_pt in subgraph:
-            this_subgraph = subgraph
-            break
-
-    contiguous_mask = np.zeros(input_mask.shape, dtype=bool)
-    for node in this_subgraph:
-        contiguous_mask[node[0], node[1]] = True
-    return contiguous_mask
+    labeled_img = skimage_label(input_mask, connectivity=2)
+    seed_label = labeled_img[seed_pt[0], seed_pt[1]]
+    return (labeled_img == seed_label)

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -325,7 +325,7 @@ def roi_list_from_file(file_path: pathlib.Path) -> List[OphysROI]:
 
 
 def select_contiguous_region(
-        seed_pt: Tuple[int],
+        seed_pt: Tuple[int, int],
         input_mask: np.ndarray) -> np.ndarray:
     """
     Select only the contiguous region of an ROI mask that contains

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -346,6 +346,11 @@ def select_contiguous_region(
         A mask of booleans corresponding to the contiguous
         block of True pixels in input_mask that contains seed_pt
     """
+    if seed_pt[0] >= input_mask.shape[0] or seed_pt[1] >= input_mask.shape[1]:
+        msg = f"seed_pt: {seed_pt}\n"
+        msg += f"does not exist in mask with shape {input_mask.shape}"
+        raise IndexError(msg)
+
     if not input_mask[seed_pt[0], seed_pt[1]]:
         return np.zeros(input_mask.shape, dtype=bool)
 

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -340,11 +340,11 @@ def select_contiguous_region(
     input_mask: np.ndarray
         A mask of booleans
 
-   Returns
-   -------
-   contiguous_mask: np.ndarray
-       A mask of booleans corresponding to the contiguous
-       block of True pixels in input_mask that contains seed_pt
+    Returns
+    -------
+    contiguous_mask: np.ndarray
+        A mask of booleans corresponding to the contiguous
+        block of True pixels in input_mask that contains seed_pt
     """
     if not input_mask[seed_pt[0], seed_pt[1]]:
         return np.zeros(input_mask.shape, dtype=bool)

--- a/tests/modules/segmentation/utils/test_roi_utils.py
+++ b/tests/modules/segmentation/utils/test_roi_utils.py
@@ -12,7 +12,8 @@ from ophys_etl.modules.segmentation.utils.roi_utils import (
     sub_video_from_roi,
     intersection_over_union,
     convert_to_lims_roi,
-    roi_list_from_file)
+    roi_list_from_file,
+    select_contiguous_region)
 
 
 @pytest.mark.parametrize(
@@ -268,3 +269,33 @@ def test_roi_list_from_file(roi_file, list_of_roi):
     actual = [ophys_roi_to_extract_roi(roi)
               for roi in raw_actual]
     assert actual == list_of_roi
+
+
+def test_select_contiguous_region():
+
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[2:5, 2:5] = True
+    mask[3:10, 7:10] = True
+
+    output = select_contiguous_region((3, 3), mask)
+    expected = np.zeros((10, 10), dtype=bool)
+    expected[2:5, 2:5] = True
+    np.testing.assert_array_equal(output, expected)
+
+    output = select_contiguous_region((4, 9), mask)
+    expected = np.zeros((10, 10), dtype=bool)
+    expected[3:10, 7:10] = True
+    np.testing.assert_array_equal(output, expected)
+
+    # try when seed_pt is not True
+    output = select_contiguous_region((2, 9), mask)
+    expected = np.zeros((10, 10), dtype=bool)
+    np.testing.assert_array_equal(output, expected)
+
+    # try with diagonally connected blocks
+    mask[1, 1] = True
+    output = select_contiguous_region((3, 3), mask)
+    expected = np.zeros((10, 10), dtype=bool)
+    expected[2:5, 2:5] = True
+    expected[1, 1] = True
+    np.testing.assert_array_equal(output, expected)

--- a/tests/modules/segmentation/utils/test_roi_utils.py
+++ b/tests/modules/segmentation/utils/test_roi_utils.py
@@ -277,6 +277,23 @@ def test_select_contiguous_region():
     mask[2:5, 2:5] = True
     mask[3:10, 7:10] = True
 
+    # check that correct error is raised when you
+    # pass in invalid seed_pt
+    with pytest.raises(
+            IndexError,
+            match='does not exist in mask with shape \\(10, 10\\)'):
+        select_contiguous_region((100, 100), mask)
+
+    with pytest.raises(
+            IndexError,
+            match='does not exist in mask with shape \\(10, 10\\)'):
+        select_contiguous_region((100, 3), mask)
+
+    with pytest.raises(
+            IndexError,
+            match='does not exist in mask with shape \\(10, 10\\)'):
+        select_contiguous_region((3, 100), mask)
+
     output = select_contiguous_region((3, 3), mask)
     expected = np.zeros((10, 10), dtype=bool)
     expected[2:5, 2:5] = True


### PR DESCRIPTION
This PR prevents the FVS from returning disjoint ROIs by adding a step at the end of `ROI.get_mask()` which limits the ROI mask to the contiguous block of pixels containing the seed point. To validate this fix I ran it on OPhys experiment 1048483616. Here are the masks of all of the ROIs whose centroids are within 35 pixels of (384, 200) in that experiment segmented before this PR (this region was chosen based on some other work I was doing; note the upper left-hand mask where there is an obvious cell whose mask includes a lot of extraneous satellite regions)

![disjoint_roi](https://user-images.githubusercontent.com/1682854/127888692-f8f0df53-b697-431e-9acb-4786e429c030.png)

Here are the masks of all of the ROIs within 35 pixels of that point after this PR. The obvious-cell-with-satellite-chaff ROI now only contains the obvious cell.

![fixed_roi](https://user-images.githubusercontent.com/1682854/127888736-acc33bb3-9f5b-4e10-bce6-bd6a851d4180.png)

For good measure, here is the "detect" phase diagnostic plot resulting from running FVS before this PR

![1048483616_0 1_disjoint_plot](https://user-images.githubusercontent.com/1682854/127889717-009deb2b-0bf6-4346-8c90-b6c0d1dc316c.png)

and here it is after this PR

![1048483616_0 1_plot](https://user-images.githubusercontent.com/1682854/127888820-820959d6-8cdc-45ba-8479-af3c05093fea.png)

Eliminating the disjoint ROIs seems to have cut down a lot on the density of bogus ROIs

