### PR TITLE
update notebook documentation

### DIFF
--- a/notebooks/segmentation/segmentation_inspection.ipynb
+++ b/notebooks/segmentation/segmentation_inspection.ipynb
@@ -41,7 +41,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have populated a sqlite database with the metadata associated with each of th 160 SSF experiments, as well as the paths to artifacts generated in the course of segmenting those experiments. The `EvalDBReader` provides an API for accessing that database."
+    "We have populated a sqlite database with the metadata associated with each of the 160 SSF experiments, as well as the paths to artifacts generated in the course of segmenting those experiments. The `EvalDBReader` provides an API for accessing that database."
    ]
   },
   {
@@ -84,7 +84,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The metadata and artifact paths for a given experiment is stored in a dict returned by `dbreader.get_inspection_manifest`. See the example below:"
+    "### **inspection manifest specification**\n",
+    "\n",
+    "The above sqlite interface is designed to feed this inspection notebook with an inspection manifest.\n",
+    "\n",
+    "The metadata and artifact paths for a given experiment are stored in a dict returned by `dbreader.get_inspection_manifest`. See the example below:"
    ]
   },
   {
@@ -113,9 +117,7 @@
     "tags": []
    },
    "source": [
-    "### **inspection manifest specification**\n",
     "\n",
-    "the above sqlite interface is designed to feed this inspection notebook with an inspection manifest.\n",
     "\n",
     "But, if one wants to manually specify inspection data sources, the format is:\n",
     "\n",
@@ -139,6 +141,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The \"processing logs\" are the HDF5 files where all of the outputs from the prototype segmentation pipeline are stored. They can be accessed through the API provided by the `SegmentationProcessingLog` class. In this cell, we will get a dict which serves as a lookup table mapping between roi_id and ROIs produced by the `filter` stage of the pipeline.\n",
+    "\n",
+    "**Note:** to get the ROIs produced by a different stage in the pipeline, change the first arg of `get_roi_lookup_from_group`. Currently, the only valid group names are \"detect\" and \"filter\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "processing_log_path = f\"/allen/aibs/informatics/aamster/ticket_325/detect/{ophys_experiment_id}.h5\"\n",
+    "print(processing_log_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "processing_log = SegmentationProcessingLog(processing_log_path, read_only=True)\n",
+    "roi_lookup = processing_log.get_roi_lookup_from_group('filter', valid_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### **ROI Viewer**"
    ]
   },
@@ -150,7 +181,7 @@
     "\n",
     "The columns of the widget allow the user to choose:\n",
     "- backgrounds: the different projection images used to summarize the videos\n",
-    "- processing logs: these are HDF5 files that contain the results of different segmentations. `*_legacy_from_lims.h5` will contain the legacy segmentation (where available)' `{ophys_experiment_id}.h5` will contain the results of the new prototype segmentation.\n",
+    "- processing logs: these are HDF5 files that contain the results of different segmentations. `*_legacy_from_lims.h5` will contain the legacy segmentation (where available); `{ophys_experiment_id}.h5` will contain the results of the new prototype segmentation.\n",
     "- dataset: The prototype segmenter runs in multiple stages, each of which produces ROIs. `detect` will specify the ROIs found in the initial detection phase. `filter` will specify the ROIs after a rough quality filter has been applied (**Note:** to select only ROIs that pass the filter, you must check `valid only` for the `filter` dataset).\n",
     "- Whether or not to display ROI labels and whether or not to limit the display to only ROIs marked as \"valid\" (all ROIs are marked \"valid\" by the `detect` phase).\n",
     "\n",
@@ -286,16 +317,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "noisy_video_generator = VideoGenerator('/allen/programs/braintv/production/neuralcoding/prod55/specimen_734689833/ophys_session_785378984/ophys_experiment_785569447/processed/785569447_suite2p_motion_output.h5')\n",
-    "denoised_video_generator = VideoGenerator('/allen/programs/braintv/workgroups/nc-ophys/danielk/deepinterpolation/experiments/ophys_experiment_785569447/videos/deep_denoised.h5')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `rois_dict` returned by the trace-plotting cells above is a dict of lists which lists the ROIs from the different segmentations (LIMS, prototype detect phase, and prototype filter phase). ROIs are saved as dicts containing their ID, position, size, and serialized pixel masks. We will now construct a dict to allow us to lookup ROIs based on ROI ID"
+    "noisy_movie_path = '/allen/programs/braintv/production/neuralcoding/prod55/specimen_734689833/ophys_session_785378984/ophys_experiment_785569447/processed/785569447_suite2p_motion_output.h5'\n",
+    "denoised_movie_path = '/allen/programs/braintv/workgroups/nc-ophys/danielk/deepinterpolation/experiments/ophys_experiment_785569447/videos/deep_denoised.h5'"
    ]
   },
   {
@@ -304,7 +327,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "roi_lookup = {roi['id']: roi for roi in rois_dict[f'{ophys_experiment_id}.h5-filter']}"
+    "%%time\n",
+    "noisy_video_generator = VideoGenerator(noisy_movie_path)\n",
+    "denoised_video_generator = VideoGenerator(denoised_movie_path)"
    ]
   },
   {
@@ -320,7 +345,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "roi_8 = roi_lookup[8]"
+    "roi_id = 8"
    ]
   },
   {
@@ -339,7 +364,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "example_thumbnail = denoised_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=(255, 0, 0), quality=9)"
+    "example_thumbnail = denoised_video_generator.get_thumbnail_video_from_roi(roi_lookup[roi_id], roi_color=(255, 0, 0), quality=9)"
    ]
   },
   {
@@ -392,14 +417,14 @@
     "%%time\n",
     "timesteps = np.arange(8500, 10500)\n",
     "\n",
-    "noisy_video_with_roi = noisy_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=(255, 0, 0), quality=9,\n",
+    "noisy_video_with_roi = noisy_video_generator.get_thumbnail_video_from_roi(roi_lookup[roi_id], roi_color=(255, 0, 0), quality=9,\n",
     "                                                                          timesteps=timesteps)\n",
     "\n",
-    "denoised_video_with_roi = denoised_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=(255, 0, 0), quality=9,\n",
+    "denoised_video_with_roi = denoised_video_generator.get_thumbnail_video_from_roi(roi_lookup[roi_id], roi_color=(255, 0, 0), quality=9,\n",
     "                                                                                timesteps=timesteps)\n",
     "\n",
     "# this video will show the same field of view without the ROI superimposed over it\n",
-    "noisy_video_without_roi = noisy_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=None, quality=9,\n",
+    "noisy_video_without_roi = noisy_video_generator.get_thumbnail_video_from_roi(roi_lookup[roi_id], roi_color=None, quality=9,\n",
     "                                                                             timesteps=timesteps)"
    ]
   },
@@ -434,7 +459,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is also possible to generate a thumbnail video by specifying an origin and a field of view shape (this thumbnail video will not have any ROIs overplotted)."
+    "It is also possible to generate a thumbnail video by specifying an origin and a field of view shape. This method also accepts the `timesteps` kwarg."
    ]
   },
   {
@@ -444,9 +469,11 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "by_hand_thumbnail = denoised_video_generator.get_thumbnail_video(origin=(100, 200),\n",
+    "timesteps = np.arange(3700, 5500)\n",
+    "by_hand_thumbnail = denoised_video_generator.get_thumbnail_video(origin=(100, 60),\n",
     "                                                                 frame_shape=(64, 64),\n",
-    "                                                                 quality=5)"
+    "                                                                 quality=9,\n",
+    "                                                                 timesteps=timesteps)"
    ]
   },
   {
@@ -460,25 +487,40 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "To see the same region with all overlapping ROIs overplotted, you can pass in a dict or list of ROIs using the `rois` kwarg. Use `valid_only` to make sure you only plot ROIs that are flagged as \"valid\".\n",
+    "\n",
+    "**Note:** using `valid_only` is somewhat redundant in our example, since we used `valid_only=True` when constructing our roi lookup dict."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "%%time\n",
+    "timesteps = np.arange(3700, 5500)\n",
+    "by_hand_thumbnail_with_rois = denoised_video_generator.get_thumbnail_video(\n",
+    "                                                                 origin=(100, 60),\n",
+    "                                                                 frame_shape=(64, 64),\n",
+    "                                                                 quality=9,\n",
+    "                                                                 timesteps=timesteps,\n",
+    "                                                                 rois=roi_lookup,\n",
+    "                                                                 valid_only=True)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "%%time\n",
+    "Video(**display_generator.display_video(by_hand_thumbnail_with_rois))"
+   ]
   },
   {
    "cell_type": "code",

--- a/notebooks/segmentation/segmentation_inspection.ipynb
+++ b/notebooks/segmentation/segmentation_inspection.ipynb
@@ -38,12 +38,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have populated a sqlite database with the metadata associated with each of th 160 SSF experiments, as well as the paths to artifacts generated in the course of segmenting those experiments. The `EvalDBReader` provides an API for accessing that database."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sqlite_path = Path(\"/allen/aibs/informatics/segmentation_eval_dbs/djk_sep01.db\")\n",
+    "sqlite_path = Path(\"/allen/aibs/informatics/segmentation_eval_dbs/ssf_mouse_id_409828.db\")\n",
     "dbreader = EvalDBReader(sqlite_path)"
    ]
   },
@@ -58,14 +65,46 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`all_metadata` is a pandas dataframe that can be queried using the pandas API. For instance, to list all of the experiments with a depth between 250 and 350 microns, you can"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ophys_experiment_id = 1048483616\n",
+    "all_metadata.query('depth>250 and depth<350')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The metadata and artifact paths for a given experiment is stored in a dict returned by `dbreader.get_inspection_manifest`. See the example below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ophys_experiment_id = 785569447\n",
     "inspection_manifest = dbreader.get_inspection_manifest(ophys_experiment_id)\n",
     "pd.DataFrame.from_records([inspection_manifest[\"metadata\"]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspection_manifest"
    ]
   },
   {
@@ -101,6 +140,21 @@
    "metadata": {},
    "source": [
     "### **ROI Viewer**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cells below provide a widgetized interface for viewing different segmentations of the same experiment superimposed on different background images.\n",
+    "\n",
+    "The columns of the widget allow the user to choose:\n",
+    "- backgrounds: the different projection images used to summarize the videos\n",
+    "- processing logs: these are HDF5 files that contain the results of different segmentations. `*_legacy_from_lims.h5` will contain the legacy segmentation (where available)' `{ophys_experiment_id}.h5` will contain the results of the new prototype segmentation.\n",
+    "- dataset: The prototype segmenter runs in multiple stages, each of which produces ROIs. `detect` will specify the ROIs found in the initial detection phase. `filter` will specify the ROIs after a rough quality filter has been applied (**Note:** to select only ROIs that pass the filter, you must check `valid only` for the `filter` dataset).\n",
+    "- Whether or not to display ROI labels and whether or not to limit the display to only ROIs marked as \"valid\" (all ROIs are marked \"valid\" by the `detect` phase).\n",
+    "\n",
+    "The controls to the left of the widget allow the user to zoom and scroll all of the plots in unison."
    ]
   },
   {
@@ -140,6 +194,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell below provides a widgetized interface for viewing the traces of ROIs extracted from the available video files. ROI IDs can be exposed by clicking the `include label` selectors in the ROI viewer widget above.\n",
+    "\n",
+    "Select the video files from which to extract traces and the ROI whose trace you which to extract (-1 means \"no ROI from this dataset\").\n",
+    "\n",
+    "**Note:** Plotting traces can take several minutes, since the traces have to be read in from the video files."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -164,6 +229,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cells below provide classes and functions to view thumbnail videos in this notebook.\n",
+    "\n",
+    "The interface relies on two classes. `VideoGenerator` creates instances of the class `ThumbnailVideo` which point to videos stored on disk. `VideoDisplayGenerator` reads `ThumbnailVideo` instances and converts them into kwargs that can be passed to IPython's `Video` API.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display_generator = VideoDisplayGenerator()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `inspection_manifest` lists the available video files under `\"videos\"`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -178,24 +268,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display_generator = VideoDisplayGenerator()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "video_generator = VideoGenerator(movie_list[0])"
+    "movie_list"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Display full field of view"
+    "We will now instantiate two `VideoGenerator` instances: one for the noisy video; one for the denoised video.\n",
+    "\n",
+    "This will take a few minutes as the `VideoGenerator` scans the entire video file to find a contrast-enhancing normalization for the video data."
    ]
   },
   {
@@ -205,24 +287,49 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "full_fov = video_generator.get_thumbnail_video(origin=(0,0), frame_shape=None, quality=4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "Video(**display_generator.display_video(full_fov, width=512, height=512))"
+    "noisy_video_generator = VideoGenerator('/allen/programs/braintv/production/neuralcoding/prod55/specimen_734689833/ophys_session_785378984/ophys_experiment_785569447/processed/785569447_suite2p_motion_output.h5')\n",
+    "denoised_video_generator = VideoGenerator('/allen/programs/braintv/workgroups/nc-ophys/danielk/deepinterpolation/experiments/ophys_experiment_785569447/videos/deep_denoised.h5')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get and display a random thumbnail by hand"
+    "The `rois_dict` returned by the trace-plotting cells above is a dict of lists which lists the ROIs from the different segmentations (LIMS, prototype detect phase, and prototype filter phase). ROIs are saved as dicts containing their ID, position, size, and serialized pixel masks. We will now construct a dict to allow us to lookup ROIs based on ROI ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roi_lookup = {roi['id']: roi for roi in rois_dict[f'{ophys_experiment_id}.h5-filter']}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As an illustration, we will select the ROI with ID 8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roi_8 = roi_lookup[8]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `VideoGenerator` instances include a method to generate thumbnail videos centered on an ROI, either with, or without the ROI overplotted. We will now create a thumbnail video from the denoised movie with the ROI boundary overplotted in red. To do this, pass the ROI as the first argument of `get_thumbnail_video_from_roi`.\n",
+    "\n",
+    "This will also take a few minutes, as the video is generated and written to disk."
    ]
   },
   {
@@ -232,8 +339,114 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "by_hand_thumbnail = video_generator.get_thumbnail_video(origin=(100, 200), frame_shape=(64, 64),\n",
-    "                                                        quality=5)"
+    "example_thumbnail = denoised_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=(255, 0, 0), quality=9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To display the video, we use the `display_generator` and IPython's `Video` API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Video(**display_generator.display_video(example_thumbnail))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see where the video has been written to disk, use its `video_path` property (this will be a seemingly random filename generated using Python's `tempfile` API).\n",
+    "\n",
+    "**Note:** once a `ThumbnailVideo` instance passes out of scope, its video on disk is deleted. If you want to save a thumbnail video for later use, you need to copy it before the associated `ThumbnailVideo` instance is deleted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_thumbnail.video_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`get_thumbnail_video_from_roi` allows you to focus on a specific subset of timesteps using the `timestep` kwarg. From the trace plot above, we know that timesteps `[8500, 10500]` are interesting for this ROI. We will generate thumbnail videos focusing exclusively on that window in time below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "timesteps = np.arange(8500, 10500)\n",
+    "\n",
+    "noisy_video_with_roi = noisy_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=(255, 0, 0), quality=9,\n",
+    "                                                                          timesteps=timesteps)\n",
+    "\n",
+    "denoised_video_with_roi = denoised_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=(255, 0, 0), quality=9,\n",
+    "                                                                                timesteps=timesteps)\n",
+    "\n",
+    "# this video will show the same field of view without the ROI superimposed over it\n",
+    "noisy_video_without_roi = noisy_video_generator.get_thumbnail_video_from_roi(roi_8, roi_color=None, quality=9,\n",
+    "                                                                             timesteps=timesteps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Video(**display_generator.display_video(noisy_video_with_roi))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Video(**display_generator.display_video(noisy_video_without_roi))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Video(**display_generator.display_video(denoised_video_with_roi))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to generate a thumbnail video by specifying an origin and a field of view shape (this thumbnail video will not have any ROIs overplotted)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "by_hand_thumbnail = denoised_video_generator.get_thumbnail_video(origin=(100, 200),\n",
+    "                                                                 frame_shape=(64, 64),\n",
+    "                                                                 quality=5)"
    ]
   },
   {
@@ -247,147 +460,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": [
-    "Get and display a thumbnail containing an ROI"
-   ]
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "keys = list(rois_dict.keys())\n",
-    "raw_roi = rois_dict[keys[0]][6]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "convert_roi_keys([raw_roi])[0].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "keys = list(rois_dict.keys())\n",
-    "raw_roi = convert_roi_keys([rois_dict[keys[0]][6]])[0]\n",
-    "roi = ExtractROI(x=raw_roi['x'], y=raw_roi['y'], width=raw_roi['width'], height=raw_roi['height'],\n",
-    "                 mask=raw_roi['mask_matrix'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "roi_thumbnail = video_generator.get_thumbnail_video_from_roi(roi, roi_color=(255,0,0), quality=9)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "Video(**display_generator.display_video(roi_thumbnail, width=512, height=512))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Use padding kwarg to increase number of pixels on either side of the ROI"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "padded_roi_thumbnail = video_generator.get_thumbnail_video_from_roi(roi, padding=20, roi_color=(255,0,0), quality=7)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "Video(**display_generator.display_video(padded_roi_thumbnail, width=512, height=512))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Display without the ROI's border"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "no_border_thumbnail = video_generator.get_thumbnail_video_from_roi(roi, quality=9)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "Video(**display_generator.display_video(no_border_thumbnail, width=512, height=512))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Focus on timesteps where we know (from above) there is activity"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "t0 = 4*60+26\n",
-    "t1 = 4*60+38\n",
-    "timesteps = np.arange(t0*31,t1*31)\n",
-    "active_thumbnail = video_generator.get_thumbnail_video_from_roi(roi, roi_color=(255, 0, 0),\n",
-    "                                                                quality=9, timesteps=timesteps)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "Video(**display_generator.display_video(active_thumbnail, width=512, height=512))"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -420,7 +504,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/src/ophys_etl/modules/segmentation/processing_log.py
+++ b/src/ophys_etl/modules/segmentation/processing_log.py
@@ -5,7 +5,7 @@ import matplotlib
 import warnings
 import numpy as np
 from pathlib import Path
-from typing import List
+from typing import List, Dict
 
 from ophys_etl.modules.segmentation.utils import roi_utils
 from ophys_etl.types import ExtractROI
@@ -453,3 +453,32 @@ class SegmentationProcessingLog:
                             valid.append(roi)
             rois = valid
         return rois
+
+    def get_roi_lookup_from_group(
+                            self,
+                            group_name: str,
+                            dataset_name: str = "rois",
+                            valid_only: bool = False) -> Dict[int, ExtractROI]:
+        """Read and deserialize ROIs from a group.
+        Return a dict mapping roi_id to the deserialized ROIs.
+
+        Parameters
+        ----------
+        group_name: str
+            the name of the group, i.e. 'detect', 'merge', etc.
+        dataset_name: str
+            the name of the dataset to read and deserialize,
+            typically 'rois'
+
+        Returns
+        -------
+        roi_lookup: Dict[int, ExtractROI]
+            A dict mapping roi_id to the deserialized ROIs
+
+        """
+        roi_list = self.get_rois_from_group(
+                            group_name,
+                            dataset_name=dataset_name,
+                            valid_only=valid_only)
+        roi_lookup = {roi['id']: roi for roi in roi_list}
+        return roi_lookup

--- a/src/ophys_etl/modules/segmentation/qc_utils/video_generator.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/video_generator.py
@@ -61,7 +61,8 @@ class VideoGenerator(object):
             quality: int = 5,
             rois: Optional[Union[List[ExtractROI],
                            Dict[int, ExtractROI]]] = None,
-            roi_color: Tuple[int, int, int] = (255, 0, 0)
+            roi_color: Tuple[int, int, int] = (255, 0, 0),
+            valid_only: bool = False
             ) -> video_utils.ThumbnailVideo:
         """
         Get a ThumbnailVideo from by-hand specified parameters
@@ -93,6 +94,10 @@ class VideoGenerator(object):
 
         roi_color: Tuple[int, int, int]
             RGB color to plot ROIs (default (255, 0, 0))
+
+        valid_only: bool
+            If rois is not None, only plot valid ROIs
+            (default: False)
 
         Returns
         -------
@@ -130,6 +135,8 @@ class VideoGenerator(object):
                 if roi_c1 < colmin:
                     continue
                 if roi_c0 > colmax:
+                    continue
+                if valid_only and not this_roi['valid']:
                     continue
                 roi_list.append(this_roi)
 

--- a/src/ophys_etl/modules/segmentation/qc_utils/video_generator.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/video_generator.py
@@ -104,7 +104,7 @@ class VideoGenerator(object):
             frame_shape = self.video_shape[1:3]
 
         roi_list = None
-        if roi_list is not None:
+        if rois is not None:
             # select only ROIs that have a hope of intersecting
             # with the field of view
 

--- a/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
@@ -775,6 +775,8 @@ def add_roi_boundary_to_video(sub_video: np.ndarray,
     """
 
     sub_video_bdry = np.copy(sub_video)
+    n_video_rows = sub_video_bdry.shape[1]
+    n_video_cols = sub_video_bdry.shape[2]
 
     # construct an ROI object to get the boundary mask
     # for us
@@ -789,10 +791,14 @@ def add_roi_boundary_to_video(sub_video: np.ndarray,
     boundary_mask = ophys_roi.boundary_mask
     for irow in range(boundary_mask.shape[0]):
         row = irow+ophys_roi.y0-origin[0]
+        if row < 0 or row >= n_video_rows:
+            continue
         for icol in range(boundary_mask.shape[1]):
             if not boundary_mask[irow, icol]:
                 continue
             col = icol+ophys_roi.x0-origin[1]
+            if col <0 or col >= n_video_cols:
+                continue
             for i_color in range(3):
                 sub_video_bdry[:, row, col, i_color] = roi_color[i_color]
     return sub_video_bdry

--- a/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
@@ -482,7 +482,8 @@ def thumbnail_video_from_array(
         origin_offset: Optional[Tuple[int, int]] = None,
         timestep_offset: Optional[np.ndarray] = None,
         roi_list: Optional[List[ExtractROI]] = None,
-        roi_color: Optional[Tuple[int, int, int]] = (255, 0, 0)) -> ThumbnailVideo:
+        roi_color: Optional[Tuple[int, int, int]] = (255, 0, 0)
+        ) -> ThumbnailVideo:
     """
     Create a ThumbnailVideo (mp4) from a numpy array. This method
     will do the work of trimming the array in space and time.
@@ -607,7 +608,9 @@ def thumbnail_video_from_path(
         quality: int = 5,
         min_max: Optional[Tuple[numbers.Number, numbers.Number]] = None,
         quantiles: Optional[Tuple[numbers.Number, numbers.Number]] = None,
-        origin_offset: Optional[Tuple[int, int]] = None) -> ThumbnailVideo:
+        origin_offset: Optional[Tuple[int, int]] = None,
+        roi_list: Optional[List[ExtractROI]] = None,
+        roi_color: Tuple[int, int, int] = (255, 0, 0)) -> ThumbnailVideo:
     """
     Create a ThumbnailVideo (mp4) from a path to an HDF5 file.
     Automatically converts video to an array of np.uint8s
@@ -657,6 +660,14 @@ def thumbnail_video_from_path(
         after pre-truncating the video in space; do NOT use this
         by hand*
 
+    roi_list: Optional[List[ExtractROI]]
+        If not None, list of ROIs whose boundaries are to be drawn
+        in the thumbnail video (default: None)
+
+    roi_color: Optional[Tuple[int, int, int]]
+        RGB color of ROIs to be drawn in the thumbnail video.
+        (default (255, 0, 0))
+
     Returns
     -------
     ThumbnailVideo
@@ -701,7 +712,9 @@ def thumbnail_video_from_path(
                     tmp_dir=tmp_dir,
                     fps=fps,
                     quality=quality,
-                    origin_offset=origin)
+                    origin_offset=origin,
+                    roi_list=roi_list,
+                    roi_color=roi_color)
     return thumbnail
 
 
@@ -816,7 +829,7 @@ def add_roi_boundary_to_video(sub_video: np.ndarray,
             if not boundary_mask[irow, icol]:
                 continue
             col = icol+ophys_roi.x0-origin[1]
-            if col <0 or col >= n_video_cols:
+            if col < 0 or col >= n_video_cols:
                 continue
             for i_color in range(3):
                 sub_video_bdry[:, row, col, i_color] = roi_color[i_color]
@@ -954,7 +967,6 @@ def _thumbnail_video_from_ROI_array(
     roi_list = None
     if roi_color is not None:
         roi_list = [roi]
-
 
     thumbnail = thumbnail_video_from_array(
                     sub_video,

--- a/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
@@ -759,7 +759,7 @@ def add_roi_boundary_to_video(sub_video: np.ndarray,
         The video as an RGB movie. Shape is (n_t, nrows, ncols, 3)
 
     origin: Tuple[int, int]
-        global (romin, colmin) of the video in sub_video
+        global (rowmin, colmin) of the video in sub_video
 
     roi: ExtractROI
         The parameters of this ROI are in global coordinates,

--- a/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/video_utils.py
@@ -579,6 +579,11 @@ def thumbnail_video_from_array(
             timesteps = timestep_offset
 
     if roi_list is not None:
+        # convert to RGB
+        if len(sub_video.shape) < 4:
+            sub_video = get_rgb_sub_video(sub_video,
+                                          (0, 0),
+                                          sub_video.shape[1:3])
         for roi in roi_list:
             sub_video = add_roi_boundary_to_video(
                             sub_video,

--- a/tests/modules/segmentation/qc_utils/conftest.py
+++ b/tests/modules/segmentation/qc_utils/conftest.py
@@ -40,7 +40,7 @@ def list_of_roi():
             valid_roi = False
         roi = ExtractROI(x=x0, width=width,
                          y=y0, height=height,
-                         valid_roi=valid_roi,
+                         valid=valid_roi,
                          mask=real_mask,
                          id=ii)
         output.append(roi)

--- a/tests/modules/segmentation/qc_utils/test_video_generator.py
+++ b/tests/modules/segmentation/qc_utils/test_video_generator.py
@@ -125,6 +125,76 @@ def test_get_thumbnail_video(tmpdir,
     del generator
 
 
+@pytest.mark.parametrize('origin, frame_shape, timesteps',
+                         product((None, (5, 5)),
+                                 (None, (16, 20)),
+                                 (None, np.array([1, 4, 5, 17,
+                                                  19, 23, 23, 25, 38]))))
+def test_thumbnail_with_roi_list(
+                             tmpdir,
+                             example_video,
+                             origin,
+                             frame_shape,
+                             timesteps,
+                             list_of_roi):
+    """
+    Just a smoketest that we can generate a by-hand thumbnail with ROIs
+    displayed in it
+    """
+    video_tmpdir = pathlib.Path(tmpdir) / 'video_temp'
+    generator = VideoGenerator(example_video,
+                               tmp_dir=video_tmpdir)
+
+    fps = 11
+    quality = 6
+
+    thumbnail = generator.get_thumbnail_video(origin=origin,
+                                              frame_shape=frame_shape,
+                                              timesteps=timesteps,
+                                              fps=fps,
+                                              quality=quality,
+                                              rois=list_of_roi)
+
+    assert thumbnail.video_path.is_file()
+    del thumbnail
+
+    thumbnail = generator.get_thumbnail_video(origin=origin,
+                                              frame_shape=frame_shape,
+                                              timesteps=timesteps,
+                                              fps=fps,
+                                              quality=quality,
+                                              rois=list_of_roi,
+                                              valid_only=True)
+
+    assert thumbnail.video_path.is_file()
+    del thumbnail
+
+    roi_lookup = {roi['id']: roi for roi in list_of_roi}
+
+    thumbnail = generator.get_thumbnail_video(origin=origin,
+                                              frame_shape=frame_shape,
+                                              timesteps=timesteps,
+                                              fps=fps,
+                                              quality=quality,
+                                              rois=roi_lookup)
+
+    assert thumbnail.video_path.is_file()
+    del thumbnail
+
+    thumbnail = generator.get_thumbnail_video(origin=origin,
+                                              frame_shape=frame_shape,
+                                              timesteps=timesteps,
+                                              fps=fps,
+                                              quality=quality,
+                                              rois=roi_lookup,
+                                              valid_only=True)
+
+    assert thumbnail.video_path.is_file()
+
+    del thumbnail
+    del generator
+
+
 @pytest.mark.parametrize('roi_color, timesteps, padding',
                          product((None, (122, 201, 53)),
                                  (None, np.array([1, 4, 5, 17, 19,


### PR DESCRIPTION
Try to add more documentation to the segmentation inspection notebook in anticipation of our 9/16/2021 meeting with the science team.

It looks like the evaluation database this notebook points to

"/allen/aibs/informatics/segmentation_eval_dbs/ssf_mouse_id_409828.db"

contains artifacts both from the recent running of segmentation on all 160 SSF experiments and from some of the early prototyping segmentations (in cases where the prototyping experiments were in the SSF set). I think the right thing to do is clean up that database up so that it only points to artifacts from the recent SSF segmentation run so as not to confuse users.