### PR TITLE
increase verbosity of pytest invocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             # uses the latest pip with more strict dependency resolution
             pip install --upgrade pip
             pip install .
-            python -m pytest -m "not suite2p_only and not event_detect_only" --cov ophys_etl --cov-report xml
+            python -m pytest --verbose -s -m "not suite2p_only and not event_detect_only" --cov ophys_etl --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -cF not_container_tests
           name: Test
 


### PR DESCRIPTION
In February 2022, some tests were failing because multiprocessing
was not cleaning itself up properly on CircleCI. This problem was
not evident from the log until these flags were added to our
CircleCI configuration script. "Unfortunately" the problem resolved
itself. We are adding these flags here so we can more easily
diagnose the problem (we hope), should it arise again.