### PR TITLE
fix max/avg projection code to handle pixels that are < 0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
     steps:
       - checkout
       - run:
-          no_output_timeout: 20m
           command: |
             # uses the latest pip with more strict dependency resolution
             pip install --upgrade pip
@@ -69,7 +68,6 @@ jobs:
     steps:
       - checkout
       - run:
-          no_output_timeout: 20m
           command: |
             pip install flake8
             # `|| true` to force exit code 0 even if no files found

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - checkout
       - run:
+          no_output_timeout: 20m
           command: |
             # uses the latest pip with more strict dependency resolution
             pip install --upgrade pip
@@ -68,6 +69,7 @@ jobs:
     steps:
       - checkout
       - run:
+          no_output_timeout: 20m
           command: |
             pip install flake8
             # `|| true` to force exit code 0 even if no files found

--- a/src/ophys_etl/modules/suite2p_registration/utils.py
+++ b/src/ophys_etl/modules/suite2p_registration/utils.py
@@ -2,6 +2,7 @@ import h5py
 import numpy as np
 from typing import Tuple, List
 from scipy.ndimage.filters import median_filter
+from ophys_etl.utils.array_utils import normalize_array
 
 
 def projection_process(data: np.ndarray,
@@ -28,12 +29,7 @@ def projection_process(data: np.ndarray,
     else:
         raise ValueError("projection can be \"max\" or \"avg\" not "
                          f"{projection}")
-
-    mn = proj.min()
-    mx = proj.max()
-    delta = mx-mn
-    proj = np.round((proj.astype(float)-mn) * 255.0 / delta).astype(np.uint8)
-    return proj
+    return normalize_array(proj)
 
 
 def identify_and_clip_outliers(data: np.ndarray,

--- a/src/ophys_etl/modules/suite2p_registration/utils.py
+++ b/src/ophys_etl/modules/suite2p_registration/utils.py
@@ -28,7 +28,11 @@ def projection_process(data: np.ndarray,
     else:
         raise ValueError("projection can be \"max\" or \"avg\" not "
                          f"{projection}")
-    proj = np.uint8(proj * 255.0 / proj.max())
+
+    mn = proj.min()
+    mx = proj.max()
+    delta = mx-mn
+    proj = np.round((proj.astype(float)-mn) * 255.0 / delta).astype(np.uint8)
     return proj
 
 


### PR DESCRIPTION
without wrapping them around to maximum saturation

This addresses ticket #411 

Here are the relevant artifacts as produced by this branch. The saturated negative pixels are gone.
![774393007_max_projection](https://user-images.githubusercontent.com/1682854/151043874-86e0099a-86e3-484d-ab90-a2923a9e1b74.png)
![774393007_avg_projection](https://user-images.githubusercontent.com/1682854/151043892-0be08acf-c782-470c-8499-18242f03aaaa.png)
![774393007_registration_summary](https://user-images.githubusercontent.com/1682854/151043909-91d1c148-140b-4f0d-8c3e-5fd50dd9e701.png)
: