### PR TITLE
Segmentation/filter/metric

### DIFF
--- a/src/ophys_etl/modules/segmentation/filter/filter_utils.py
+++ b/src/ophys_etl/modules/segmentation/filter/filter_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+
+
+def average_metric_from_roi(
+        roi: OphysROI,
+        img: np.ndarray) -> float:
+    """
+    Calculate the average metric value in an ROI based on
+    a provided metric image
+
+    Parameters
+    ----------
+    roi: OphysROI
+
+    img: np.ndarray
+        The metric image whose average value in the ROI is
+        being returned. Shape is (nrows, ncolumns)
+
+    Returns
+    -------
+    avg_metric_value: float
+        The average value of pixels in img that are a part
+        of the ROI
+    """
+
+    rows = roi.global_pixel_array[:, 0]
+    cols = roi.global_pixel_array[:, 1]
+    return np.mean(img[rows, cols])

--- a/src/ophys_etl/modules/segmentation/filter/filter_utils.py
+++ b/src/ophys_etl/modules/segmentation/filter/filter_utils.py
@@ -3,11 +3,11 @@ import numpy as np
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 
 
-def average_metric_from_roi(
+def mean_metric_from_roi(
         roi: OphysROI,
         img: np.ndarray) -> float:
     """
-    Calculate the average metric value in an ROI based on
+    Calculate the mean metric value in an ROI based on
     a provided metric image
 
     Parameters
@@ -21,10 +21,37 @@ def average_metric_from_roi(
     Returns
     -------
     avg_metric_value: float
-        The average value of pixels in img that are a part
+        The mean value of pixels in img that are a part
         of the ROI
     """
 
     rows = roi.global_pixel_array[:, 0]
     cols = roi.global_pixel_array[:, 1]
     return np.mean(img[rows, cols])
+
+
+def median_metric_from_roi(
+        roi: OphysROI,
+        img: np.ndarray) -> float:
+    """
+    Calculate the median metric value in an ROI based on
+    a provided metric image
+
+    Parameters
+    ----------
+    roi: OphysROI
+
+    img: np.ndarray
+        The metric image whose average value in the ROI is
+        being returned. Shape is (nrows, ncolumns)
+
+    Returns
+    -------
+    avg_metric_value: float
+        The median value of pixels in img that are a part
+        of the ROI
+    """
+
+    rows = roi.global_pixel_array[:, 0]
+    cols = roi.global_pixel_array[:, 1]
+    return np.median(img[rows, cols])

--- a/src/ophys_etl/modules/segmentation/filter/filter_utils.py
+++ b/src/ophys_etl/modules/segmentation/filter/filter_utils.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
@@ -55,3 +56,90 @@ def median_metric_from_roi(
     rows = roi.global_pixel_array[:, 0]
     cols = roi.global_pixel_array[:, 1]
     return np.median(img[rows, cols])
+
+
+def z_vs_background_from_roi(
+        roi: OphysROI,
+        img: np.ndarray,
+        background_mask: np.ndarray,
+        n_desired_background: Optional[int] = None) -> float:
+    """
+    For an ROI and a metric image, calculate the z-score
+    of the average metric value in the ROI with respect to
+    its local background, i.e.
+
+    (roi_pixel_mean-background_pixel_mean)/background_pixel_std
+
+    Parameters
+    ----------
+    roi: OphysROI
+
+    img: np.ndarray
+        The metric image whose average value in the ROI is
+        being returned. Shape is (nrows, ncolumns)
+
+    background_mask:
+        A np.ndarray of booleans the same shape as
+        img. Marked as False for any pixel that is included
+        in an ROI. This is used when selecting background
+        pixels to compare against. No pixels that are included
+        in any ROI will be selected.
+
+    n_desired_background: Optional[int]
+        The minimum number of background pixels to use
+        in calculating the z_score. If None, take roi.area.
+        Default: None.
+
+    Returns
+    -------
+    z_score: float
+    """
+
+    if img.shape != background_mask.shape:
+        msg = f"img.shape: {img.shape}\n"
+        msg += f"background_mask.shape: {background_mask.shape}\n"
+        msg += "These must be equal"
+        raise RuntimeError(msg)
+
+    if n_desired_background is None:
+        n_desired_background = roi.area
+
+    # find a square window centered on the ROI that contains
+    # the desired number of background pixels
+
+    centroid_row = np.round(roi.centroid_y).astype(int)
+    centroid_col = np.round(roi.centroid_x).astype(int)
+
+    area_estimate = roi.area + n_desired_background
+    pixel_radius = max(np.round(np.sqrt(area_estimate)).astype(int)//2,
+                       1)
+    n_background = 0
+    while n_background < n_desired_background:
+        rowmin = max(0, centroid_row-pixel_radius)
+        rowmax = min(img.shape[0], centroid_row+pixel_radius+1)
+        colmin = max(0, centroid_col-pixel_radius)
+        colmax = min(img.shape[1], centroid_col+pixel_radius+1)
+        local_mask = background_mask[rowmin:rowmax, colmin:colmax]
+        n_background = local_mask.sum()
+        pixel_radius += 1
+        if local_mask.sum() == background_mask.sum():
+            # we are now using all of the background pixels
+            break
+
+    local_img = img[rowmin:rowmax, colmin:colmax]
+    background_pixels = local_img[local_mask].flatten()
+
+    roi_rows = roi.global_pixel_array[:, 0]
+    roi_cols = roi.global_pixel_array[:, 1]
+    roi_pixels = img[roi_rows, roi_cols].flatten()
+
+    roi_mean = np.mean(roi_pixels)
+    background_mean = np.mean(background_pixels)
+
+    # use interquartile range to estimate standard deviation
+    # of background pixels
+    q25, q75 = np.quantile(background_pixels, (0.25, 0.75))
+    background_std = max(1.0e-6, (q75-q25)/1.34896)
+
+    z_score = (roi_mean-background_mean)/background_std
+    return z_score

--- a/src/ophys_etl/modules/segmentation/filter/filter_utils.py
+++ b/src/ophys_etl/modules/segmentation/filter/filter_utils.py
@@ -6,60 +6,6 @@ from ophys_etl.modules.segmentation.utils.roi_utils import (
     select_window_from_background)
 
 
-def mean_metric_from_roi(
-        roi: OphysROI,
-        img: np.ndarray) -> float:
-    """
-    Calculate the mean metric value in an ROI based on
-    a provided metric image
-
-    Parameters
-    ----------
-    roi: OphysROI
-
-    img: np.ndarray
-        The metric image whose average value in the ROI is
-        being returned. Shape is (nrows, ncolumns)
-
-    Returns
-    -------
-    avg_metric_value: float
-        The mean value of pixels in img that are a part
-        of the ROI
-    """
-
-    rows = roi.global_pixel_array[:, 0]
-    cols = roi.global_pixel_array[:, 1]
-    return np.mean(img[rows, cols])
-
-
-def median_metric_from_roi(
-        roi: OphysROI,
-        img: np.ndarray) -> float:
-    """
-    Calculate the median metric value in an ROI based on
-    a provided metric image
-
-    Parameters
-    ----------
-    roi: OphysROI
-
-    img: np.ndarray
-        The metric image whose average value in the ROI is
-        being returned. Shape is (nrows, ncolumns)
-
-    Returns
-    -------
-    avg_metric_value: float
-        The median value of pixels in img that are a part
-        of the ROI
-    """
-
-    rows = roi.global_pixel_array[:, 0]
-    cols = roi.global_pixel_array[:, 1]
-    return np.median(img[rows, cols])
-
-
 def z_vs_background_from_roi(
         roi: OphysROI,
         img: np.ndarray,

--- a/src/ophys_etl/modules/segmentation/filter/roi_filter.py
+++ b/src/ophys_etl/modules/segmentation/filter/roi_filter.py
@@ -10,13 +10,14 @@ from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     ophys_roi_to_extract_roi,
     ophys_roi_list_from_deserialized,
-    background_mask_from_roi_list)
+    background_mask_from_roi_list,
+    mean_metric_from_roi,
+    median_metric_from_roi,)
+
 from ophys_etl.modules.segmentation.processing_log import \
     SegmentationProcessingLog
 
 from ophys_etl.modules.segmentation.filter.filter_utils import (
-    mean_metric_from_roi,
-    median_metric_from_roi,
     z_vs_background_from_roi)
 
 

--- a/src/ophys_etl/modules/segmentation/filter/roi_filter.py
+++ b/src/ophys_etl/modules/segmentation/filter/roi_filter.py
@@ -291,19 +291,30 @@ class ZvsBackgroundFilter(ROIBaseFilter):
     n_background_min: int
         The minimum number of background pixels to use
         (in case roi.area is very small)
+
+    clip_quantile: float
+        Discard the dimmest clip_quantile [0, 1.0) pixels from
+        the ROI before computing the mean to compare against
+        the background.
     """
 
     def __init__(self,
                  metric_img: np.ndarray,
                  min_z: float,
                  n_background_factor: int,
-                 n_background_min: int):
+                 n_background_min: int,
+                 clip_quantile: float):
         self._img = np.copy(metric_img)
         self._min_z = min_z
         self._n_background_factor = n_background_factor
         self._n_background_min = n_background_min
         self._background_mask = None
         self._reason = "z-score vs background pixels"
+        self._clip_quantile = clip_quantile
+
+    @property
+    def clip_quantile(self) -> float:
+        return self._clip_quantile
 
     @property
     def img(self) -> np.ndarray:
@@ -361,6 +372,7 @@ class ZvsBackgroundFilter(ROIBaseFilter):
                         roi,
                         self.img,
                         self.background_mask,
+                        self.clip_quantile,
                         n_desired_background=n_bckgd)
         if z_score < self.min_z:
             return False

--- a/src/ophys_etl/modules/segmentation/filter/schemas.py
+++ b/src/ophys_etl/modules/segmentation/filter/schemas.py
@@ -138,6 +138,15 @@ class StatFilterSchema(MetricBaseSchema):
 
 class ZvsBackgroundSchema(MetricBaseSchema):
 
+    clip_quantile = argschema.fields.Float(
+            default=0.25,
+            required=False,
+            allow_none=False,
+            description=("fraction of ROI pixels to remove from "
+                         "the bottom (in brightness) before "
+                         "computing ROI mean to compare against "
+                         "the background"))
+
     min_z = argschema.fields.Float(
             default=None,
             required=True,
@@ -160,3 +169,10 @@ class ZvsBackgroundSchema(MetricBaseSchema):
                          "when selecting population of background "
                          "pixels to use in calculating z-score "
                          "(in case ROI.AREA is small)"))
+
+    @post_load
+    def check_clip_quantile(self, data, **kwargs):
+        if data['clip_quantile'] < 0.0 or data['clip_quantile'] >= 1.0:
+            msg = "clip_quantile must be in [0.0, 1.0); "
+            msg += f"you gave {data['clip_quantile']: .2e}"
+            raise ValidationError(msg)

--- a/src/ophys_etl/modules/segmentation/filter/schemas.py
+++ b/src/ophys_etl/modules/segmentation/filter/schemas.py
@@ -176,3 +176,4 @@ class ZvsBackgroundSchema(MetricBaseSchema):
             msg = "clip_quantile must be in [0.0, 1.0); "
             msg += f"you gave {data['clip_quantile']: .2e}"
             raise ValidationError(msg)
+        return data

--- a/src/ophys_etl/modules/segmentation/filter/schemas.py
+++ b/src/ophys_etl/modules/segmentation/filter/schemas.py
@@ -1,6 +1,7 @@
 import h5py
 import argschema
 from marshmallow import post_load, ValidationError
+from marshmallow.validate import OneOf
 
 from ophys_etl.schemas.fields import InputOutputFile
 from ophys_etl.modules.segmentation.processing_log import \
@@ -66,4 +67,64 @@ class AreaFilterSchema(FilterBaseSchema):
             msg = "min_area and max_area are both None; "
             msg += "must specify at least one"
             raise RuntimeError(msg)
+        return data
+
+
+class StatFilterSchema(FilterBaseSchema):
+
+    stat_name = argschema.fields.String(
+            default=None,
+            required=True,
+            allow_none=False,
+            validation=OneOf(['mean', 'median']),
+            description=('metric statistic on which to filter'))
+
+    graph_input = argschema.fields.InputFile(
+            default=None,
+            required=True,
+            allow_none=False,
+            description=('path to pkl file containing the graph '
+                         'that will be used to generate the metric image'))
+
+    attribute_name = argschema.fields.String(
+            default='filtered_hnc_Gaussian',
+            required=True,
+            allow_none=False,
+            description=('attribute of graph that will be used to '
+                         'generate the metric image'))
+
+    min_value = argschema.fields.Float(
+            default=None,
+            required=False,
+            allow_none=True,
+            description=("minimum value of stat allowed for a valid ROI"))
+
+    max_value = argschema.fields.Float(
+            default=None,
+            required=False,
+            allow_none=True,
+            description=("maximum value of stat allowed for a valid ROI"))
+
+    @post_load
+    def check_stat_filter_fields(self, data, **kwargs):
+        msg = ''
+        is_valid = True
+        if data['min_value'] is None and data['max_value'] is None:
+            msg += "\nmin_value and max_value are both None; "
+            msg += "must specify at least one\n"
+            is_valid = False
+
+        if data['min_value'] is not None and data['max_value'] is not None:
+            if data['min_value'] > data['max_value']:
+                msg += "\nmin_value > max_value\n"
+                is_valid = False
+
+        if not str(data['graph_input']).endswith('pkl'):
+            msg += f"\n{data['graph_input']} does not appear "
+            msg += "to be a pkl file\n"
+            is_valid = False
+
+        if not is_valid:
+            raise RuntimeError(msg)
+
         return data

--- a/src/ophys_etl/modules/segmentation/filter/schemas.py
+++ b/src/ophys_etl/modules/segmentation/filter/schemas.py
@@ -145,7 +145,7 @@ class ZvsBackgroundSchema(MetricBaseSchema):
             description=("minimum z-value above background of valid ROI"))
 
     n_background_factor = argschema.fields.Int(
-            default=2,
+            default=5,
             required=False,
             allow_none=False,
             description=("select N_BACKGROUND_FACTOR*ROI.AREA pixels "
@@ -153,7 +153,7 @@ class ZvsBackgroundSchema(MetricBaseSchema):
                          "pixels to use in calculating z-score"))
 
     n_background_minimum = argschema.fields.Int(
-            default=100,
+            default=1000,
             required=False,
             allow_none=False,
             description=("minimum number of background pixels to use "

--- a/src/ophys_etl/modules/segmentation/modules/filter_metric_stat.py
+++ b/src/ophys_etl/modules/segmentation/modules/filter_metric_stat.py
@@ -1,0 +1,31 @@
+import pathlib
+
+from ophys_etl.modules.segmentation.graph_utils.conversion import (
+    graph_to_img)
+
+from ophys_etl.modules.segmentation.filter.schemas import (
+    StatFilterSchema)
+
+from ophys_etl.modules.segmentation.filter.roi_filter import (
+    FilterRunnerBase,
+    ROIMetricStatFilter)
+
+
+class StatFilterRunner(FilterRunnerBase):
+    default_schema = StatFilterSchema
+
+    def get_filter(self):
+        metric_img = graph_to_img(
+                        pathlib.Path(self.args['graph_input']),
+                        attribute_name=self.args['attribute_name'])
+
+        return ROIMetricStatFilter(
+                   metric_img,
+                   self.args['stat_name'],
+                   self.args['min_value'],
+                   self.args['max_value'])
+
+
+if __name__ == "__main__":
+    runner = StatFilterRunner()
+    runner.run()

--- a/src/ophys_etl/modules/segmentation/modules/filter_z_score.py
+++ b/src/ophys_etl/modules/segmentation/modules/filter_z_score.py
@@ -1,0 +1,31 @@
+import pathlib
+
+from ophys_etl.modules.segmentation.graph_utils.conversion import (
+    graph_to_img)
+
+from ophys_etl.modules.segmentation.filter.schemas import (
+    ZvsBackgroundSchema)
+
+from ophys_etl.modules.segmentation.filter.roi_filter import (
+    FilterRunnerBase,
+    ZvsBackgroundFilter)
+
+
+class ZvsBackgroundFilterRunner(FilterRunnerBase):
+    default_schema = ZvsBackgroundSchema
+
+    def get_filter(self):
+        metric_img = graph_to_img(
+                        pathlib.Path(self.args['graph_input']),
+                        attribute_name=self.args['attribute_name'])
+
+        return ZvsBackgroundFilter(
+                    metric_img,
+                    self.args['min_z'],
+                    self.args['n_background_factor'],
+                    self.args['n_background_minimum'])
+
+
+if __name__ == "__main__":
+    runner = ZvsBackgroundFilterRunner()
+    runner.run()

--- a/src/ophys_etl/modules/segmentation/modules/filter_z_score.py
+++ b/src/ophys_etl/modules/segmentation/modules/filter_z_score.py
@@ -23,7 +23,8 @@ class ZvsBackgroundFilterRunner(FilterRunnerBase):
                     metric_img,
                     self.args['min_z'],
                     self.args['n_background_factor'],
-                    self.args['n_background_minimum'])
+                    self.args['n_background_minimum'],
+                    self.args['clip_quantile'])
 
 
 if __name__ == "__main__":

--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_utils.py
@@ -11,7 +11,9 @@ from ophys_etl.types import ExtractROI
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 
 from ophys_etl.modules.segmentation.utils.roi_utils import (
-    convert_roi_keys)
+    convert_roi_keys,
+    extract_roi_to_ophys_roi,
+    mean_metric_from_roi)
 
 from ophys_etl.modules.decrosstalk.ophys_plane import (
     OphysMovie,
@@ -821,9 +823,10 @@ def roi_average_metric(roi_list: List[ExtractROI],
     """
     average_metric: Dict[int, float] = dict()
     for roi in roi_list:
-        sub_image = metric_image[roi["y"]: (roi["y"] + roi["height"]),
-                                 roi["x"]: (roi["x"] + roi["width"])]
-        average_metric[roi["id"]] = sub_image[np.array(roi["mask"])].mean()
+        ophys_roi = extract_roi_to_ophys_roi(roi)
+        average_metric[roi["id"]] = mean_metric_from_roi(
+                                         ophys_roi,
+                                         metric_image)
 
     return average_metric
 

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -128,7 +128,7 @@ def ophys_roi_to_extract_roi(roi: OphysROI) -> ExtractROI:
                          width=roi.width,
                          height=roi.height,
                          mask=mask,
-                         valid_roi=roi.valid_roi,
+                         valid=roi.valid_roi,
                          id=roi.roi_id)
     return new_roi
 

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -90,12 +90,12 @@ def extract_roi_to_ophys_roi(roi: ExtractROI) -> OphysROI:
     -------
     OphysROI
     """
-    new_roi = OphysROI(x0=roi['x'],
-                       y0=roi['y'],
-                       width=roi['width'],
-                       height=roi['height'],
+    new_roi = OphysROI(x0=int(roi['x']),
+                       y0=int(roi['y']),
+                       width=int(roi['width']),
+                       height=int(roi['height']),
                        mask_matrix=roi['mask'],
-                       roi_id=roi['id'],
+                       roi_id=int(roi['id']),
                        valid_roi=roi['valid'])
 
     return new_roi

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -534,3 +534,57 @@ def select_window_from_background(
             break
 
     return ((rowmin, rowmax), (colmin, colmax))
+
+
+def mean_metric_from_roi(
+        roi: OphysROI,
+        img: np.ndarray) -> float:
+    """
+    Calculate the mean metric value in an ROI based on
+    a provided metric image
+
+    Parameters
+    ----------
+    roi: OphysROI
+
+    img: np.ndarray
+        The metric image whose average value in the ROI is
+        being returned. Shape is (nrows, ncolumns)
+
+    Returns
+    -------
+    avg_metric_value: float
+        The mean value of pixels in img that are a part
+        of the ROI
+    """
+
+    rows = roi.global_pixel_array[:, 0]
+    cols = roi.global_pixel_array[:, 1]
+    return np.mean(img[rows, cols])
+
+
+def median_metric_from_roi(
+        roi: OphysROI,
+        img: np.ndarray) -> float:
+    """
+    Calculate the median metric value in an ROI based on
+    a provided metric image
+
+    Parameters
+    ----------
+    roi: OphysROI
+
+    img: np.ndarray
+        The metric image whose average value in the ROI is
+        being returned. Shape is (nrows, ncolumns)
+
+    Returns
+    -------
+    avg_metric_value: float
+        The median value of pixels in img that are a part
+        of the ROI
+    """
+
+    rows = roi.global_pixel_array[:, 0]
+    cols = roi.global_pixel_array[:, 1]
+    return np.median(img[rows, cols])

--- a/src/ophys_etl/modules/segmentation/utils/roi_utils.py
+++ b/src/ophys_etl/modules/segmentation/utils/roi_utils.py
@@ -448,3 +448,30 @@ def select_contiguous_region(
     labeled_img = skimage_label(input_mask, connectivity=2)
     seed_label = labeled_img[seed_pt[0], seed_pt[1]]
     return (labeled_img == seed_label)
+
+
+def background_mask_from_roi_list(
+        roi_list: List[OphysROI],
+        img_shape: Tuple[int]) -> np.ndarray:
+    """
+    Take a list of ROIs. Return an np.ndarray of booleans marked
+    as False on any pixel that is included in the ROIs.
+
+    Parameters
+    ----------
+    roi_list: List[OphysROI]
+
+    img_shape: Tuple[int]
+        The shape of the output mask array
+
+    Returns
+    -------
+    background_mask: np.ndarray
+    """
+
+    background_mask = np.ones(img_shape, dtype=bool)
+    for roi in roi_list:
+        rows = roi.global_pixel_array[:, 0]
+        cols = roi.global_pixel_array[:, 1]
+        background_mask[rows, cols] = False
+    return background_mask

--- a/tests/modules/segmentation/end_to_end/test_end_to_end.py
+++ b/tests/modules/segmentation/end_to_end/test_end_to_end.py
@@ -149,7 +149,7 @@ def test_edge_fvs_filter_merge(tmpdir, synthetic_video_path, roi_class):
 
     n_valid_filtered_roi = 0
     for roi in filtered_rois:
-        if roi['valid_roi']:
+        if roi['valid']:
             n_valid_filtered_roi += 1
     assert n_valid_filtered_roi > 0
     assert n_valid_filtered_roi < n_raw_roi
@@ -253,7 +253,7 @@ def test_edge_hnc_filter_merge(tmpdir, synthetic_video_path):
 
     n_valid_filtered_roi = 0
     for roi in filtered_rois:
-        if roi['valid_roi']:
+        if roi['valid']:
             n_valid_filtered_roi += 1
     assert n_valid_filtered_roi > 0
     assert n_valid_filtered_roi < n_raw_roi

--- a/tests/modules/segmentation/filter/conftest.py
+++ b/tests/modules/segmentation/filter/conftest.py
@@ -20,7 +20,7 @@ def seeder_fixture():
 
 
 @pytest.fixture(scope='session')
-def roi_dict():
+def area_roi_dict():
     """
     Create a dict of ROIs with IDs [1, 6)
     whose areas = 2*roi_id.
@@ -48,17 +48,3 @@ def roi_dict():
         assert roi.area == 2*roi_id
         roi_dict[roi_id] = roi
     return roi_dict
-
-
-@pytest.fixture(scope='session')
-def roi_input_path(tmpdir_factory, roi_dict):
-    tmpdir = pathlib.Path(tmpdir_factory.mktemp('filter_test_rois'))
-    file_path = tmpdir/'roi_input.json'
-
-    key_list = list(roi_dict.keys())
-    key_list.sort()
-    roi_list = [ophys_roi_to_extract_roi(roi_dict[k])
-                for k in key_list]
-    with open(file_path, 'w') as out_file:
-        json.dump(roi_list, out_file, indent=2)
-    yield file_path

--- a/tests/modules/segmentation/filter/conftest.py
+++ b/tests/modules/segmentation/filter/conftest.py
@@ -8,6 +8,16 @@ from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     ophys_roi_to_extract_roi)
 
+from ophys_etl.modules.segmentation.seed.seeder import ImageMetricSeeder
+
+
+@pytest.fixture
+def seeder_fixture():
+    # minimal seeder to satisfy logging
+    seeder = ImageMetricSeeder()
+    seeder._seed_image = np.zeros((10, 10))
+    return seeder
+
 
 @pytest.fixture(scope='session')
 def roi_dict():

--- a/tests/modules/segmentation/filter/conftest.py
+++ b/tests/modules/segmentation/filter/conftest.py
@@ -2,11 +2,19 @@ import pytest
 import numpy as np
 import pathlib
 import json
+import networkx
+from itertools import product
 
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     ophys_roi_to_extract_roi)
+
+from ophys_etl.modules.segmentation.graph_utils.conversion import (
+    graph_to_img)
+
+from ophys_etl.modules.segmentation.processing_log import (
+    SegmentationProcessingLog)
 
 from ophys_etl.modules.segmentation.seed.seeder import ImageMetricSeeder
 
@@ -48,3 +56,119 @@ def area_roi_dict():
         assert roi.area == 2*roi_id
         roi_dict[roi_id] = roi
     return roi_dict
+
+
+@pytest.fixture(scope='session')
+def img_shape_fixture():
+    """
+    Tuple representing the shape of the image
+    reference/created by the fixture below
+    """
+    return (64, 64)
+
+
+@pytest.fixture(scope='session')
+def roi_list_fixture(img_shape_fixture):
+    """
+    list of OphysROIs
+    """
+    rng = np.random.default_rng(771223)
+    roi_list = []
+    for ii in range(10):
+        x0 = rng.integers(0, img_shape_fixture[1]-5)
+        width = min(img_shape_fixture[1]-x0,
+                    rng.integers(5, 8))
+        y0 = rng.integers(0, img_shape_fixture[0]-5)
+        height = min(img_shape_fixture[0]-y0,
+                     rng.integers(5, 8))
+        mask = rng.integers(0, 2, (height, width)).astype(bool)
+        roi = OphysROI(x0=int(x0), width=int(width),
+                       y0=int(y0), height=int(height),
+                       valid_roi=True, roi_id=ii,
+                       mask_matrix=mask)
+        roi_list.append(roi)
+    return roi_list
+
+
+@pytest.fixture(scope='function')
+def processing_log_path_fixture(tmpdir,
+                                roi_list_fixture,
+                                seeder_fixture):
+    """
+    Path to a processing log containing roi_list_fixture
+    """
+    extract_roi_list = [ophys_roi_to_extract_roi(roi)
+                        for roi in roi_list_fixture]
+
+    log_path = pathlib.Path(tmpdir) / 'roi_log_for_filter_test.h5'
+    log = SegmentationProcessingLog(log_path, read_only=False)
+    log.log_detection(attribute='dummy',
+                      rois=extract_roi_list,
+                      group_name='detect',
+                      seeder=seeder_fixture)
+    yield log_path
+
+
+@pytest.fixture(scope='session')
+def roi_list_path_fixture(tmpdir_factory, roi_list_fixture):
+    """
+    Path to a file where roi_list_fixture is serialized
+    """
+    tmpdir_path = pathlib.Path(tmpdir_factory.mktemp('z_score_roi'))
+    roi_path = tmpdir_path / 'input_rois.json'
+    extract_roi_list = [ophys_roi_to_extract_roi(roi)
+                        for roi in roi_list_fixture]
+    with open(roi_path, 'w') as out_file:
+        out_file.write(json.dumps(extract_roi_list, indent=2))
+    yield roi_path
+
+
+@pytest.fixture(scope='session')
+def graph_fixture(tmpdir_factory, roi_list_fixture, img_shape_fixture):
+    """
+    Graph used for generating a test image; metric is called 'dummy'.
+    Pixels in ROIs from roi_list_fixture are correlated with each other
+    """
+
+    rng = np.random.default_rng(542392)
+    graph = networkx.Graph()
+    for r, c in product(range(img_shape_fixture[0]),
+                        range(img_shape_fixture[1])):
+        graph.add_node((r, c))
+    for r, c in product(range(img_shape_fixture[0]),
+                        range(img_shape_fixture[1])):
+        r0 = max(0, r-1)
+        r1 = min(r+2, img_shape_fixture[0])
+        c0 = max(0, c-1)
+        c1 = min(c+2, img_shape_fixture[1])
+        for dr, dc in product(range(r0, r1), range(c0, c1)):
+            if dr == 0 and dc == 0:
+                continue
+            graph.add_edge((r, c), (dr, dc),
+                           dummy=rng.normal(0.22, 0.01))
+
+    for roi in roi_list_fixture:
+        mu = rng.random()*4.0 + roi.roi_id
+        for i0 in range(roi.global_pixel_array.shape[0]):
+            pt0 = (roi.global_pixel_array[i0, 0],
+                   roi.global_pixel_array[i0, 1])
+            for i1 in range(i0+1, roi.global_pixel_array.shape[1]):
+                pt1 = (roi.global_pixel_array[i1, 0],
+                       roi.global_pixel_array[i0, 1])
+                edge = (pt0, pt1)
+                graph.add_edge(edge[0], edge[1], dummy=rng.normal(mu, 0.1))
+                graph.add_edge(edge[1], edge[0], dummy=rng.normal(mu, 0.1))
+
+    graph_path = pathlib.Path(tmpdir_factory.mktemp('z_score_graph'))
+    graph_path = graph_path / 'graph.pkl'
+    networkx.write_gpickle(graph, graph_path)
+    yield graph_path
+
+
+@pytest.fixture(scope='session')
+def img_fixture(graph_fixture):
+    """
+    Metric image derived from graph_fixture
+    """
+    return graph_to_img(graph_fixture,
+                        attribute_name='dummy')

--- a/tests/modules/segmentation/filter/test_filter_area.py
+++ b/tests/modules/segmentation/filter/test_filter_area.py
@@ -10,7 +10,6 @@ from ophys_etl.modules.segmentation.utils.roi_utils import \
     ophys_roi_to_extract_roi
 from ophys_etl.modules.segmentation.processing_log import \
     SegmentationProcessingLog
-from ophys_etl.modules.segmentation.seed.seeder import ImageMetricSeeder
 
 
 def compare_rois(roi0: OphysROI,
@@ -44,14 +43,6 @@ def compare_rois(roi0: OphysROI,
         return False
 
     return True
-
-
-@pytest.fixture
-def seeder_fixture():
-    # minimal seeder to satisfy logging
-    seeder = ImageMetricSeeder()
-    seeder._seed_image = np.zeros((10, 10))
-    return seeder
 
 
 @pytest.fixture

--- a/tests/modules/segmentation/filter/test_filter_area.py
+++ b/tests/modules/segmentation/filter/test_filter_area.py
@@ -90,7 +90,7 @@ def test_area_filter_runner(log_file_with_previous_step,
                                     read_only=True)
     original_rois = log.get_rois_from_group("previous_step")
     filtered_rois = log.get_rois_from_group("filter")
-    valid_filtered = {i['id'] for i in filtered_rois if i["valid_roi"]}
+    valid_filtered = {i['id'] for i in filtered_rois if i["valid"]}
     # filter should not delete ROIs
     assert len(original_rois) == len(filtered_rois)
     # expected valid ROIs
@@ -100,7 +100,7 @@ def test_area_filter_runner(log_file_with_previous_step,
     filtered_lookup = {i['id']: i for i in original_rois}
     for k, v in filtered_lookup.items():
         original = copy.deepcopy(original_lookup[k])
-        if not v["valid_roi"]:
+        if not v["valid"]:
             # if invalid, pop this key for comparison
             was_valid = original.pop("valid_roi")
             is_valid = v.pop("valid_roi")

--- a/tests/modules/segmentation/filter/test_filter_area.py
+++ b/tests/modules/segmentation/filter/test_filter_area.py
@@ -46,9 +46,9 @@ def compare_rois(roi0: OphysROI,
 
 
 @pytest.fixture
-def log_file_with_previous_step(tmpdir, roi_dict, seeder_fixture):
+def log_file_with_previous_step(tmpdir, area_roi_dict, seeder_fixture):
     path = tmpdir / "log_with_step.h5"
-    rois = [ophys_roi_to_extract_roi(i) for i in roi_dict.values()]
+    rois = [ophys_roi_to_extract_roi(i) for i in area_roi_dict.values()]
     log = SegmentationProcessingLog(path, read_only=False)
     log.log_detection(attribute="something",
                       rois=rois,

--- a/tests/modules/segmentation/filter/test_filter_metric.py
+++ b/tests/modules/segmentation/filter/test_filter_metric.py
@@ -72,3 +72,11 @@ def test_filter_on_stat(img_fixture, roi_list_fixture,
     assert len(valid_set.intersection(invalid_set)) == 0
     assert len(valid_set) + len(invalid_set) == len(roi_list_fixture)
     assert valid_set == expected_valid
+
+
+def test_errors(img_fixture):
+    with pytest.raises(ValueError, match='only knows how to'):
+        ROIMetricStatFilter(img_fixture, 'nonsense')
+
+    with pytest.raises(RuntimeError, match='specify at least one'):
+        ROIMetricStatFilter(img_fixture, 'mean')

--- a/tests/modules/segmentation/filter/test_filter_metric.py
+++ b/tests/modules/segmentation/filter/test_filter_metric.py
@@ -1,0 +1,74 @@
+import pytest
+import numpy as np
+
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+
+from ophys_etl.modules.segmentation.filter.roi_filter import (
+    ROIMetricStatFilter)
+
+
+@pytest.fixture(scope='session')
+def img_fixture():
+    data = np.arange(1024, dtype=float).reshape(32, 32)
+    return data
+
+
+@pytest.fixture(scope='session')
+def roi_list_fixture():
+
+    roi_list = []
+    roi = OphysROI(x0=0, y0=3, height=3, width=3,
+                   valid_roi=True,
+                   roi_id=0,
+                   mask_matrix=[[False, True, False],
+                                [True, True, True],
+                                [True, True, False]])
+    roi_list.append(roi)
+    roi = OphysROI(x0=3, y0=2, width=2, height=2,
+                   valid_roi=True,
+                   roi_id=1,
+                   mask_matrix=[[True, False], [True, True]])
+    roi_list.append(roi)
+    roi = OphysROI(x0=9, y0=3, width=3, height=2,
+                   valid_roi=True,
+                   roi_id=2,
+                   mask_matrix=[[True, True, True],
+                                [False, True, True]])
+    roi_list.append(roi)
+    roi = OphysROI(x0=0, y0=1, width=2, height=3,
+                   valid_roi=True,
+                   roi_id=3,
+                   mask_matrix=[[False, False], [True, True],
+                                [False, True]])
+    roi_list.append(roi)
+    roi = OphysROI(x0=5, y0=7, width=2, height=2,
+                   valid_roi=True,
+                   roi_id=4,
+                   mask_matrix=[[True, False], [True, True]])
+    roi_list.append(roi)
+    return roi_list
+
+
+@pytest.mark.parametrize(
+    "stat_name, min_val, max_val, expected_valid",
+    [('mean', 88.6, None, set([0, 1, 2, 4])),
+     ('mean', 88.6, 134.0, set([1, 2])),
+     ('mean', None, 108.0, set([1, 3])),
+     ('median', 88.8, None, set([0, 1, 2, 4])),
+     ('median', 88.8, 130.0, set([0, 1, 2])),
+     ('median', None, 130.0, set([0, 1, 2, 3]))]
+)
+def test_filter_on_stat(img_fixture, roi_list_fixture,
+                        stat_name, min_val, max_val, expected_valid):
+
+    this_filter = ROIMetricStatFilter(img_fixture,
+                                      stat_name,
+                                      min_metric=min_val,
+                                      max_metric=max_val)
+
+    result = this_filter.do_filtering(roi_list_fixture)
+    valid_set = set([roi.roi_id for roi in result['valid_roi']])
+    invalid_set = set([roi.roi_id for roi in result['invalid_roi']])
+    assert len(valid_set.intersection(invalid_set)) == 0
+    assert len(valid_set) + len(invalid_set) == len(roi_list_fixture)
+    assert valid_set == expected_valid

--- a/tests/modules/segmentation/filter/test_filter_metric.py
+++ b/tests/modules/segmentation/filter/test_filter_metric.py
@@ -8,13 +8,13 @@ from ophys_etl.modules.segmentation.filter.roi_filter import (
 
 
 @pytest.fixture(scope='session')
-def img_fixture():
+def small_img_fixture():
     data = np.arange(1024, dtype=float).reshape(32, 32)
     return data
 
 
 @pytest.fixture(scope='session')
-def roi_list_fixture():
+def small_roi_list_fixture():
 
     roi_list = []
     roi = OphysROI(x0=0, y0=3, height=3, width=3,
@@ -58,19 +58,19 @@ def roi_list_fixture():
      ('median', 88.8, 130.0, set([0, 1, 2])),
      ('median', None, 130.0, set([0, 1, 2, 3]))]
 )
-def test_filter_on_stat(img_fixture, roi_list_fixture,
+def test_filter_on_stat(small_img_fixture, small_roi_list_fixture,
                         stat_name, min_val, max_val, expected_valid):
 
-    this_filter = ROIMetricStatFilter(img_fixture,
+    this_filter = ROIMetricStatFilter(small_img_fixture,
                                       stat_name,
                                       min_metric=min_val,
                                       max_metric=max_val)
 
-    result = this_filter.do_filtering(roi_list_fixture)
+    result = this_filter.do_filtering(small_roi_list_fixture)
     valid_set = set([roi.roi_id for roi in result['valid_roi']])
     invalid_set = set([roi.roi_id for roi in result['invalid_roi']])
     assert len(valid_set.intersection(invalid_set)) == 0
-    assert len(valid_set) + len(invalid_set) == len(roi_list_fixture)
+    assert len(valid_set) + len(invalid_set) == len(small_roi_list_fixture)
     assert valid_set == expected_valid
 
 

--- a/tests/modules/segmentation/filter/test_filter_metric_module.py
+++ b/tests/modules/segmentation/filter/test_filter_metric_module.py
@@ -95,16 +95,17 @@ def roi_list_fixture(tmpdir_factory, graph_fixture):
 
 
 @pytest.fixture(scope='function')
-def processing_log_path_fixture(tmpdir, roi_list_fixture):
+def processing_log_path_fixture(tmpdir, roi_list_fixture, seeder_fixture):
     with open(roi_list_fixture['path'], 'rb') as in_file:
         extract_roi_list = deserialize_extract_roi_list(
                                 in_file.read())
 
     log_path = pathlib.Path(tmpdir) / 'roi_log_for_filter_test.h5'
-    log = SegmentationProcessingLog(log_path)
+    log = SegmentationProcessingLog(log_path, read_only=False)
     log.log_detection(attribute='dummy_metric',
                       rois=extract_roi_list,
-                      group_name='detect')
+                      group_name='detect',
+                      seeder=seeder_fixture)
     yield log_path
 
 

--- a/tests/modules/segmentation/filter/test_filter_metric_module.py
+++ b/tests/modules/segmentation/filter/test_filter_metric_module.py
@@ -166,9 +166,9 @@ def test_stat_filter_runner(processing_log_path_fixture,
     assert len(expected_invalid) > 0
 
     actual_valid = set([roi['id'] for roi in filtered_rois
-                        if roi['valid_roi']])
+                        if roi['valid']])
     actual_invalid = set([roi['id'] for roi in filtered_rois
-                          if not roi['valid_roi']])
+                          if not roi['valid']])
 
     assert actual_valid == expected_valid
     assert actual_invalid == expected_invalid

--- a/tests/modules/segmentation/filter/test_filter_metric_module.py
+++ b/tests/modules/segmentation/filter/test_filter_metric_module.py
@@ -1,0 +1,165 @@
+import pytest
+import networkx
+import pathlib
+import numpy as np
+import json
+import h5py
+from itertools import product
+
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+
+from ophys_etl.modules.segmentation.graph_utils.conversion import (
+    graph_to_img)
+
+from ophys_etl.modules.segmentation.utils.roi_utils import (
+    ophys_roi_to_extract_roi)
+
+from ophys_etl.modules.segmentation.filter.filter_utils import (
+    mean_metric_from_roi,
+    median_metric_from_roi)
+
+from ophys_etl.modules.segmentation.modules.filter_metric_stat import (
+    StatFilterRunner)
+
+
+@pytest.fixture(scope='session')
+def graph_fixture(tmpdir_factory):
+    tmpdir_path = pathlib.Path(tmpdir_factory.mktemp('stat_graph'))
+    graph_path = tmpdir_path / 'stat_graph.pkl'
+
+    graph = networkx.Graph()
+    for r in range(32):
+        for c in range(32):
+            pt = (r, c)
+            graph.add_node(pt)
+
+    rng = np.random.default_rng(77123)
+    for r in range(32):
+        r0 = max(0, r-1)
+        r1 = min(31, r+1)
+        for c in range(32):
+            c0 = max(0, c-1)
+            c1 = min(31, c+1)
+            pt = (r, c)
+            for rr, cc in product(range(r0, r1), range(c0, c1)):
+                if rr == r and cc == c:
+                    continue
+                other = (rr, cc)
+                val = rng.random()
+                graph.add_edge(pt, other, dummy_metric=val)
+
+    networkx.write_gpickle(graph, graph_path)
+    yield graph_path
+
+
+@pytest.fixture(scope='session')
+def roi_list_fixture(tmpdir_factory, graph_fixture):
+    metric_img = graph_to_img(graph_fixture, attribute_name='dummy_metric')
+
+    tmpdir_path = pathlib.Path(tmpdir_factory.mktemp('roi_list'))
+    roi_list_path = tmpdir_path / 'roi_list.json'
+
+    roi_list = []
+    mean_lookup = dict()
+    median_lookup = dict()
+
+    rng = np.random.default_rng(623321)
+    for ii in range(20):
+        x0 = rng.integers(0, 20)
+        y0 = rng.integers(0, 20)
+        width = min(rng.integers(3, 6), 32-x0)
+        height = min(rng.integers(3, 6), 32-y0)
+        mask = rng.integers(0, 2, (height, width)).astype(bool)
+        roi = OphysROI(x0=int(x0), width=int(width),
+                       y0=int(y0), height=int(height),
+                       valid_roi=True,
+                       roi_id=ii,
+                       mask_matrix=mask)
+        mn = mean_metric_from_roi(roi, metric_img)
+        md = median_metric_from_roi(roi, metric_img)
+        mean_lookup[ii] = mn
+        median_lookup[ii] = md
+
+        roi_list.append(ophys_roi_to_extract_roi(roi))
+
+    with open(roi_list_path, 'w') as out_file:
+        out_file.write(json.dumps(roi_list, indent=2))
+
+    yield {'path': roi_list_path,
+           'mean_lookup': mean_lookup,
+           'median_lookup': median_lookup}
+
+
+@pytest.mark.parametrize(
+    'stat_name, use_min, use_max',
+    [('mean', False, True),
+     ('mean', True, False),
+     ('mean', True, True),
+     ('median', False, True),
+     ('median', True, False),
+     ('median', True, True)])
+def test_stat_filter_runner(tmpdir,
+                            graph_fixture, roi_list_fixture,
+                            stat_name, use_min, use_max):
+
+    lookup = roi_list_fixture[f'{stat_name}_lookup']
+    value_list = list(lookup.values())
+    value_list.sort()
+    if use_min:
+        min_val = value_list[4]
+    else:
+        min_val = None
+    if use_max:
+        max_val = value_list[16]
+    else:
+        max_val = None
+
+    tmpdir_path = pathlib.Path(tmpdir)
+    out_path = tmpdir_path/'output_rois.json'
+    log_path = tmpdir_path/'log.h5'
+    data = {'roi_input': str(roi_list_fixture['path']),
+            'graph_input': str(graph_fixture),
+            'roi_output': str(out_path),
+            'roi_log_path': str(log_path),
+            'pipeline_stage': 'just a test',
+            'stat_name': stat_name,
+            'attribute_name': 'dummy_metric',
+            'min_value': min_val,
+            'max_value': max_val}
+
+    runner = StatFilterRunner(input_data=data, args=[])
+    runner.run()
+    assert out_path.is_file()
+    assert log_path.is_file()
+
+    expected_valid = set()
+    expected_invalid = set()
+    for roi_id in lookup:
+        is_valid = True
+        if min_val is not None and lookup[roi_id] < min_val:
+            is_valid = False
+        if max_val is not None and lookup[roi_id] > max_val:
+            is_valid = False
+        if is_valid:
+            expected_valid.add(roi_id)
+        else:
+            expected_invalid.add(roi_id)
+    assert len(expected_valid) > 0
+    assert len(expected_invalid) > 0
+    with open(out_path, 'rb') as in_file:
+        filtered_rois = json.load(in_file)
+    actual_valid = set([roi['id'] for roi in filtered_rois
+                        if roi['valid_roi']])
+    actual_invalid = set([roi['id'] for roi in filtered_rois
+                          if not roi['valid_roi']])
+
+    assert actual_valid == expected_valid
+    assert actual_invalid == expected_invalid
+
+    with h5py.File(log_path, 'r') as in_file:
+        qc_log = in_file['filter_log']
+        log_invalid = set(qc_log['invalid_roi_id'][()])
+        log_reason = np.unique(qc_log['reason'][()])
+    assert log_invalid == expected_invalid
+    assert len(log_reason) == 1
+    assert f'{stat_name}'.encode('utf-8') in log_reason[0]

--- a/tests/modules/segmentation/filter/test_filter_metric_module.py
+++ b/tests/modules/segmentation/filter/test_filter_metric_module.py
@@ -13,9 +13,7 @@ from ophys_etl.modules.segmentation.graph_utils.conversion import (
 
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     ophys_roi_to_extract_roi,
-    deserialize_extract_roi_list)
-
-from ophys_etl.modules.segmentation.filter.filter_utils import (
+    deserialize_extract_roi_list,
     mean_metric_from_roi,
     median_metric_from_roi)
 

--- a/tests/modules/segmentation/filter/test_filter_utils.py
+++ b/tests/modules/segmentation/filter/test_filter_utils.py
@@ -46,7 +46,8 @@ def test_median_from_roi(image_fixture, x0, y0, mask, expected):
     assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)
 
 
-def test_z_vs_background_from_roi():
+@pytest.mark.parametrize('clip_quantile', [0.0, 0.2222, 0.3333])
+def test_z_vs_background_from_roi(clip_quantile):
 
     rng = np.random.default_rng(776233)
     img_shape = (32, 32)
@@ -68,6 +69,7 @@ def test_z_vs_background_from_roi():
                   roi,
                   img,
                   background,
+                  clip_quantile,
                   n_desired_background=100)
     assert np.allclose(z_score, 3, rtol=0.1, atol=0.0)
 
@@ -77,6 +79,7 @@ def test_z_vs_background_from_roi():
                   roi,
                   img,
                   background,
+                  clip_quantile,
                   n_desired_background=10000)
     assert np.allclose(z_score, 3, rtol=0.1, atol=0.0)
 
@@ -85,4 +88,21 @@ def test_z_vs_background_from_roi():
                   roi,
                   img,
                   np.ones((10, 10), dtype=bool),
+                  clip_quantile,
+                  n_desired_background=100)
+
+    with pytest.raises(RuntimeError, match='\\[0.0, 1.0\\)'):
+            z_vs_background_from_roi(
+                  roi,
+                  img,
+                  np.ones((10, 10), dtype=bool),
+                  -0.1,
+                  n_desired_background=100)
+
+    with pytest.raises(RuntimeError, match='\\[0.0, 1.0\\)'):
+            z_vs_background_from_roi(
+                  roi,
+                  img,
+                  np.ones((10, 10), dtype=bool),
+                  1.0001,
                   n_desired_background=100)

--- a/tests/modules/segmentation/filter/test_filter_utils.py
+++ b/tests/modules/segmentation/filter/test_filter_utils.py
@@ -1,0 +1,26 @@
+import pytest
+import numpy as np
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+from ophys_etl.modules.segmentation.filter.filter_utils import (
+    average_metric_from_roi)
+
+
+@pytest.fixture(scope='session')
+def image_fixture():
+    data = np.arange(1024, dtype=float).reshape(32, 32)
+    return data
+
+
+@pytest.mark.parametrize(
+        "x0, y0, mask, expected",
+        [(12, 15, [[True, False, True], [False, True, False]], 503.66667),
+         (20, 5, [[True, True, False, False],
+                  [False, True, False, False],
+                  [True, True, True, True]], 222.28571)])
+def test_avg_from_roi(image_fixture, x0, y0, mask, expected):
+    roi = OphysROI(x0=x0, width=len(mask[0]),
+                   y0=y0, height=len(mask),
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+    actual = average_metric_from_roi(roi, image_fixture)
+    assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)

--- a/tests/modules/segmentation/filter/test_filter_utils.py
+++ b/tests/modules/segmentation/filter/test_filter_utils.py
@@ -2,7 +2,8 @@ import pytest
 import numpy as np
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 from ophys_etl.modules.segmentation.filter.filter_utils import (
-    average_metric_from_roi)
+    mean_metric_from_roi,
+    median_metric_from_roi)
 
 
 @pytest.fixture(scope='session')
@@ -17,10 +18,26 @@ def image_fixture():
          (20, 5, [[True, True, False, False],
                   [False, True, False, False],
                   [True, True, True, True]], 222.28571)])
-def test_avg_from_roi(image_fixture, x0, y0, mask, expected):
+def test_mean_from_roi(image_fixture, x0, y0, mask, expected):
     roi = OphysROI(x0=x0, width=len(mask[0]),
                    y0=y0, height=len(mask),
                    valid_roi=True, roi_id=0,
                    mask_matrix=mask)
-    actual = average_metric_from_roi(roi, image_fixture)
+    actual = mean_metric_from_roi(roi, image_fixture)
+    assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)
+
+
+@pytest.mark.parametrize(
+        "x0, y0, mask, expected",
+        [(12, 15, [[True, False, True], [False, True, False]], 494.0),
+         (20, 5, [[True, True, False, False],
+                  [False, True, False, False],
+                  [True, True, True, True]], 244.0),
+         (11, 9, [[True, False, True], [True, True, False]], 316.0)])
+def test_median_from_roi(image_fixture, x0, y0, mask, expected):
+    roi = OphysROI(x0=x0, width=len(mask[0]),
+                   y0=y0, height=len(mask),
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+    actual = median_metric_from_roi(roi, image_fixture)
     assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)

--- a/tests/modules/segmentation/filter/test_filter_utils.py
+++ b/tests/modules/segmentation/filter/test_filter_utils.py
@@ -1,9 +1,12 @@
 import pytest
 import numpy as np
 from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+from ophys_etl.modules.segmentation.utils.roi_utils import (
+    background_mask_from_roi_list)
 from ophys_etl.modules.segmentation.filter.filter_utils import (
     mean_metric_from_roi,
-    median_metric_from_roi)
+    median_metric_from_roi,
+    z_vs_background_from_roi)
 
 
 @pytest.fixture(scope='session')
@@ -41,3 +44,45 @@ def test_median_from_roi(image_fixture, x0, y0, mask, expected):
                    mask_matrix=mask)
     actual = median_metric_from_roi(roi, image_fixture)
     assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)
+
+
+def test_z_vs_background_from_roi():
+
+    rng = np.random.default_rng(776233)
+    img_shape = (32, 32)
+    img = rng.normal(1.0, 0.1, img_shape)
+
+    mask = [[True, True, True],
+            [True, True, True],
+            [True, True, True]]
+
+    roi = OphysROI(x0=10, width=3, y0=10, height=3,
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+
+    img[10:13, 10:13] = 1.3
+
+    background = background_mask_from_roi_list([roi], img_shape)
+
+    z_score = z_vs_background_from_roi(
+                  roi,
+                  img,
+                  background,
+                  n_desired_background=100)
+    assert np.allclose(z_score, 3, rtol=0.1, atol=0.0)
+
+    # make sure it can handle case where you ask for
+    # more pixels than are available
+    z_score = z_vs_background_from_roi(
+                  roi,
+                  img,
+                  background,
+                  n_desired_background=10000)
+    assert np.allclose(z_score, 3, rtol=0.1, atol=0.0)
+
+    with pytest.raises(RuntimeError, match='These must be equal'):
+        z_vs_background_from_roi(
+                  roi,
+                  img,
+                  np.ones((10, 10), dtype=bool),
+                  n_desired_background=100)

--- a/tests/modules/segmentation/filter/test_filter_utils.py
+++ b/tests/modules/segmentation/filter/test_filter_utils.py
@@ -92,7 +92,7 @@ def test_z_vs_background_from_roi(clip_quantile):
                   n_desired_background=100)
 
     with pytest.raises(RuntimeError, match='\\[0.0, 1.0\\)'):
-            z_vs_background_from_roi(
+        z_vs_background_from_roi(
                   roi,
                   img,
                   np.ones((10, 10), dtype=bool),
@@ -100,7 +100,7 @@ def test_z_vs_background_from_roi(clip_quantile):
                   n_desired_background=100)
 
     with pytest.raises(RuntimeError, match='\\[0.0, 1.0\\)'):
-            z_vs_background_from_roi(
+        z_vs_background_from_roi(
                   roi,
                   img,
                   np.ones((10, 10), dtype=bool),

--- a/tests/modules/segmentation/filter/test_filter_utils.py
+++ b/tests/modules/segmentation/filter/test_filter_utils.py
@@ -4,46 +4,7 @@ from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     background_mask_from_roi_list)
 from ophys_etl.modules.segmentation.filter.filter_utils import (
-    mean_metric_from_roi,
-    median_metric_from_roi,
     z_vs_background_from_roi)
-
-
-@pytest.fixture(scope='session')
-def image_fixture():
-    data = np.arange(1024, dtype=float).reshape(32, 32)
-    return data
-
-
-@pytest.mark.parametrize(
-        "x0, y0, mask, expected",
-        [(12, 15, [[True, False, True], [False, True, False]], 503.66667),
-         (20, 5, [[True, True, False, False],
-                  [False, True, False, False],
-                  [True, True, True, True]], 222.28571)])
-def test_mean_from_roi(image_fixture, x0, y0, mask, expected):
-    roi = OphysROI(x0=x0, width=len(mask[0]),
-                   y0=y0, height=len(mask),
-                   valid_roi=True, roi_id=0,
-                   mask_matrix=mask)
-    actual = mean_metric_from_roi(roi, image_fixture)
-    assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)
-
-
-@pytest.mark.parametrize(
-        "x0, y0, mask, expected",
-        [(12, 15, [[True, False, True], [False, True, False]], 494.0),
-         (20, 5, [[True, True, False, False],
-                  [False, True, False, False],
-                  [True, True, True, True]], 244.0),
-         (11, 9, [[True, False, True], [True, True, False]], 316.0)])
-def test_median_from_roi(image_fixture, x0, y0, mask, expected):
-    roi = OphysROI(x0=x0, width=len(mask[0]),
-                   y0=y0, height=len(mask),
-                   valid_roi=True, roi_id=0,
-                   mask_matrix=mask)
-    actual = median_metric_from_roi(roi, image_fixture)
-    assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)
 
 
 @pytest.mark.parametrize('clip_quantile', [0.0, 0.2222, 0.3333])

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -1,18 +1,5 @@
 import pytest
 import h5py
-import numpy as np
-from itertools import product
-import pathlib
-import json
-import networkx
-
-from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
-
-from ophys_etl.modules.segmentation.utils.roi_utils import (
-    ophys_roi_to_extract_roi)
-
-from ophys_etl.modules.segmentation.graph_utils.conversion import (
-    graph_to_img)
 
 from ophys_etl.modules.segmentation.utils.roi_utils import (
     background_mask_from_roi_list,
@@ -27,108 +14,14 @@ from ophys_etl.modules.segmentation.filter.roi_filter import (
 from ophys_etl.modules.segmentation.modules.filter_z_score import (
     ZvsBackgroundFilterRunner)
 
-from ophys_etl.modules.segmentation.processing_log import (
-    SegmentationProcessingLog)
-
-
-@pytest.fixture(scope='session')
-def img_shape_fixture():
-    return (64, 64)
-
-
-@pytest.fixture(scope='session')
-def roi_list_fixture(img_shape_fixture):
-    rng = np.random.default_rng(771223)
-    roi_list = []
-    for ii in range(10):
-        x0 = rng.integers(0, img_shape_fixture[1]-5)
-        width = min(img_shape_fixture[1]-x0,
-                    rng.integers(5, 8))
-        y0 = rng.integers(0, img_shape_fixture[0]-5)
-        height = min(img_shape_fixture[0]-y0,
-                     rng.integers(5, 8))
-        mask = rng.integers(0, 2, (height, width)).astype(bool)
-        roi = OphysROI(x0=int(x0), width=int(width),
-                       y0=int(y0), height=int(height),
-                       valid_roi=True, roi_id=ii,
-                       mask_matrix=mask)
-        roi_list.append(roi)
-    return roi_list
-
-
-@pytest.fixture(scope='function')
-def processing_log_path_fixture(tmpdir, roi_list_fixture, seeder_fixture):
-    extract_roi_list = [ophys_roi_to_extract_roi(roi)
-                        for roi in roi_list_fixture]
-
-    log_path = pathlib.Path(tmpdir) / 'roi_log_for_filter_test.h5'
-    log = SegmentationProcessingLog(log_path, read_only=False)
-    log.log_detection(attribute='dummy_metric',
-                      rois=extract_roi_list,
-                      group_name='detect',
-                      seeder=seeder_fixture)
-    yield log_path
-
-
-@pytest.fixture(scope='session')
-def roi_list_path_fixture(tmpdir_factory, roi_list_fixture):
-    tmpdir_path = pathlib.Path(tmpdir_factory.mktemp('z_score_roi'))
-    roi_path = tmpdir_path / 'input_rois.json'
-    extract_roi_list = [ophys_roi_to_extract_roi(roi)
-                        for roi in roi_list_fixture]
-    with open(roi_path, 'w') as out_file:
-        out_file.write(json.dumps(extract_roi_list, indent=2))
-    yield roi_path
-
-
-@pytest.fixture(scope='session')
-def graph_fixture(tmpdir_factory, roi_list_fixture, img_shape_fixture):
-
-    rng = np.random.default_rng(542392)
-    graph = networkx.Graph()
-    for r, c in product(range(img_shape_fixture[0]),
-                        range(img_shape_fixture[1])):
-        graph.add_node((r, c))
-    for r, c in product(range(img_shape_fixture[0]),
-                        range(img_shape_fixture[1])):
-        r0 = max(0, r-1)
-        r1 = min(r+2, img_shape_fixture[0])
-        c0 = max(0, c-1)
-        c1 = min(c+2, img_shape_fixture[1])
-        for dr, dc in product(range(r0, r1), range(c0, c1)):
-            if dr == 0 and dc == 0:
-                continue
-            graph.add_edge((r, c), (dr, dc),
-                           dummy=rng.normal(0.22, 0.01))
-
-    for roi in roi_list_fixture:
-        mu = rng.random()*4.0 + roi.roi_id
-        for i0 in range(roi.global_pixel_array.shape[0]):
-            pt0 = (roi.global_pixel_array[i0, 0],
-                   roi.global_pixel_array[i0, 1])
-            for i1 in range(i0+1, roi.global_pixel_array.shape[1]):
-                pt1 = (roi.global_pixel_array[i1, 0],
-                       roi.global_pixel_array[i0, 1])
-                edge = (pt0, pt1)
-                graph.add_edge(edge[0], edge[1], dummy=rng.normal(mu, 0.1))
-                graph.add_edge(edge[1], edge[0], dummy=rng.normal(mu, 0.1))
-
-    graph_path = pathlib.Path(tmpdir_factory.mktemp('z_score_graph'))
-    graph_path = graph_path / 'graph.pkl'
-    networkx.write_gpickle(graph, graph_path)
-    yield graph_path
-
-
-@pytest.fixture(scope='session')
-def img_fixture(graph_fixture):
-    return graph_to_img(graph_fixture,
-                        attribute_name='dummy')
-
 
 @pytest.fixture(scope='session')
 def ground_truth_fixture(roi_list_fixture,
                          img_shape_fixture,
                          img_fixture):
+    """
+    lookup table mapping roi_id to z-score above background
+    """
     bckgd_mask = background_mask_from_roi_list(
                        roi_list_fixture,
                        img_shape_fixture)

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -209,9 +209,9 @@ def test_z_vs_background_module(
                              in_file['filter/rois'][()])
 
     actual_valid = set([roi['id'] for roi in results
-                        if roi['valid_roi']])
+                        if roi['valid']])
     actual_invalid = set([roi['id'] for roi in results
-                          if not roi['valid_roi']])
+                          if not roi['valid']])
 
     assert actual_valid == valid_roi_id
     assert actual_invalid == invalid_roi_id

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -30,6 +30,8 @@ from ophys_etl.modules.segmentation.modules.filter_z_score import (
 from ophys_etl.modules.segmentation.processing_log import (
     SegmentationProcessingLog)
 
+from ophys_etl.modules.segmentation.seed.seeder import ImageMetricSeeder
+
 
 @pytest.fixture(scope='session')
 def img_shape_fixture():

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -139,6 +139,7 @@ def ground_truth_fixture(roi_list_fixture,
                       roi,
                       img_fixture,
                       bckgd_mask,
+                      0.25,
                       n_desired_background=max(15, 2*roi.area))
         z_score_lookup[roi.roi_id] = z_score
     return z_score_lookup

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -164,7 +164,8 @@ def test_z_vs_background_filter(
                      img_fixture,
                      cutoff,
                      2,
-                     15)
+                     15,
+                     0.25)
     results = this_filter.do_filtering(roi_list_fixture)
 
     actual_valid = set([r.roi_id for r in results['valid_roi']])

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -30,8 +30,6 @@ from ophys_etl.modules.segmentation.modules.filter_z_score import (
 from ophys_etl.modules.segmentation.processing_log import (
     SegmentationProcessingLog)
 
-from ophys_etl.modules.segmentation.seed.seeder import ImageMetricSeeder
-
 
 @pytest.fixture(scope='session')
 def img_shape_fixture():
@@ -56,14 +54,6 @@ def roi_list_fixture(img_shape_fixture):
                        mask_matrix=mask)
         roi_list.append(roi)
     return roi_list
-
-
-@pytest.fixture
-def seeder_fixture():
-    # minimal seeder to satisfy logging
-    seeder = ImageMetricSeeder()
-    seeder._seed_image = np.zeros((10, 10))
-    return seeder
 
 
 @pytest.fixture(scope='function')

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -56,6 +56,14 @@ def roi_list_fixture(img_shape_fixture):
     return roi_list
 
 
+@pytest.fixture
+def seeder_fixture():
+    # minimal seeder to satisfy logging
+    seeder = ImageMetricSeeder()
+    seeder._seed_image = np.zeros((10, 10))
+    return seeder
+
+
 @pytest.fixture(scope='function')
 def processing_log_path_fixture(tmpdir, roi_list_fixture, seeder_fixture):
     extract_roi_list = [ophys_roi_to_extract_roi(roi)

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -66,12 +66,12 @@ def ground_truth_fixture(roi_list_fixture,
                       roi,
                       img_fixture,
                       bckgd_mask,
-                      n_desired_background=100)
+                      n_desired_background=max(15, 2*roi.area))
         z_score_lookup[roi.roi_id] = z_score
     return z_score_lookup
 
 
-@pytest.mark.parametrize('cutoff', [0.0, 9.0, 19.0])
+@pytest.mark.parametrize('cutoff', [0.0, 9.0, 18.5, 19.0])
 def test_z_vs_background_filter(
         roi_list_fixture,
         img_fixture,
@@ -89,7 +89,8 @@ def test_z_vs_background_filter(
     this_filter = ZvsBackgroundFilter(
                      img_fixture,
                      cutoff,
-                     100)
+                     2,
+                     15)
     results = this_filter.do_filtering(roi_list_fixture)
 
     actual_valid = set([r.roi_id for r in results['valid_roi']])

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -1,0 +1,98 @@
+import pytest
+import numpy as np
+
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+
+from ophys_etl.modules.segmentation.utils.roi_utils import (
+    background_mask_from_roi_list)
+
+from ophys_etl.modules.segmentation.filter.filter_utils import (
+    z_vs_background_from_roi)
+
+from ophys_etl.modules.segmentation.filter.roi_filter import (
+    ZvsBackgroundFilter)
+
+
+@pytest.fixture(scope='session')
+def img_shape_fixture():
+    return (64, 64)
+
+
+@pytest.fixture(scope='session')
+def roi_list_fixture(img_shape_fixture):
+    rng = np.random.default_rng(771223)
+    roi_list = []
+    for ii in range(10):
+        x0 = rng.integers(0, img_shape_fixture[1]-5)
+        width = min(img_shape_fixture[1]-x0,
+                    rng.integers(5, 8))
+        y0 = rng.integers(0, img_shape_fixture[0]-5)
+        height = min(img_shape_fixture[0]-y0,
+                     rng.integers(5, 8))
+        mask = rng.integers(0, 2, (height, width)).astype(bool)
+        roi = OphysROI(x0=int(x0), width=int(width),
+                       y0=int(y0), height=int(height),
+                       valid_roi=True, roi_id=ii,
+                       mask_matrix=mask)
+        roi_list.append(roi)
+    return roi_list
+
+
+@pytest.fixture(scope='session')
+def img_fixture(roi_list_fixture, img_shape_fixture):
+
+    rng = np.random.default_rng(542392)
+    img = rng.normal(2.0, 0.2, img_shape_fixture)
+    for roi in roi_list_fixture:
+        value = rng.random()*4.0+2.0
+        rows = roi.global_pixel_array[:, 0]
+        cols = roi.global_pixel_array[:, 1]
+        roi_values = rng.normal(value, 0.1, len(rows))
+        img[rows, cols] = roi_values
+    return img
+
+
+@pytest.fixture(scope='session')
+def ground_truth_fixture(roi_list_fixture,
+                         img_shape_fixture,
+                         img_fixture):
+    bckgd_mask = background_mask_from_roi_list(
+                       roi_list_fixture,
+                       img_shape_fixture)
+
+    z_score_lookup = dict()
+    for roi in roi_list_fixture:
+        z_score = z_vs_background_from_roi(
+                      roi,
+                      img_fixture,
+                      bckgd_mask,
+                      n_desired_background=100)
+        z_score_lookup[roi.roi_id] = z_score
+    return z_score_lookup
+
+
+@pytest.mark.parametrize('cutoff', [0.0, 9.0, 19.0])
+def test_z_vs_background_filter(
+        roi_list_fixture,
+        img_fixture,
+        ground_truth_fixture,
+        cutoff):
+
+    valid_roi_id = set()
+    invalid_roi_id = set()
+    for roi in roi_list_fixture:
+        if ground_truth_fixture[roi.roi_id] < cutoff:
+            invalid_roi_id.add(roi.roi_id)
+        else:
+            valid_roi_id.add(roi.roi_id)
+
+    this_filter = ZvsBackgroundFilter(
+                     img_fixture,
+                     cutoff,
+                     100)
+    results = this_filter.do_filtering(roi_list_fixture)
+
+    actual_valid = set([r.roi_id for r in results['valid_roi']])
+    actual_invalid = set([r.roi_id for r in results['invalid_roi']])
+    assert actual_valid == valid_roi_id
+    assert actual_invalid == invalid_roi_id

--- a/tests/modules/segmentation/filter/test_filter_z_score.py
+++ b/tests/modules/segmentation/filter/test_filter_z_score.py
@@ -57,15 +57,16 @@ def roi_list_fixture(img_shape_fixture):
 
 
 @pytest.fixture(scope='function')
-def processing_log_path_fixture(tmpdir, roi_list_fixture):
+def processing_log_path_fixture(tmpdir, roi_list_fixture, seeder_fixture):
     extract_roi_list = [ophys_roi_to_extract_roi(roi)
                         for roi in roi_list_fixture]
 
     log_path = pathlib.Path(tmpdir) / 'roi_log_for_filter_test.h5'
-    log = SegmentationProcessingLog(log_path)
+    log = SegmentationProcessingLog(log_path, read_only=False)
     log.log_detection(attribute='dummy_metric',
                       rois=extract_roi_list,
-                      group_name='detect')
+                      group_name='detect',
+                      seeder=seeder_fixture)
     yield log_path
 
 

--- a/tests/modules/segmentation/filter/test_roi_filter.py
+++ b/tests/modules/segmentation/filter/test_roi_filter.py
@@ -27,7 +27,7 @@ def test_base_roi_filter():
         roi_filter.reason
 
 
-def test_invalid_area_roi_filter(roi_dict):
+def test_invalid_area_roi_filter():
     with pytest.raises(RuntimeError, match='Both max_area and min_area'):
         ROIAreaFilter()
 

--- a/tests/modules/segmentation/filter/test_roi_filter.py
+++ b/tests/modules/segmentation/filter/test_roi_filter.py
@@ -38,21 +38,24 @@ def test_invalid_area_roi_filter():
          (6, None, set([3, 4, 5, 6])),
          (4, 8, set([2, 3, 4]))
          ])
-def test_area_roi_filter(roi_dict, min_area, max_area, expected_valid):
+def test_area_roi_filter(area_roi_dict,
+                         min_area,
+                         max_area,
+                         expected_valid):
 
     area_filter = ROIAreaFilter(min_area=min_area,
                                 max_area=max_area)
 
     assert area_filter.reason == 'area'
 
-    results = area_filter.do_filtering(list(roi_dict.values()))
+    results = area_filter.do_filtering(list(area_roi_dict.values()))
 
     valid_lookup = {roi.roi_id: roi for roi in results['valid_roi']}
     invalid_lookup = {roi.roi_id: roi for roi in results['invalid_roi']}
     assert (len(results['valid_roi'])
-            + len(results['invalid_roi'])) == len(roi_dict)
+            + len(results['invalid_roi'])) == len(area_roi_dict)
 
-    for roi_id in roi_dict:
+    for roi_id in area_roi_dict:
         if roi_id in expected_valid:
             assert roi_id in valid_lookup
             actual_roi = valid_lookup[roi_id]
@@ -62,7 +65,7 @@ def test_area_roi_filter(roi_dict, min_area, max_area, expected_valid):
             actual_roi = invalid_lookup[roi_id]
             assert not actual_roi.valid_roi
 
-        expected_roi = roi_dict[roi_id]
+        expected_roi = area_roi_dict[roi_id]
         assert expected_roi.x0 == actual_roi.x0
         assert expected_roi.y0 == actual_roi.y0
         assert expected_roi.width == actual_roi.width
@@ -106,7 +109,7 @@ def test_area_filter_schema(tmpdir):
         area_schema.load(invalid_schema)
 
 
-def test_log_invalid_rois(tmpdir, roi_dict):
+def test_log_invalid_rois(tmpdir, area_roi_dict):
 
     # test case of non-empty log file
     log_path = pathlib.Path(tmpdir)/'dummy_invalid_log.h5'
@@ -117,7 +120,7 @@ def test_log_invalid_rois(tmpdir, roi_dict):
         g.create_dataset('reason',
                          data=np.array(['prefill'.encode('utf-8')]*4))
 
-    roi_list = list(roi_dict.values())
+    roi_list = list(area_roi_dict.values())
     log_invalid_rois(roi_list, 'area post-merge', log_path)
 
     expected_roi_id = [-5, -4, -3, -2] + list([roi.roi_id for roi in roi_list])
@@ -137,7 +140,7 @@ def test_log_invalid_rois(tmpdir, roi_dict):
 
     # test case of empty log file
     log_path = pathlib.Path(tmpdir)/'dummy_invalid_log2.h5'
-    roi_list = list(roi_dict.values())
+    roi_list = list(area_roi_dict.values())
     log_invalid_rois(roi_list, 'area pre-merge', log_path)
 
     with h5py.File(log_path, 'r') as in_file:

--- a/tests/modules/segmentation/utils/conftest.py
+++ b/tests/modules/segmentation/utils/conftest.py
@@ -72,7 +72,7 @@ def list_of_roi():
             valid_roi = False
         roi = ExtractROI(x=x0, width=width,
                          y=y0, height=height,
-                         valid_roi=valid_roi,
+                         valid=valid_roi,
                          mask=real_mask,
                          id=ii)
         output.append(roi)

--- a/tests/modules/segmentation/utils/test_roi_stats.py
+++ b/tests/modules/segmentation/utils/test_roi_stats.py
@@ -1,0 +1,43 @@
+import pytest
+import numpy as np
+from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
+from ophys_etl.modules.segmentation.utils.roi_utils import (
+    mean_metric_from_roi,
+    median_metric_from_roi)
+
+
+@pytest.fixture(scope='session')
+def image_fixture():
+    data = np.arange(1024, dtype=float).reshape(32, 32)
+    return data
+
+
+@pytest.mark.parametrize(
+        "x0, y0, mask, expected",
+        [(12, 15, [[True, False, True], [False, True, False]], 503.66667),
+         (20, 5, [[True, True, False, False],
+                  [False, True, False, False],
+                  [True, True, True, True]], 222.28571)])
+def test_mean_from_roi(image_fixture, x0, y0, mask, expected):
+    roi = OphysROI(x0=x0, width=len(mask[0]),
+                   y0=y0, height=len(mask),
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+    actual = mean_metric_from_roi(roi, image_fixture)
+    assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)
+
+
+@pytest.mark.parametrize(
+        "x0, y0, mask, expected",
+        [(12, 15, [[True, False, True], [False, True, False]], 494.0),
+         (20, 5, [[True, True, False, False],
+                  [False, True, False, False],
+                  [True, True, True, True]], 244.0),
+         (11, 9, [[True, False, True], [True, True, False]], 316.0)])
+def test_median_from_roi(image_fixture, x0, y0, mask, expected):
+    roi = OphysROI(x0=x0, width=len(mask[0]),
+                   y0=y0, height=len(mask),
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+    actual = median_metric_from_roi(roi, image_fixture)
+    assert np.allclose(actual, expected, rtol=0.0, atol=0.0001)

--- a/tests/modules/segmentation/utils/test_roi_utils.py
+++ b/tests/modules/segmentation/utils/test_roi_utils.py
@@ -15,7 +15,6 @@ from ophys_etl.modules.segmentation.utils.roi_utils import (
     intersection_over_union,
     convert_to_lims_roi,
     ophys_roi_list_from_file,
-    select_contiguous_region,
     serialize_extract_roi_list,
     deserialize_extract_roi_list,
     check_matching_extract_roi_lists,


### PR DESCRIPTION
This PR adds ROI filtering modules based on the metric images generated from the `calculate_edges` module. Three filters are implemented

- filtering on the mean value of the metric image pixels contained in the ROI
- filtering on the median value of the image pixels contained in the ROI
- filtering on the z-score of the mean image pixels in the ROI relative to the local background

Of these three, only the 3rd, filtering on the z-score relative to the background, proved effective at eliminating bogus ROIs without also eliminating valid ROIs. I am leaving the other two filters in the PR in case they prove useful at a later time.

**Validation**

Here are some experiments which benefit from z-score filtering. Note that there are two parameters: the value of the z-score used to determine whether or not an ROI is valid and the quantile at which the ROI's pixels are clipped before the mean is calculated ("clipped at 0.1" means that the bottom 0.1 of pixels are discarded from the ROI before the mean is taken). Experiments 1048483616 and 951980484 show cases where this clipping is beneficial

Note the dendrite-and-soma process at around row, col = (200, 100), which seems to survive filtering better with clipping quantile > 0

![1048483616_filter_plot](https://user-images.githubusercontent.com/1682854/128777667-ed3936bc-2df7-4860-9d3e-9d668a66bebf.png)

Note the ROI at row, col ~ (75, 400) that only shows up with non-zero clipping quantile

![951980484_filter_plot](https://user-images.githubusercontent.com/1682854/128777825-b87dad76-19b4-4cd7-8d81-be7166dc87b3.png)

Here are experiments in which filtering in general removes a lot of bogus ROIs

![806928824_filter_plot](https://user-images.githubusercontent.com/1682854/128777969-4b282442-d5f0-41a7-b4ff-f9e38484f2a8.png)
![1048483611_filter_plot](https://user-images.githubusercontent.com/1682854/128777984-f95547ea-d330-4c9d-9b82-45bf3adc7dbf.png)

