### PR TITLE
Ticket/407/dev/enable/suite2p/tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,31 @@
 version: 2.1
 orbs:
   python: circleci/python@1.4
+
+commands:
+  build_and_test:
+    parameters:
+      python_version:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Build docker image
+          command: |
+            docker build --build-arg OPHYS_ETL_TAG=${CIRCLE_BRANCH} --build-arg OPHYS_ETL_COMMIT_SHA=${CIRCLE_SHA1} --build-arg TEST_PYTHON_VERSION=<< parameters.python_version >> -t alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} .circleci/docker
+      - run:
+          name: Run docker image pytest
+          # docker runs should succeed with --read-only flag if expected to be
+          # run by singularity
+          # https://sylabs.io/guides/3.6/user-guide/singularity_and_docker.html#best-practices
+          command: |
+                set -e
+                mkdir /tmp/<< parameters.python_version >>
+                mkdir $PWD/coverage_outputs_<< parameters.python_version >>
+                # set entrypoint like this so we can handle quotes
+                docker run --entrypoint /bin/bash --read-only --tmpfs /tmp --mount type=bind,source=$PWD/coverage_outputs_<< parameters.python_version >>,target=/coverage_outputs_<< parameters.python_version >> alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/run_and_test.sh "not event_detect_only" << parameters.python_version >> ophys_etl general_cov.xml
+                bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs_<< parameters.python_version >>/general_cov.xml -cF general_tests
+
 jobs:
   docker:
     machine: true
@@ -17,14 +42,14 @@ jobs:
           # https://sylabs.io/guides/3.6/user-guide/singularity_and_docker.html#best-practices
           command: |
                   set -e
-                  mkdir $PWD/coverage_outputs
+                  mkdir $PWD/coverage_outputs_3.8
                   # set entrypoint like this so we can handle quotes
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs:/coverage_outputs alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/suite2p_container_test.sh
-                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs/suite2p_cov.xml -cF suite2p_tests
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs:/coverage_outputs alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/event_container_test.sh
-                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs/event_cov.xml -cF event_detection_tests
-                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs:/coverage_outputs alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/general_container_test.sh
-                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs/general_cov.xml -cF general_tests
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs_3.8:/coverage_outputs_3.8 alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/run_and_test.sh "not event_detect_only" 3.8 suite2p suite2p_cov.xml
+                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs_3.8/suite2p_cov.xml -cF suite2p_tests
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs_3.8:/coverage_outputs_3.8 alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/run_and_test.sh "event_detect_only" 3.8 event_detection event_cov.xml
+                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs_3.8/event_cov.xml -cF event_detection_tests
+                  docker run --entrypoint /bin/bash --read-only --tmpfs /tmp -v $PWD/coverage_outputs_3.8:/coverage_outputs_3.8 alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} /repos/ophys_etl/.circleci/scripts/run_and_test.sh "not event_detect_only" 3.8 ophys_etl general_cov.xml
+                  bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f $PWD/coverage_outputs_3.8/general_cov.xml -cF general_tests
       - run:
           name: Run docker image smoke test
           command: |
@@ -42,26 +67,17 @@ jobs:
             fi
             docker push alleninstitutepika/ophys_etl_pipelines
 
-  build377: &test-template
-    executor:
-      name: python/default
-      tag: "3.7.7"
+  build377:
+    machine: true
     steps:
-      - checkout
-      - run:
-          command: |
-            # uses the latest pip with more strict dependency resolution
-            pip install --upgrade pip
-            pip install .
-            python -m pytest --verbose -s -m "not event_detect_only" --cov ophys_etl --cov-report xml
-            bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -cF not_container_tests
-          name: Test
+      - build_and_test:
+          python_version: "3.7.7"
 
-  build38: 
-    <<: *test-template
-    executor:
-      name: python/default
-      tag: "3.8"
+  build38:
+    machine: true
+    steps:
+      - build_and_test:
+          python_version: "3.8"
 
   lint:
     executor: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             # uses the latest pip with more strict dependency resolution
             pip install --upgrade pip
             pip install .
-            python -m pytest --verbose -s -m "not suite2p_only and not event_detect_only" --cov ophys_etl --cov-report xml
+            python -m pytest --verbose -s -m "not event_detect_only" --cov ophys_etl --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -cF not_container_tests
           name: Test
 

--- a/.circleci/coveragerc_file
+++ b/.circleci/coveragerc_file
@@ -1,0 +1,5 @@
+# config file for coverage.py
+# https://coverage.readthedocs.io/en/latest/config.html
+[run]
+branch = True
+concurrency = multiprocessing

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -1,0 +1,54 @@
+FROM continuumio/miniconda3:4.8.2
+
+LABEL maintainer="nicholas.mei@alleninstitute.org"
+LABEL version=1.0
+LABEL description="This dockerfile provides an environment in which to run \
+                   the unit tests for the Allen Institue for Brain Science \
+                   optical physiology data processing pipelines."
+
+ARG OPHYS_ETL_TAG
+ARG OPHYS_ETL_COMMIT_SHA="unknown build"
+ARG TEST_PYTHON_VERSION
+
+ENV OPHYS_ETL_COMMIT_SHA=${OPHYS_ETL_COMMIT_SHA}
+ENV CONDA_ENVS=/envs
+ENV OPHYS_ETL_ENV=${CONDA_ENVS}/ophys_etl
+ENV NUMBA_CACHE_DIR=/tmp
+
+RUN mkdir ${CONDA_ENVS}
+
+# NOTE: To install into conda environments during docker build we need to
+# use "conda run -n <my_env> subsequent commands". For details see:
+# https://pythonspeed.com/articles/activate-conda-dockerfile/
+
+# Install Suite2P (into conda environment named suite2p)
+WORKDIR /repos
+RUN apt-get -y update --allow-releaseinfo-change \
+    && git clone -b ${OPHYS_ETL_TAG} https://github.com/AllenInstitute/ophys_etl_pipelines ./ophys_etl \
+    && conda create --prefix ${OPHYS_ETL_ENV} python=${TEST_PYTHON_VERSION} \
+    # the following installs scipy/numpy with MKL backend,
+    # if requirements.txt specifies a different version, these will get overwritten
+    # and some other BLAS backend will be used - speed will decrease
+    && conda run --prefix ${OPHYS_ETL_ENV} conda install scipy \
+    && conda run --prefix ${OPHYS_ETL_ENV} pip install --no-cache ./ophys_etl \
+    && echo "use for ophys_etl "$(conda run --prefix ${OPHYS_ETL_ENV} which python) \
+    && conda clean --all
+
+# leave /repos/ophys_etl so we can run tests
+
+# The base image has the default entrypoint activate the base conda env.
+# We are creating 2 separate envs.
+# The easiest way to run them is
+# docker run --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:<tag> /envs/suite2p/bin/python -m ophys_etl.transforms.suite2p_wrapper -h"
+# or
+# docker run --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:<tag> /envs/ophys_etl/bin/python -m ophys_etl.transforms.postprocess_rois -h"
+
+# If you need to troubleshoot by running interacticely inside the container:
+# docker run --rm -it --entrypoint "/bin/bash" alleninstitutepika/ophys_etl_pipelines
+
+# If you need to pass args that contain quotes:
+# docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:<tag> -c "/envs/ophys_etl/bin/python -m pytest -m 'not suite2p_only'"
+
+# Uses the bash $@ special parameter to consume all docker args after
+# image_name:tag as args to container bash shell
+ENTRYPOINT ["/bin/bash", "-c", "$@", "--"]

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3:4.8.2
 
-LABEL maintainer="nicholas.mei@alleninstitute.org"
+LABEL maintainer="scott.daniel@alleninstitute.org"
 LABEL version=1.0
 LABEL description="This dockerfile provides an environment in which to run \
                    the unit tests for the Allen Institue for Brain Science \
@@ -36,19 +36,4 @@ RUN apt-get -y update --allow-releaseinfo-change \
 
 # leave /repos/ophys_etl so we can run tests
 
-# The base image has the default entrypoint activate the base conda env.
-# We are creating 2 separate envs.
-# The easiest way to run them is
-# docker run --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:<tag> /envs/suite2p/bin/python -m ophys_etl.transforms.suite2p_wrapper -h"
-# or
-# docker run --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:<tag> /envs/ophys_etl/bin/python -m ophys_etl.transforms.postprocess_rois -h"
-
-# If you need to troubleshoot by running interacticely inside the container:
-# docker run --rm -it --entrypoint "/bin/bash" alleninstitutepika/ophys_etl_pipelines
-
-# If you need to pass args that contain quotes:
-# docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ophys_etl_pipelines:<tag> -c "/envs/ophys_etl/bin/python -m pytest -m 'not suite2p_only'"
-
-# Uses the bash $@ special parameter to consume all docker args after
-# image_name:tag as args to container bash shell
 ENTRYPOINT ["/bin/bash", "-c", "$@", "--"]

--- a/.circleci/scripts/event_container_test.sh
+++ b/.circleci/scripts/event_container_test.sh
@@ -1,8 +1,0 @@
-set -e
-export COVERAGE_FILE=/tmp/.coverage
-cd /repos/ophys_etl/
-/envs/event_detection/bin/python -m \
-    pytest -m "event_detect_only" \
-    --cov-report xml:/coverage_outputs/event_cov.xml \
-    --cov ophys_etl \
-    tests

--- a/.circleci/scripts/general_container_test.sh
+++ b/.circleci/scripts/general_container_test.sh
@@ -1,8 +1,0 @@
-set -e
-export COVERAGE_FILE=/tmp/.coverage
-cd /repos/ophys_etl/
-/envs/ophys_etl/bin/python -m \
-    pytest -m "not event_detect_only" \
-    --cov-report xml:/coverage_outputs/general_cov.xml \
-    --cov ophys_etl \
-    tests

--- a/.circleci/scripts/general_container_test.sh
+++ b/.circleci/scripts/general_container_test.sh
@@ -2,7 +2,7 @@ set -e
 export COVERAGE_FILE=/tmp/.coverage
 cd /repos/ophys_etl/
 /envs/ophys_etl/bin/python -m \
-    pytest -m "not suite2p_only and not event_detect_only" \
+    pytest -m "not event_detect_only" \
     --cov-report xml:/coverage_outputs/general_cov.xml \
     --cov ophys_etl \
     tests

--- a/.circleci/scripts/run_and_test.sh
+++ b/.circleci/scripts/run_and_test.sh
@@ -1,0 +1,30 @@
+PYTEST_MARK=${1}
+PYTHON_VERSION=${2}
+ENV_SPECIFICATION=${3}  # which conda environment to run in
+OUTPUT_XML=${4}    # the name of the coverage xml file (not its full path)
+
+echo "mark: "${PYTEST_MARK}
+echo "version: "${PYTHON_VERSION}
+echo "env: "${ENV_SPECIFICATION}
+echo "xml: "${OUTPUT_XML}
+
+set -e
+export COVERAGE_FILE=/tmp/.coverage_${ENV_SPECIFICATION}_${PYTHON_VERSION}
+echo "COVERAGE_FILE set to "${COVERAGE_FILE}
+cd /repos/ophys_etl/
+/envs/${ENV_SPECIFICATION}/bin/coverage run --rcfile .circleci/coveragerc_file --concurrency=multiprocessing -m \
+    pytest --verbose -s -m "${PYTEST_MARK}" \
+    tests
+
+/envs/${ENV_SPECIFICATION}/bin/coverage combine --data-file=${COVERAGE_FILE} --rcfile .circleci/coveragerc_file
+
+# coverage automatically adds random salt to the end of the
+# coverage file name; need to detect the name of the file
+# that was actually produced
+coverage_file_list=($(ls /tmp/.coverage_${ENV_SPECIFICATION}_${PYTHON_VERSION}*))
+echo "after combining "
+echo ${coverage_file_list[@]}
+
+/envs/${ENV_SPECIFICATION}/bin/coverage xml --data-file=${COVERAGE_FILE} \
+-o /coverage_outputs_${PYTHON_VERSION}/${OUTPUT_XML} \
+--rcfile .circleci/coveragerc_file

--- a/.circleci/scripts/suite2p_container_test.sh
+++ b/.circleci/scripts/suite2p_container_test.sh
@@ -1,9 +1,0 @@
-set -e
-export COVERAGE_FILE=/tmp/.coverage
-cd /repos/ophys_etl/
-/envs/suite2p/bin/python -m \
-    pytest \
-    --ignore=/repos/ophys_etl/tests/modules/event_detection \
-    --cov-report xml:/coverage_outputs/suite2p_cov.xml \
-    --cov ophys_etl \
-    tests

--- a/.circleci/scripts/suite2p_container_test.sh
+++ b/.circleci/scripts/suite2p_container_test.sh
@@ -2,7 +2,7 @@ set -e
 export COVERAGE_FILE=/tmp/.coverage
 cd /repos/ophys_etl/
 /envs/suite2p/bin/python -m \
-    pytest -m "suite2p_only or suite2p_also" \
+    pytest \
     --ignore=/repos/ophys_etl/tests/modules/event_detection \
     --cov-report xml:/coverage_outputs/suite2p_cov.xml \
     --cov ophys_etl \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,6 @@ LABEL description="This dockerfile provides a working environment for \
                    Allen Institute for Brain Science optical physiology data \
                    processing pipelines."
 
-ARG SUITE2P_TAG=v0.10.2
 ARG LZEROCOMMIT=cdfaade68ceb6aa15ec5003c460de4e0575f1d5f
 ARG OPHYS_ETL_TAG=main
 ARG OPHYS_ETL_COMMIT_SHA="unknown build"
@@ -27,18 +26,11 @@ RUN mkdir ${CONDA_ENVS}
 # Install Suite2P (into conda environment named suite2p)
 WORKDIR /repos
 RUN apt-get -y update --allow-releaseinfo-change \
-    # for Suite2P
-    && apt-get -y install libgl1-mesa-glx \
     # for FastLZero
     && apt-get -y install clang libhdf5-serial-dev g++ \
     && rm -rf /var/lib/apt/* \
-    && git clone -b ${SUITE2P_TAG} https://github.com/MouseLand/suite2p ./suite2p \
-    && conda env update --prefix ${SUITE2P_ENV} --file ./suite2p/environment.yml \
-    && conda run --prefix ${SUITE2P_ENV} pip install pyqt5==5.15.1 \
-    pyqt5-sip==12.8.1 \
-    pyqtgraph==0.11.0 \
-    && conda run --prefix ${SUITE2P_ENV} pip install --no-cache ./suite2p \
     && git clone -b ${OPHYS_ETL_TAG} https://github.com/AllenInstitute/ophys_etl_pipelines ./ophys_etl \
+    && conda create --prefix ${SUITE2P_ENV} python=3.8 \
     && conda run --prefix ${SUITE2P_ENV} pip install --no-cache ./ophys_etl \
     && echo "use for suite2p "$(conda run --prefix ${SUITE2P_ENV} which python) \
     && conda create --prefix ${OPHYS_ETL_ENV} python=3.8 \

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 markers =
-    suite2p_only: mark a test to run only inside Suite2P env.
-    suite2p_also: mark a test to run both inside and outside Suite2P env.
     event_detect_only: mark a test to run only inside FastLZero event detection env.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 imageio-ffmpeg
 pytest
-pytest-cov
+coverage
 argschema==2.0.2
 h5py
 matplotlib

--- a/tests/modules/decrosstalk/test_qc_plotting.py
+++ b/tests/modules/decrosstalk/test_qc_plotting.py
@@ -163,7 +163,7 @@ def test_find_overlapping_roi_pairs():
                           ])
 def test_get_img_thumbnails(x0, y0, x1, y1):
     """
-    Test that, when fed to ROIs that are very distant and do not
+    Test that, when fed two ROIs that are very distant and do not
     overlap, get_img_thumbnails returns bounds
     (xmin, xmax), (ymin, ymax) bounds that cover both ROIs
     """

--- a/tests/modules/median_filtered_max_projection/test_filtered_maximum_projection_utils.py
+++ b/tests/modules/median_filtered_max_projection/test_filtered_maximum_projection_utils.py
@@ -54,9 +54,9 @@ def test_median_filter_to_video(kernel_size):
 
 
 @pytest.mark.parametrize('n_processors, input_frame_rate, kernel_size',
-                         product((2, 3, 4),
-                                 (3.0, 6.0, 11.0, 31.0),
-                                 (2, 3, 4)))
+                         product((2, 3),
+                                 (3.0, 11.0),
+                                 (2, 3)))
 def test_median_filtered_max_projection_from_array(
         n_processors,
         input_frame_rate,
@@ -93,16 +93,17 @@ def test_median_filtered_max_projection_from_array(
 
 
 @pytest.mark.parametrize(
-        "input_frame_rate, downsampled_frame_rate, median_filter_kernel_size, "
+        "median_filter_kernel_size, "
         "n_frames_at_once",
-        product((31.0, 11.0), (7.0, 4.0), (3, 4), (100, 52, -1, 0)))
+        product((3, 4), (100, 52, -1, 0)))
 def test_maximum_projection_from_path(
         video_path_fixture,
         video_data_fixture,
-        input_frame_rate,
-        downsampled_frame_rate,
         median_filter_kernel_size,
         n_frames_at_once):
+
+    input_frame_rate = 11.0
+    downsampled_frame_rate = 7.0
 
     expected = median_filtered_max_projection_from_array(
                     video_data_fixture,

--- a/tests/modules/postprocess_rois/test_postprocess_rois.py
+++ b/tests/modules/postprocess_rois/test_postprocess_rois.py
@@ -7,7 +7,6 @@ from ophys_etl.types import DenseROI
 from ophys_etl.schemas import DenseROISchema
 
 
-@pytest.mark.suite2p_also
 def test_output_schema_element():
     """test that attempts to keep the TypedDict and subschema element in sync
     """
@@ -37,7 +36,6 @@ def test_output_schema_element():
     assert subschema.dump(s) == s
 
 
-@pytest.mark.suite2p_also
 @pytest.mark.parametrize("s2p_stat_fixture, ophys_movie_fixture, "
                          "motion_correction_fixture, "
                          "aspect_threshold, expected_rois",

--- a/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
@@ -56,12 +56,14 @@ def video_path_fixture(tmpdir_factory):
     "do_optimize_motion_params, use_ave_image_as_reference",
     product((True, False), (True, False), (True, False), (True, False)))
 def test_suite2p_motion_correction(
-        tmpdir,
+        tmp_path_factory,
         nonrigid,
         clip_negative,
         do_optimize_motion_params,
         use_ave_image_as_reference,
         video_path_fixture):
+
+    tmpdir = tmp_path_factory.mktemp('s2p_motion')
 
     corr_video_path = tempfile.mkstemp(
                             dir=tmpdir,
@@ -97,7 +99,7 @@ def test_suite2p_motion_correction(
                                    prefix='output_',
                                    suffix='.json')[1]
 
-    str_tmpdir = str(pathlib.Path(tmpdir).resolve().absolute())
+    str_tmpdir = str(tmpdir.resolve().absolute())
     s2p_args = {'nonrigid': nonrigid,
                 'h5py': str(video_path_fixture.resolve().absolute()),
                 'tmp_dir': str_tmpdir,

--- a/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
@@ -5,18 +5,8 @@ import tempfile
 from itertools import product
 import numpy as np
 
-has_suite2p = True
-try:
-    import suite2p.registration  # noqa: F401
-except ImportError:
-    # need to get around the fact that Suite2P may not be defined
-    # in the test environment. These tests should all be marked with
-    # pytest.mark.suite2p_only, which means they will only be run in
-    # our CircleCI environments that contain Suite2P
-    has_suite2p = False
-
-if has_suite2p:
-    from ophys_etl.modules.suite2p_registration.__main__ import (
+import suite2p.registration
+from ophys_etl.modules.suite2p_registration.__main__ import (
         Suite2PRegistration)
 
 
@@ -62,7 +52,6 @@ def video_path_fixture(tmpdir_factory):
     video_path.unlink()
 
 
-@pytest.mark.suite2p_only
 @pytest.mark.parametrize(
     "nonrigid, clip_negative, "
     "do_optimize_motion_params, use_ave_image_as_reference",

--- a/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
@@ -5,7 +5,6 @@ import tempfile
 from itertools import product
 import numpy as np
 
-import suite2p.registration
 from ophys_etl.modules.suite2p_registration.__main__ import (
         Suite2PRegistration)
 

--- a/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
@@ -97,8 +97,11 @@ def test_suite2p_motion_correction(
                                    prefix='output_',
                                    suffix='.json')[1]
 
+    str_tmpdir = str(pathlib.Path(tmpdir).resolve().absolute())
     s2p_args = {'nonrigid': nonrigid,
-                'h5py': str(video_path_fixture.resolve().absolute())}
+                'h5py': str(video_path_fixture.resolve().absolute()),
+                'tmp_dir': str_tmpdir,
+                'output_dir': str_tmpdir}
 
     args = {'suite2p_args': s2p_args,
             'movie_frame_rate_hz': 6.1,

--- a/tests/modules/suite2p_registration/test_suite2p_registration_suite2p_utils.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_suite2p_utils.py
@@ -2,13 +2,8 @@ import h5py
 import json
 import numpy as np
 from pathlib import Path
-import sys
-import pytest
 import unittest
 from unittest.mock import MagicMock, Mock, patch
-
-import suite2p.registration
-
 
 from ophys_etl.modules.suite2p_registration.suite2p_utils import (  # noqa: E402, E501
     compute_reference, load_initial_frames, compute_acutance,

--- a/tests/modules/suite2p_registration/test_suite2p_registration_suite2p_utils.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_suite2p_utils.py
@@ -7,15 +7,7 @@ import pytest
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
-has_suite2p = True
-try:
-    import suite2p.registration  # noqa: F401
-except ImportError:
-    # only mock Suite2P if necessary; otherwise, the mock
-    # makes it into the tests that actually rely on Suite2P
-    has_suite2p = False
-    sys.modules['suite2p.registration.rigid'] = Mock()
-    sys.modules['suite2p.registration.register'] = Mock()
+import suite2p.registration
 
 
 from ophys_etl.modules.suite2p_registration.suite2p_utils import (  # noqa: E402, E501
@@ -210,7 +202,6 @@ class TestRegistrationSuite2pUtils(unittest.TestCase):
         self.assertEqual(result_reference[0, -1], mean_value)
         self.assertEqual(result_reference[-1, 0], mean_value)
 
-    @pytest.mark.suite2p_only
     def test_compute_reference(self):
         """Test that the method creates a reference image as expected using
         suite2p.
@@ -336,7 +327,6 @@ class TestRegistrationSuite2pUtils(unittest.TestCase):
         self.assertEqual(result['dy_max'], 20)
         self.assertEqual(result['dx_max'], 20)
 
-    @pytest.mark.suite2p_only
     def test_add_required_parameters(self):
         """Test adding to config parameters to the dict.
         """

--- a/tests/modules/suite2p_registration/test_suite2p_registration_with_mocks.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_with_mocks.py
@@ -10,17 +10,7 @@ import pandas as pd
 import pytest
 import tifffile
 
-has_suite2p = True
-try:
-    import suite2p.registration  # noqa: F401
-except ImportError:
-    # only mock Suite2P if necessary; otherwise, the mock
-    # makes it into the tests that actually rely on Suite2P
-    has_suite2p = False
-
-if not has_suite2p:
-    sys.modules['suite2p'] = Mock()
-    sys.modules['suite2p.registration.rigid'] = Mock()
+import suite2p.registration
 
 from ophys_etl.modules.suite2p_wrapper.schemas import \
         Suite2PWrapperSchema, Suite2PWrapperOutputSchema  # noqa: E402

--- a/tests/modules/suite2p_registration/test_suite2p_registration_with_mocks.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_with_mocks.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -9,8 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import tifffile
-
-import suite2p.registration
 
 from ophys_etl.modules.suite2p_wrapper.schemas import \
         Suite2PWrapperSchema, Suite2PWrapperOutputSchema  # noqa: E402

--- a/tests/modules/suite2p_wrapper/test_suite2p_wrapper_utils.py
+++ b/tests/modules/suite2p_wrapper/test_suite2p_wrapper_utils.py
@@ -19,7 +19,6 @@ def path_to_hash(file_path):
     return str(hasher.hexdigest())
 
 
-@pytest.mark.suite2p_also
 @pytest.mark.parametrize(
         "basenames, dstsubdir, use_mv, exception",
         [


### PR DESCRIPTION
The original scope of this PR was to get us into a state where, now that Suite2P is a formal requirement of ophys_etl_pipelines, the Suite2P tests are run on every branch, not just the branches for which Docker images are created. In the course of doing this work, the following was discovered

- Running the Suite2P tests in the Docker containers provided by CircleCI is an order of magnitude slower than running them in Docker containers that we build on top of CircleCI's "machine" instances. I cannot adequately explain why this is the case, I can just say that it is so.

- pytest-cov, which we were previously using to generate our code coverage data, was producing silent failures when run on tests that involve multiprocessing. The failures were not breaking our builds, but I think they were rendering our code coverage statistics meaningless. For an example of this, see ~ line 156 of

https://circleci.com/api/v1.1/project/github/AllenInstitute/ophys_etl_pipelines/7634/output/103/0?file=true&allocation-id=620ac38190fcb021377a5e90-0-build%2F3B41E89A

(or open in browser and search for "During handling of the above exception, another exception occurred:")

Accordingly, this PR changes our CircleCI scripts so that all tests are run in Docker containers that we build atop CircleCI's "machine" instances. It also removes all dependence on pytest-cov and invokes coverage.py directly to produce code coverage statistics.

Obviously, it is not ideal to have two Dockerfiles floating around in this repo (one in `docker/` one in `.circleci/docker`). Once this code has been merged and we are confident that the stack is stable, we will have a conversation about transitioning the LIMS Suite2P strategies to using the `ophys_etl` conda environment (rather than the `suite2p` environment they currently used). Once that transition is made, we should be able to consolidate Dockerfiles. For now, I just want to get the Suite2P tests running on all branches.