### PR TITLE
Ticket/nnn/roi/plotting/utils

### DIFF
--- a/src/ophys_etl/utils/array_utils.py
+++ b/src/ophys_etl/utils/array_utils.py
@@ -159,15 +159,14 @@ def array_to_rgb(
         (nrows, ncols, 3); original data clipped
         (if cutoffs set) and scaled to np.uint8
     """
-    output_array = np.zeros((input_array.shape[0],
-                             input_array.shape[1],
-                             3), dtype=np.uint8)
 
     scaled_array = normalize_array(
                         array=input_array,
                         lower_cutoff=lower_cutoff,
                         upper_cutoff=upper_cutoff)
 
-    for ic in range(3):
-        output_array[:, :, ic] = scaled_array
+    output_array = np.stack([scaled_array,
+                             scaled_array,
+                             scaled_array]).transpose(1, 2, 0)
+
     return output_array

--- a/src/ophys_etl/utils/array_utils.py
+++ b/src/ophys_etl/utils/array_utils.py
@@ -130,3 +130,44 @@ def normalize_array(
     normalized = np.round(normalized * 255 / delta)
     normalized = normalized.astype(np.uint8)
     return normalized
+
+
+def array_to_rgb(
+        input_array: np.ndarray,
+        lower_cutoff: Optional[float] = None,
+        upper_cutoff: Optional[float] = None) -> np.ndarray:
+    """
+    Take a 2-D np.ndarray of arbitrary dtype and cast it into
+    a 3-D array of np.uint8 representing an RGB image
+
+    Parameters
+    ----------
+    input_array: np.ndarray
+        (nrows, ncols)
+
+    lower_cutoff: Optional[float]
+        threshold, below which will be = 0
+        (if None, do not clip the array)
+
+    upper_cutoff: Optional[float]
+        threshold, abovewhich will be = 255
+        (if None, do not clip the array)
+
+    Returns
+    -------
+    rgb_array:
+        (nrows, ncols, 3); original data clipped
+        (if cutoffs set) and scaled to np.uint8
+    """
+    output_array = np.zeros((input_array.shape[0],
+                             input_array.shape[1],
+                             3), dtype=np.uint8)
+
+    scaled_array = normalize_array(
+                        array=input_array,
+                        lower_cutoff=lower_cutoff,
+                        upper_cutoff=upper_cutoff)
+
+    for ic in range(3):
+        output_array[:, :, ic] = scaled_array
+    return output_array

--- a/src/ophys_etl/utils/roi_plotting_utils.py
+++ b/src/ophys_etl/utils/roi_plotting_utils.py
@@ -10,6 +10,27 @@ from ophys_etl.utils.rois import (
     extract_roi_to_ophys_roi)
 
 
+def _is_img_blank(img: np.ndarray) -> bool:
+    """
+    Return True if every pixel in img is the same color.
+    False otherwise.
+    Works for both grayscale and RGB images.
+    """
+    # detect if image is blank
+    is_blank = False
+    if len(img.shape) == 2:
+        if len(np.unique(img)) == 1:
+            is_blank = True
+    else:
+        # check each color channel individually
+        is_blank = True
+        for ic in range(3):
+            if len(np.unique(img[:, :, ic])) > 1:
+                is_blank = False
+
+    return is_blank
+
+
 def plot_rois_over_img(
         img: np.ndarray,
         roi_list: Union[List[OphysROI], List[Dict]],
@@ -61,16 +82,7 @@ def plot_rois_over_img(
             raise ValueError(msg)
 
     # detect if image is blank
-    is_blank = False
-    if len(img.shape) == 2:
-        if len(np.unique(img)) == 1:
-            is_blank = True
-    else:
-        # check each color channel individually
-        is_blank = True
-        for ic in range(3):
-            if len(np.unique(img[:, :, ic])) > 1:
-                is_blank = False
+    is_blank = _is_img_blank(img=img)
 
     if is_blank:
         # if the image is blank, just create an array of zeros

--- a/src/ophys_etl/utils/roi_plotting_utils.py
+++ b/src/ophys_etl/utils/roi_plotting_utils.py
@@ -1,0 +1,44 @@
+from typing import Tuple
+import numpy as np
+from ophys_etl.types import OphysROI
+
+
+def add_roi_contour_to_img(
+        img: np.ndarray,
+        roi: OphysROI,
+        color: Tuple[int, int, int],
+        alpha: float) -> np.ndarray:
+    """
+    Add colored ROI contour to an image
+
+    Parameters
+    ----------
+    img: np.ndarray
+        RGB representation of image
+
+    roi: OphysROI
+
+    color: Tuple[int]
+        RGB color of ROI
+
+    alpha: float
+
+    Returns
+    -------
+    img: np.ndarray
+
+    Note
+    ----
+    While this function does return an image, it also operates
+    on img in place
+    """
+    bdry = roi.contour_mask
+    valid = np.argwhere(bdry)
+    rows = np.array([r+roi.y0 for r in valid[:, 0]])
+    cols = np.array([c+roi.x0 for c in valid[:, 1]])
+    for ic in range(3):
+        old_vals = img[rows, cols, ic]
+        new_vals = np.round(alpha*color[ic]+(1.0-alpha)*old_vals).astype(int)
+        img[rows, cols, ic] = new_vals
+    img = np.where(img >= 255, 255, img)
+    return img

--- a/src/ophys_etl/utils/roi_plotting_utils.py
+++ b/src/ophys_etl/utils/roi_plotting_utils.py
@@ -1,6 +1,9 @@
-from typing import Tuple
+from typing import Tuple, List, Union, Dict
 import numpy as np
 from ophys_etl.types import OphysROI
+from ophys_etl.utils.rois import (
+    sanitize_extract_roi_list,
+    extract_roi_to_ophys_roi)
 
 
 def add_roi_contour_to_img(
@@ -42,3 +45,59 @@ def add_roi_contour_to_img(
         img[rows, cols, ic] = new_vals
     img = np.where(img >= 255, 255, img)
     return img
+
+
+def add_list_of_roi_contours_to_img(
+        img: np.ndarray,
+        roi_list: Union[List[OphysROI], List[Dict]],
+        color: Union[Tuple[int, int, int],
+                     Dict[int, Tuple[int, int, int]]] = (255, 0, 0),
+        alpha: float = 0.25) -> np.ndarray:
+    """
+    Add colored ROI contours to an image
+
+    Parameters
+    ----------
+    img: np.ndarray
+        RGB representation of image
+
+    roi_list: List[OphysROI]
+        list of ROIs to add to image
+
+    color: Union[Tuple[int,int, int],
+                 Dict[int, Tuple[int, int, int]]
+        Either a representing an RGB color, or a dict
+        mapping roi_id to tuples representing RGB colors
+        (default = (255, 0, 0))
+
+    alpha: float
+        transparency factor to apply to ROI (default=0.25)
+
+    Returns
+    -------
+    new_img: np.ndarray
+        New image with ROI borders superimposed
+    """
+
+    new_img = np.copy(img)
+    if len(roi_list) == 0:
+        return new_img
+
+    if not isinstance(roi_list[0], OphysROI):
+        roi_list = sanitize_extract_roi_list(roi_list)
+        roi_list = [extract_roi_to_ophys_roi(roi)
+                    for roi in roi_list]
+
+    if isinstance(color, tuple):
+        color_map = {roi.roi_id: color for roi in roi_list}
+    else:
+        color_map = color
+
+    for roi in roi_list:
+        new_img = add_roi_contour_to_img(
+                      new_img,
+                      roi,
+                      color_map[roi.roi_id],
+                      alpha)
+
+    return new_img

--- a/src/ophys_etl/utils/roi_plotting_utils.py
+++ b/src/ophys_etl/utils/roi_plotting_utils.py
@@ -17,7 +17,30 @@ def plot_rois_over_img(
                      Dict[int, Tuple[int, int, int]]],
         alpha: float = 0.5) -> np.ndarray:
     """
-    Plot a list of ROIs over a provided image
+    Plot contours from a list of ROIs over a provided image
+
+    Parameters
+    ----------
+    img: np.ndarray
+        The image, either grayscale or RGB
+
+    roi_list: Union[List[OphysROI], List[Dict]]
+        A list of ROIs represented either as an OphysROI
+        or an ExtractROI
+
+    color: Union[Tuple[int, int, int],
+                 Dict[int, Tuple[int, int, int]]
+        Either a tuple indicating a single RGB color for all ROIs
+        or a dict mapping ROI ID to an RGB color (as a tuple of ints)
+
+    alpha: float
+        The transparency
+
+    Returns
+    -------
+    new_img: np.ndarray
+        An RGB image with the ROIs overplotted (does not
+        modify img in place)
     """
     if len(img.shape) == 2:
         img = array_to_rgb(img)
@@ -39,12 +62,12 @@ def plot_rois_over_img(
         msg = f"Cannot handle image with shape {img.shape}"
         raise ValueError(msg)
 
-    img = add_list_of_roi_contours_to_img(
+    new_img = add_list_of_roi_contours_to_img(
                 img=img,
                 roi_list=roi_list,
                 color=color,
                 alpha=alpha)
-    return img
+    return new_img
 
 
 def add_roi_contour_to_img(

--- a/src/ophys_etl/utils/roi_plotting_utils.py
+++ b/src/ophys_etl/utils/roi_plotting_utils.py
@@ -81,12 +81,7 @@ def plot_rois_over_img(
     elif len(img.shape) == 2:
         img = array_to_rgb(img)
     else:
-        upper_cutoff = img.max()
-        lower_cutoff = img.min()
-        new_img = normalize_array(
-                           array=img,
-                           lower_cutoff=lower_cutoff,
-                           upper_cutoff=upper_cutoff)
+        new_img = normalize_array(array=img)
         img = new_img
 
     new_img = add_list_of_roi_contours_to_img(

--- a/src/ophys_etl/utils/roi_plotting_utils.py
+++ b/src/ophys_etl/utils/roi_plotting_utils.py
@@ -62,11 +62,7 @@ def plot_rois_over_img(
         if img.shape[2] != 3:
             msg = f"Cannot handle image with shape {img.shape}"
             raise ValueError(msg)
-    else:
-        msg = f"Cannot handle image with shape {img.shape}"
-        raise ValueError(msg)
 
-    if not is_blank:
         upper_cutoff = img.max()
         lower_cutoff = img.min()
         new_img = normalize_array(
@@ -78,6 +74,9 @@ def plot_rois_over_img(
                                 new_img,
                                 new_img]).transpose(1, 2, 0)
         img = new_img
+    else:
+        msg = f"Cannot handle image with shape {img.shape}"
+        raise ValueError(msg)
 
     new_img = add_list_of_roi_contours_to_img(
                 img=img,

--- a/src/ophys_etl/utils/rois.py
+++ b/src/ophys_etl/utils/rois.py
@@ -597,19 +597,24 @@ def do_rois_abut(roi0: OphysROI,
 
 
 def get_roi_color_map(
-        roi_list: List[OphysROI]) -> Dict[int, Tuple[int, int, int]]:
+        roi_list: Union[List[OphysROI],
+                        List[Dict]]) -> Dict[int, Tuple[int, int, int]]:
     """
     Take a list of OphysROI and return a dict mapping ROI ID
     to RGB color so that no ROIs that touch have the same color
 
     Parametrs
     ---------
-    roi_list: List[OphysROI]
+    roi_list: Union[List[OphysROI], List[Dict]]
 
     Returns
     -------
     color_map: Dict[int, Tuple[int, int, int]]
     """
+    if not isinstance(roi_list[0], OphysROI):
+        roi_list = [extract_roi_to_ophys_roi(roi)
+                    for roi in sanitize_extract_roi_list(roi_list)]
+
     roi_graph = networkx.Graph()
     for roi in roi_list:
         roi_graph.add_node(roi.roi_id)

--- a/tests/utils/test_array_utils.py
+++ b/tests/utils/test_array_utils.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from itertools import product
 from ophys_etl.utils import array_utils as au
 
 
@@ -179,3 +180,25 @@ def test_scale_to_uint8(input_array, expected_array):
     """
     actual = au.normalize_array(input_array)
     np.testing.assert_array_equal(actual, expected_array)
+
+
+@pytest.mark.parametrize(
+        "lower_cutoff, upper_cutoff",
+        product((None, 15.0), (None, 77.0)))
+def test_array_to_rgb(
+        lower_cutoff, upper_cutoff):
+
+    img = np.arange(144, dtype=float).reshape(12, 12)
+    scaled = au.normalize_array(array=img,
+                                lower_cutoff=lower_cutoff,
+                                upper_cutoff=upper_cutoff)
+
+    rgb = au.array_to_rgb(
+                input_array=img,
+                lower_cutoff=lower_cutoff,
+                upper_cutoff=upper_cutoff)
+
+    assert rgb.dtype == np.uint8
+    assert rgb.shape == (12, 12, 3)
+    for ic in range(3):
+        np.testing.assert_array_equal(rgb[:, :, ic], scaled)

--- a/tests/utils/test_roi_coloring.py
+++ b/tests/utils/test_roi_coloring.py
@@ -48,6 +48,7 @@ def ophys_roi_list_fixture():
 
 @pytest.fixture(scope='session')
 def extract_roi_list_fixture(ophys_roi_list_fixture):
+    """A list of ExtractROI"""
     output = [ophys_roi_to_extract_roi(roi)
               for roi in ophys_roi_list_fixture]
 
@@ -57,7 +58,8 @@ def extract_roi_list_fixture(ophys_roi_list_fixture):
 @pytest.fixture(scope='session')
 def corrupted_extract_roi_list_fixture(
         extract_roi_list_fixture):
-
+    """A list of dicts representing ROIs with the wrong
+    keys for ExtractROI ('valid_roi' instead of 'valid', etc.)"""
     output = []
     for roi in extract_roi_list_fixture:
         new_roi = copy.deepcopy(roi)
@@ -74,6 +76,8 @@ def test_roi_coloring(
         extract_roi_list_fixture,
         corrupted_extract_roi_list_fixture,
         roi_choice):
+    """Test that get_roi_color_map runs and does not assign the
+    same color to ROIs that touch each other"""
 
     if roi_choice == 0:
         roi_list = ophys_roi_list_fixture

--- a/tests/utils/test_roi_coloring.py
+++ b/tests/utils/test_roi_coloring.py
@@ -1,13 +1,15 @@
 import pytest
+import copy
 import numpy as np
 
 from ophys_etl.types import OphysROI
+from ophys_etl.utils.rois import ophys_roi_to_extract_roi
 from ophys_etl.utils.rois import do_rois_abut
 from ophys_etl.utils.rois import get_roi_color_map
 
 
 @pytest.fixture(scope='session')
-def roi_list_fixture():
+def ophys_roi_list_fixture():
     """
     List of OphysROI
     """
@@ -44,18 +46,56 @@ def roi_list_fixture():
     return output
 
 
-def test_roi_coloring(roi_list_fixture):
-    color_map = get_roi_color_map(roi_list_fixture)
-    for roi in roi_list_fixture:
+@pytest.fixture(scope='session')
+def extract_roi_list_fixture(ophys_roi_list_fixture):
+    output = [ophys_roi_to_extract_roi(roi)
+              for roi in ophys_roi_list_fixture]
+
+    return output
+
+
+@pytest.fixture(scope='session')
+def corrupted_extract_roi_list_fixture(
+        extract_roi_list_fixture):
+
+    output = []
+    for roi in extract_roi_list_fixture:
+        new_roi = copy.deepcopy(roi)
+        new_roi['valid_roi'] = new_roi.pop('valid')
+        new_roi['roi_id'] = new_roi.pop('id')
+        new_roi['mask_matrix'] = new_roi.pop('mask')
+        output.append(new_roi)
+    return output
+
+
+@pytest.mark.parametrize("roi_choice", [0, 1, 2])
+def test_roi_coloring(
+        ophys_roi_list_fixture,
+        extract_roi_list_fixture,
+        corrupted_extract_roi_list_fixture,
+        roi_choice):
+
+    if roi_choice == 0:
+        roi_list = ophys_roi_list_fixture
+    elif roi_choice == 1:
+        roi_list = extract_roi_list_fixture
+    elif roi_choice == 2:
+        roi_list = corrupted_extract_roi_list_fixture
+
+    color_map = get_roi_color_map(roi_list)
+    for roi in ophys_roi_list_fixture:
         assert roi.roi_id in color_map
-    assert len(color_map) == len(roi_list_fixture)
+
+    assert len(color_map) == len(roi_list)
+
     pairs = 0
-    for ii in range(len(roi_list_fixture)):
-        roi0 = roi_list_fixture[ii]
-        for jj in range(ii+1, len(roi_list_fixture)):
-            roi1 = roi_list_fixture[jj]
+
+    for ii in range(len(roi_list)):
+        roi0 = ophys_roi_list_fixture[ii]
+        for jj in range(ii+1, len(roi_list)):
+            roi1 = ophys_roi_list_fixture[jj]
             if do_rois_abut(roi0, roi1):
                 pairs += 1
                 assert color_map[roi0.roi_id] != color_map[roi1.roi_id]
     assert pairs > 0
-    assert len(set(color_map.values())) < len(roi_list_fixture)
+    assert len(set(color_map.values())) < len(roi_list)

--- a/tests/utils/test_roi_plotting_utils.py
+++ b/tests/utils/test_roi_plotting_utils.py
@@ -12,7 +12,7 @@ from ophys_etl.utils.roi_plotting_utils import (
 
 @pytest.fixture(scope='session')
 def extract_roi_list_fixture():
-
+    """A list of ExtractROIs"""
     roi0 = ExtractROI(
                 id=0,
                 x=1,
@@ -43,7 +43,8 @@ def extract_roi_list_fixture():
 @pytest.fixture(scope='session')
 def corrupted_extract_roi_list_fixture(
         extract_roi_list_fixture):
-
+    """A list of ExtractROIs with the wrong keys ('valid_roi' instead
+    of 'valid', etc.)"""
     output = []
     for roi in extract_roi_list_fixture:
         new_roi = copy.deepcopy(roi)
@@ -56,18 +57,22 @@ def corrupted_extract_roi_list_fixture(
 
 @pytest.fixture(scope='session')
 def ophys_roi_list_fixture(extract_roi_list_fixture):
+    """A list of OphysROIs"""
     return [extract_roi_to_ophys_roi(roi)
             for roi in extract_roi_list_fixture]
 
 
 @pytest.fixture(scope='session')
 def color_map_fixture():
+    """an example color map"""
     return {0: (0, 255, 0),
             1: (0, 0, 255)}
 
 
 @pytest.mark.parametrize('alpha', [0.2, 0.3, 0.4])
 def test_add_roi_contour_to_img(alpha):
+    """Test that add_roi_contour_to_img creates an image with
+    the expected contours of the expected colors"""
     img = 100*np.ones((64, 64, 3), dtype=int)
 
     height = 7
@@ -121,6 +126,10 @@ def test_add_list_of_roi_contours_to_img(
         roi_list_choice,
         use_color_map,
         alpha):
+    """
+    Test taht add_list_of_roi_contours_to_img adds contours
+    of the expected colors to an image
+    """
 
     if roi_list_choice == 0:
         roi_list = extract_roi_list_fixture

--- a/tests/utils/test_roi_plotting_utils.py
+++ b/tests/utils/test_roi_plotting_utils.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy as np
+from ophys_etl.types import OphysROI
+from ophys_etl.utils.roi_plotting_utils import (
+    add_roi_contour_to_img)
+
+
+@pytest.mark.parametrize('alpha', [0.2, 0.3, 0.4])
+def test_add_roi_contour_to_img(alpha):
+    img = 100*np.ones((64, 64, 3), dtype=int)
+
+    height = 7
+    width = 12
+
+    mask = np.zeros((height, width), dtype=bool)
+    mask[1, 5:7] = True
+    mask[2, 4:8] = True
+    mask[3, 3:9] = True
+    mask[4, 2:10] = True
+    mask[5, 3:9] = True
+
+    bdry_pixels = set([(1, 5), (1, 6), (2, 4), (2, 7),
+                       (3, 3), (3, 8), (4, 2), (4, 9),
+                       (5, 3), (5, 4), (5, 5), (5, 6),
+                       (5, 7), (5, 8)])
+
+    roi = OphysROI(x0=20, width=width,
+                   y0=15, height=height,
+                   valid_roi=True, roi_id=0,
+                   mask_matrix=mask)
+
+    color = (22, 33, 44)
+    img = add_roi_contour_to_img(
+                      img,
+                      roi,
+                      color,
+                      alpha)
+
+    for row in range(height):
+        for col in range(width):
+            for ic in range(3):
+                if (row, col) not in bdry_pixels:
+                    assert img[15+row, 20+col, ic] == 100
+                else:
+                    expected = np.round(alpha*color[ic]
+                                        + (1.0-alpha)*100).astype(int)
+                    assert img[15+row, 20+col, ic] == expected

--- a/tests/utils/test_roi_plotting_utils.py
+++ b/tests/utils/test_roi_plotting_utils.py
@@ -313,3 +313,25 @@ def test_plot_rois_over_img(
         expected_channel = expected_image[:, :, ic]
         np.testing.assert_array_equal(channel[not_roi_mask],
                                       expected_channel[not_roi_mask])
+
+
+def test_plot_rois_over_img_exceptions(
+        extract_roi_list_fixture):
+    """Test that plot_rois_over_img gives the expected error
+    message when an image of the wrong shape is passed through"""
+
+    img = np.zeros((20, 20, 4))
+    with pytest.raises(ValueError, match="Cannot handle image with shape"):
+        plot_rois_over_img(
+                img=img,
+                roi_list=extract_roi_list_fixture,
+                color=(255, 0, 0),
+                alpha=0.1)
+
+    img = np.zeros((20, 20, 4, 5))
+    with pytest.raises(ValueError, match="Cannot handle image with shape"):
+        plot_rois_over_img(
+                img=img,
+                roi_list=extract_roi_list_fixture,
+                color=(255, 0, 0),
+                alpha=0.1)

--- a/tests/utils/test_roi_plotting_utils.py
+++ b/tests/utils/test_roi_plotting_utils.py
@@ -320,6 +320,14 @@ def test_plot_rois_over_img_exceptions(
     """Test that plot_rois_over_img gives the expected error
     message when an image of the wrong shape is passed through"""
 
+    img = np.zeros(4)
+    with pytest.raises(ValueError, match="Cannot handle image with shape"):
+        plot_rois_over_img(
+                img=img,
+                roi_list=extract_roi_list_fixture,
+                color=(255, 0, 0),
+                alpha=0.1)
+
     img = np.zeros((20, 20, 4))
     with pytest.raises(ValueError, match="Cannot handle image with shape"):
         plot_rois_over_img(

--- a/tests/utils/test_roi_plotting_utils.py
+++ b/tests/utils/test_roi_plotting_utils.py
@@ -9,7 +9,8 @@ from ophys_etl.utils.rois import (
 from ophys_etl.utils.roi_plotting_utils import (
     add_roi_contour_to_img,
     add_list_of_roi_contours_to_img,
-    plot_rois_over_img)
+    plot_rois_over_img,
+    _is_img_blank)
 
 
 @pytest.fixture(scope='session')
@@ -69,6 +70,19 @@ def color_map_fixture():
     """an example color map"""
     return {0: (11, 255, 56),
             1: (0, 0, 255)}
+
+
+def test_is_img_blank():
+    blank_gray = np.ones((20, 10))
+    assert _is_img_blank(blank_gray)
+    blank_rgb = np.zeros((20, 10, 3))
+    blank_rgb[:, :, 0] = 4
+    blank_rgb[:, :, 1] = 6
+    assert _is_img_blank(blank_rgb)
+    not_blank_gray = np.arange(200).reshape(20, 10)
+    assert not _is_img_blank(not_blank_gray)
+    not_blank_rgb = np.arange(600).reshape(20, 10, 3)
+    assert not _is_img_blank(not_blank_rgb)
 
 
 @pytest.mark.parametrize('alpha', [0.2, 0.3, 0.4])

--- a/tests/utils/test_roi_plotting_utils.py
+++ b/tests/utils/test_roi_plotting_utils.py
@@ -1,8 +1,69 @@
 import pytest
 import numpy as np
-from ophys_etl.types import OphysROI
+import copy
+from itertools import product
+from ophys_etl.types import OphysROI, ExtractROI
+from ophys_etl.utils.rois import (
+    extract_roi_to_ophys_roi)
 from ophys_etl.utils.roi_plotting_utils import (
-    add_roi_contour_to_img)
+    add_roi_contour_to_img,
+    add_list_of_roi_contours_to_img)
+
+
+@pytest.fixture(scope='session')
+def extract_roi_list_fixture():
+
+    roi0 = ExtractROI(
+                id=0,
+                x=1,
+                y=1,
+                width=4,
+                height=5,
+                valid=True,
+                mask=[[True, True, True, False],
+                      [True, True, True, True],
+                      [True, True, True, False],
+                      [True, True, True, False],
+                      [True, True, True, False]])
+
+    roi1 = ExtractROI(
+                id=1,
+                x=5,
+                y=5,
+                width=4,
+                height=3,
+                valid=True,
+                mask=[[True, True, True, True],
+                      [True, True, True, True],
+                      [True, True, True, True]])
+
+    return [roi0, roi1]
+
+
+@pytest.fixture(scope='session')
+def corrupted_extract_roi_list_fixture(
+        extract_roi_list_fixture):
+
+    output = []
+    for roi in extract_roi_list_fixture:
+        new_roi = copy.deepcopy(roi)
+        new_roi['valid_roi'] = new_roi.pop('valid')
+        new_roi['roi_id'] = new_roi.pop('id')
+        new_roi['mask_matrix'] = new_roi.pop('mask')
+        output.append(new_roi)
+    return output
+
+
+@pytest.fixture(scope='session')
+def ophys_roi_list_fixture(extract_roi_list_fixture):
+    return [extract_roi_to_ophys_roi(roi)
+            for roi in extract_roi_list_fixture]
+
+
+@pytest.fixture(scope='session')
+def color_map_fixture():
+    return {0: (0, 255, 0),
+            1: (0, 0, 255)}
 
 
 @pytest.mark.parametrize('alpha', [0.2, 0.3, 0.4])
@@ -45,3 +106,70 @@ def test_add_roi_contour_to_img(alpha):
                     expected = np.round(alpha*color[ic]
                                         + (1.0-alpha)*100).astype(int)
                     assert img[15+row, 20+col, ic] == expected
+
+
+@pytest.mark.parametrize(
+    "roi_list_choice, use_color_map, alpha",
+    product((0, 1, 2),
+            (True, False),
+            (0.5, 0.6)))
+def test_add_list_of_roi_contours_to_img(
+        extract_roi_list_fixture,
+        corrupted_extract_roi_list_fixture,
+        ophys_roi_list_fixture,
+        color_map_fixture,
+        roi_list_choice,
+        use_color_map,
+        alpha):
+
+    if roi_list_choice == 0:
+        roi_list = extract_roi_list_fixture
+    elif roi_list_choice == 1:
+        roi_list = corrupted_extract_roi_list_fixture
+    elif roi_list_choice == 2:
+        roi_list = ophys_roi_list_fixture
+
+    if use_color_map:
+        color = color_map_fixture
+    else:
+        color = (0, 125, 125)
+
+    img_value = 55
+    img = img_value*np.ones((20, 20, 3), dtype=np.uint8)
+
+    result = add_list_of_roi_contours_to_img(
+                img=img,
+                roi_list=roi_list,
+                color=color,
+                alpha=alpha)
+
+    # make sure that input img as not changed
+    assert (img == img_value).all()
+    assert not np.array_equal(img, result)
+
+    assert result.shape == img.shape
+    assert result.dtype == np.uint8
+
+    not_roi_mask = np.ones((20, 20), dtype=bool)
+
+    # check that ROI contour pixels were all set to correct color
+    for roi in ophys_roi_list_fixture:
+        not_roi_mask[roi.y0:roi.y0+roi.height,
+                     roi.x0:roi.x0+roi.width][roi.contour_mask] = False
+
+        if isinstance(color, tuple):
+            this_color = color
+        else:
+            this_color = color[roi.roi_id]
+        for ic in range(3):
+            expected = np.round(alpha*this_color[ic]
+                                + (1.0-alpha)*img_value).astype(np.uint8)
+            channel = result[:, :, ic]
+            actual_contour = channel[roi.y0:roi.y0+roi.height,
+                                     roi.x0:roi.x0+roi.width][roi.contour_mask]
+            assert (actual_contour == expected).all()
+
+    # check that pixels not in the ROI contour were all left untouched
+    for ic in range(3):
+        channel = result[:, :, ic]
+        assert (channel[not_roi_mask] == img_value).all()


### PR DESCRIPTION
I got tired of writing my own methods to plot a list of ROIs over an image. I am hoping that
```
utils.roi_plotting_utils.plot_rois_over_img
```
will be general enough for us to "just use it" whenever we have to plot ROI contours over a projection image.

FYI, a prototype of this method was used to generate the figures driving the Suite2P configuration discussion on 2/9/2022, e.g.
![792757238_2022_rois](https://user-images.githubusercontent.com/1682854/153677131-5697fa5b-34c9-42c5-9b08-bd0adce7333b.png)

The calling method looked like
```
from ophys_etl.utils.roi_plotting_utils import (
    plot_rois_over_img)
from ophys_etl.utils.rois import (
    get_roi_color_map)
from ophys_etl.modules.segmentation.graph_utils.conversion import(
    graph_to_img)
import matplotlib.figure as mfig

import json
import h5py
import numpy as np
import pathlib

def plot_set(video_path, roi_path, graph_path, axis_list):
    if graph_path is not None:
        corr_img = graph_to_img(graph_path)
    else:
        corr_img = None
    with h5py.File(video_path, 'r') as in_file:
        video_data = in_file['data'][()]
        max_img = np.max(video_data, axis=0)
        avg_img = np.mean(video_data, axis=0)

    with open(roi_path, 'rb') as in_file:
        roi_list = json.load(in_file)

    color_map = get_roi_color_map(roi_list)
    for axis, img in zip(axis_list, (corr_img, max_img, avg_img)):
        if img is None:
            continue
        new_img = plot_rois_over_img(
                       img=img,
                       roi_list=roi_list,
                       color=color_map,
                       alpha=1.0)
        axis.imshow(new_img)
    return None
```