### PR TITLE
fix to dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir ${CONDA_ENVS}
 
 # Install Suite2P (into conda environment named suite2p)
 WORKDIR /repos
-RUN apt-get -y update \
+RUN apt-get -y update --allow-releaseinfo-change \
     # for Suite2P
     && apt-get -y install libgl1-mesa-glx \
     # for FastLZero


### PR DESCRIPTION
The docker builds for the segmentation branch started failing today, based on my naive reading of

https://stackoverflow.com/questions/68802802/repository-http-security-debian-org-debian-security-buster-updates-inrelease

this should fix it (I can verify that it worked on the segmentation branch)