### PR TITLE
don't convert to uint8 early

### DIFF
--- a/src/ophys_etl/modules/roi_cell_classifier/utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/utils.py
@@ -202,14 +202,10 @@ def create_max_and_avg_projections(
                        (lower_quantile,
                         upper_quantile))
 
-    max_img_data = scale_img_to_uint8(max_img_data)
-
     avg_img_data = clip_img_to_quantiles(
                        avg_img_data,
                        (lower_quantile,
                         upper_quantile))
-
-    avg_img_data = scale_img_to_uint8(avg_img_data)
 
     return avg_img_data, max_img_data
 

--- a/tests/modules/roi_cell_classifier/test_artifact_module.py
+++ b/tests/modules/roi_cell_classifier/test_artifact_module.py
@@ -135,10 +135,7 @@ def test_with_graph(
                                   projection_upper_quantile))
             raw_img = np.where(raw_img > mn, raw_img, mn)
             raw_img = np.where(raw_img < mx, raw_img, mx)
-            delta = mx-mn
-            raw_img = raw_img-mn
             raw_img = raw_img.astype(float)
-            raw_img = np.round(255.0*raw_img/delta).astype(np.uint8)
             np.testing.assert_array_equal(raw_img, artifact_img)
 
         artifact_corr = artifact_file['correlation_projection'][()]


### PR DESCRIPTION
don't convert to uint8 early when creating max/avg projections.