### PR TITLE
add suite2p as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ typing_extensions
 tifffile
 scikit-image
 networkx
+suite2p==0.10.2


### PR DESCRIPTION
Validated by creating a new conda env with python 3.8, and
```
pip install -r requirements.txt
```

successfully installed all dependencies. Note that suite2p has pytorch as a dependency just so that it can use its FFT function?