### PR TITLE
Plot set of rois using a multicolor scheme by default

### DIFF
--- a/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
+++ b/src/ophys_etl/modules/segmentation/qc_utils/roi_comparison_utils.py
@@ -1,22 +1,17 @@
-from typing import List, Union, Tuple, Dict
+from typing import List, Union, Tuple
 import matplotlib.figure as mplt_fig
-from matplotlib import cm as mplt_cm
 import pathlib
 import numpy as np
 import PIL.Image
-import networkx
-
-from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 
 from ophys_etl.modules.segmentation.utils.roi_utils import (
-    ophys_roi_list_from_file,
-    do_rois_abut)
+    ophys_roi_list_from_file)
 
 from ophys_etl.modules.segmentation.graph_utils.conversion import (
     graph_to_img)
 
 from ophys_etl.modules.segmentation.qc_utils.roi_utils import (
-    add_roi_boundary_to_img)
+    add_roi_boundary_to_img, get_roi_color_map)
 
 from ophys_etl.modules.segmentation.qc_utils.video_utils import (
     scale_video_to_uint8)
@@ -63,68 +58,6 @@ def _validate_paths_v_names(
         msg += 'These must be the same shape'
         raise RuntimeError(msg)
     return paths, names
-
-
-def get_roi_color_map(
-        roi_list: List[OphysROI]) -> Dict[int, Tuple[int, int, int]]:
-    """
-    Take a list of OphysROI and return a dict mapping ROI ID
-    to RGB color so that no ROIs that touch have the same color
-
-    Parametrs
-    ---------
-    roi_list: List[OphysROI]
-
-    Returns
-    -------
-    color_map: Dict[int, Tuple[int, int, int]]
-    """
-    roi_graph = networkx.Graph()
-    for roi in roi_list:
-        roi_graph.add_node(roi.roi_id)
-    for ii in range(len(roi_list)):
-        roi0 = roi_list[ii]
-        for jj in range(ii+1, len(roi_list)):
-            roi1 = roi_list[jj]
-
-            # value of 5 is so that singleton ROIs that
-            # are near each other do not get assigned
-            # the same color
-            abut = do_rois_abut(roi0, roi1, 5.0)
-            if abut:
-                roi_graph.add_edge(roi0.roi_id, roi1.roi_id)
-                roi_graph.add_edge(roi1.roi_id, roi0.roi_id)
-
-    nx_coloring = networkx.greedy_color(roi_graph)
-    n_colors = len(set(nx_coloring.values()))
-
-    mplt_color_map = mplt_cm.jet
-
-    # create a list of colors based on the matplotlib color map
-    raw_color_list = []
-    for ii in range(n_colors):
-        color = mplt_color_map((1.0+ii)/(n_colors+1.0))
-        color = (int(color[0]*255), int(color[1]*255), int(color[2]*255))
-        raw_color_list.append(color)
-
-    # re-order colors so that colors that are adjacent in index
-    # have higher contrast
-    step = max(n_colors//3, 1)
-    color_list = []
-    for i0 in range(step):
-        for ii in range(i0, n_colors, step):
-            this_color = raw_color_list[ii]
-            color_list.append(this_color)
-
-    # reverse color list, since matplotlib.cm.jet will
-    # assign a dark blue as color_list[0], which isn't
-    # great for contrast
-    color_list.reverse()
-
-    color_map = {}
-    for roi_id in nx_coloring:
-        color_map[roi_id] = color_list[nx_coloring[roi_id]]
-    return color_map
 
 
 def create_roi_v_background_grid(

--- a/tests/modules/segmentation/qc_utils/test_roi_coloring.py
+++ b/tests/modules/segmentation/qc_utils/test_roi_coloring.py
@@ -5,8 +5,7 @@ from ophys_etl.modules.decrosstalk.ophys_plane import OphysROI
 
 from ophys_etl.modules.segmentation.utils.roi_utils import do_rois_abut
 
-from ophys_etl.modules.segmentation.qc_utils.roi_comparison_utils import (
-    get_roi_color_map)
+from ophys_etl.modules.segmentation.qc_utils.roi_utils import get_roi_color_map
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
- move `get_roi_color_map` from roi_comparison_utils.py -> roi_utils.py to avoid circular import
- Use `multicolor` plotting scheme in `add_list_of_roi_boundaries_to_img` unless a color is given