### PR TITLE
Ticket/384/scratch/space

### DIFF
--- a/src/ophys_etl/modules/suite2p_wrapper/__main__.py
+++ b/src/ophys_etl/modules/suite2p_wrapper/__main__.py
@@ -82,7 +82,8 @@ class Suite2PWrapper(argschema.ArgSchemaParser):
                     pathlib.Path(tdir),
                     odir,
                     self.args['retain_files'],
-                    self.now)
+                    self.now,
+                    use_mv=True)
             for k, v in output_files.items():
                 self.logger.info(f"wrote {k} to {v}")
 

--- a/src/ophys_etl/modules/suite2p_wrapper/utils.py
+++ b/src/ophys_etl/modules/suite2p_wrapper/utils.py
@@ -9,7 +9,8 @@ class Suite2PWrapperException(Exception):
 
 def copy_and_add_uid(
         srcdir: pathlib.Path, dstdir: pathlib.Path,
-        basenames: List[str], uid: Optional[str] = None) -> Dict[str, str]:
+        basenames: List[str], uid: Optional[str] = None,
+        use_mv: bool = False) -> Dict[str, str]:
     """copy files matching basenames from a tree search of srcdir to
     dstdir with an optional unique id inserted into the basename.
 
@@ -23,6 +24,10 @@ def copy_and_add_uid(
         list of basenames to copy
     uid : str
         uid to insert into basename (example a timestamp string)
+    use_mv: bool
+        If True, use shutil.move() instead of shutil.copyfile()
+        (i.e. delete the original file as it is copied to save space).
+        Default: False.
 
     Returns
     -------
@@ -50,7 +55,10 @@ def copy_and_add_uid(
 
             dstfile = dstdir / dstbasename
 
-            shutil.copyfile(iresult, dstfile)
+            if use_mv:
+                shutil.move(iresult, dstfile)
+            else:
+                shutil.copyfile(iresult, dstfile)
 
             copied_files[basename].append(str(dstfile))
 

--- a/src/ophys_etl/modules/suite2p_wrapper/utils.py
+++ b/src/ophys_etl/modules/suite2p_wrapper/utils.py
@@ -12,7 +12,8 @@ def copy_and_add_uid(
         basenames: List[str], uid: Optional[str] = None,
         use_mv: bool = False) -> Dict[str, str]:
     """copy files matching basenames from a tree search of srcdir to
-    dstdir with an optional unique id inserted into the basename.
+    dstdir with an optional unique id inserted into the basename. Can
+    also move the input files if having two copies of each is not desirable.
 
     Parameters
     ----------

--- a/tests/modules/suite2p_wrapper/test_suite2p_wrapper_utils.py
+++ b/tests/modules/suite2p_wrapper/test_suite2p_wrapper_utils.py
@@ -1,20 +1,41 @@
 import pytest
 import random
 from pathlib import Path
-import filecmp
+import hashlib
 
 from ophys_etl.modules.suite2p_wrapper.utils import copy_and_add_uid
 
 
+def path_to_hash(file_path):
+    """
+    Return the MD5 checksum of the file at file_path
+    """
+    hasher = hashlib.md5()
+    with open(file_path, 'rb') as in_file:
+        chunk = in_file.read(10000)
+        while len(chunk) > 0:
+            hasher.update(chunk)
+            chunk = in_file.read(10000)
+    return str(hasher.hexdigest())
+
+
 @pytest.mark.suite2p_also
 @pytest.mark.parametrize(
-        "basenames, dstsubdir, exception",
+        "basenames, dstsubdir, use_mv, exception",
         [
-            (['tmp.txt'], "other", False),
-            (['tmp.txt', "tmp2.txt"], "other", False),
-            (['tmp.txt', "tmp.txt"], "other", True),
+            (['tmp.txt'], "other", False, False),
+            (['tmp.txt', "tmp2.txt"], "other", False, False),
+            (['tmp.txt', "tmp.txt"], "other", False, True),
+            (['tmp.txt'], "other", True, False),
+            (['tmp.txt', "tmp2.txt"], "other", True, False),
+            (['tmp.txt', "tmp.txt"], "other", True, True),
+
             ])
-def test_copy_and_add_uid(tmp_path, basenames, dstsubdir, exception):
+def test_copy_and_add_uid(tmp_path,
+                          basenames,
+                          dstsubdir,
+                          use_mv,
+                          exception):
     srcfiles = {}
     for i, bname in enumerate(basenames):
         if i == 0:
@@ -37,16 +58,28 @@ def test_copy_and_add_uid(tmp_path, basenames, dstsubdir, exception):
                     tmp_path,
                     other_dir,
                     basenames,
-                    uid)
+                    uid,
+                    use_mv=use_mv)
     else:
+
+        src_hash = dict()
+        for bname in basenames:
+            src_hash[bname] = path_to_hash(srcfiles[bname])
+
         dstfiles = copy_and_add_uid(
                 tmp_path,
                 other_dir,
                 basenames,
-                uid)
+                uid,
+                use_mv=use_mv)
 
         for bname in basenames:
             src = Path(srcfiles[bname])
             dst = Path(dstfiles[bname][0])
-            assert filecmp.cmp(src, dst)
+            dst_hash = path_to_hash(dst)
+            assert dst_hash == src_hash[bname]
             assert dst.name == src.stem + f"_{uid}" + src.suffix
+            if use_mv:
+                assert not src.exists()
+            else:
+                assert src.is_file()


### PR DESCRIPTION
As discussed in the ticket, our pipeline for motion correction causes 3 copies of every movie to be written to scratch when only 2 are needed. This PR eliminates the extra copy by giving `copy_and_add_uid` the option to use `shutil.move` rather than `shutil.copyfile` so that, as the motion-corrected TIFFs are copied into their semi-final directory, they are deleted from the scratch directory used by Suite2P.