### PR TITLE
Ticket/452/motion/border/artifact

### DIFF
--- a/src/ophys_etl/modules/postprocess_rois/__main__.py
+++ b/src/ophys_etl/modules/postprocess_rois/__main__.py
@@ -6,7 +6,7 @@ from marshmallow import ValidationError
 
 from ophys_etl.utils.motion_border import (
         get_max_correction_from_file,
-        MotionBorder)
+        MaxFrameShift)
 from ophys_etl.schemas import DenseROISchema
 from ophys_etl.utils.rois import (binarize_roi_mask,
                                   coo_rois_to_lims_compatible,
@@ -67,16 +67,16 @@ class PostProcessROIs(ArgSchemaParser):
                          f" {self.args['motion_correction_values']}")
 
         if self.args['motion_correction_values'] is not None:
-            motion_border = get_max_correction_from_file(
+            max_frame_shift = get_max_correction_from_file(
                 self.args['motion_correction_values'],
                 self.args['maximum_motion_shift'])
         else:
-            motion_border = MotionBorder(left=0, right=0, up=0, down=0)
+            max_frame_shift = MaxFrameShift(left=0, right=0, up=0, down=0)
 
         # create the rois
         self.logger.info("Transforming ROIs to LIMS compatible style.")
         compatible_rois = coo_rois_to_lims_compatible(
-                binarized_coo_rois, motion_border, movie_shape,
+                binarized_coo_rois, max_frame_shift, movie_shape,
                 self.args['npixel_threshold'])
 
         if self.args['morphological_ops']:

--- a/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
@@ -92,12 +92,27 @@ class LabelerArtifactFileSchema(argschema.ArgSchema):
                 msg += 'run with --clobber=True'
                 raise RuntimeError(msg)
 
-        correlation_suffix = pathlib.Path(data['correlation_path']).suffix
-        if correlation_suffix not in set(['.png', '.pkl']):
-            msg = "correlation_path must be .pkl or .png file;\n"
-            msg += f"you gave:\n{data['correlation_path']}"
-            raise RuntimeError(msg)
+        return data
 
+    @post_load
+    def check_file_types(self, data, **kwargs):
+        msg = ''
+        for file_path_key, suffix in [('video_path', '.h5'),
+                                      ('roi_path', '.json'),
+                                      ('motion_border_path', '.csv'),
+                                      ('artifact_path', '.h5')]:
+            file_path = data[file_path_key]
+            if file_path is not None:
+                file_path = pathlib.Path(file_path)
+                if file_path.suffix != suffix:
+                    msg += f'{file_path_key} must have suffix {suffix}; '
+                    msg += f'you gave {str(file_path.resolve().absolute())}\n'
+        file_path = pathlib.Path(data['correlation_path'])
+        if file_path.suffix not in ('.pkl', '.png'):
+            msg += 'correlation_path must be either .pkl or .png; '
+            msg += f'you gave {str(file_path.resolve().absolute())}\n'
+        if len(msg) > 0:
+            raise ValueError(msg)
         return data
 
 

--- a/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
@@ -38,6 +38,14 @@ class LabelerArtifactFileSchema(argschema.ArgSchema):
             description=("Path to JSON file containing ROIs "
                          "on which to base this artifact file"))
 
+    motion_border_path = argschema.fields.InputFile(
+            required=False,
+            default=None,
+            allow_none=True,
+            description=("Path to csv file of rigid motion translations "
+                         "applied to movie during motion correction; used "
+                         "to calculate the motion border"))
+
     correlation_path = argschema.fields.InputFile(
             required=True,
             description=("Path to either png or pkl file which "

--- a/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
@@ -21,7 +21,8 @@ from ophys_etl.utils.video_utils import (
 
 from ophys_etl.utils.motion_border import (
     get_max_correction_from_file,
-    MaxFrameShift)
+    MotionBorder,
+    motion_border_from_max_shift)
 
 
 logger = logging.getLogger(__name__)
@@ -132,9 +133,11 @@ class LabelerArtifactGenerator(argschema.ArgSchemaParser):
             motion_border_path = pathlib.Path(self.args['motion_border_path'])
             max_shifts = get_max_correction_from_file(
                                    input_csv=motion_border_path)
+            motion_border = motion_border_from_max_shift(max_shifts)
         else:
             motion_border_path = None
-            max_shifts = MaxFrameShift(left=0, right=0, up=0, down=0)
+            motion_border = MotionBorder(left_side=0, right_side=0,
+                                         top=0, bottom=0)
 
         output_path = pathlib.Path(self.args['artifact_path'])
 
@@ -215,10 +218,10 @@ class LabelerArtifactGenerator(argschema.ArgSchemaParser):
             # are those that wrap on the right, etc.
             out_file.create_dataset(
                 'motion_border',
-                data=json.dumps({'bottom': max(max_shifts.up, 0),
-                                 'top': max(max_shifts.down, 0),
-                                 'left_side': max(max_shifts.right, 0),
-                                 'right_side': max(max_shifts.left, 0)},
+                data=json.dumps({'bottom': motion_border.bottom,
+                                 'top': motion_border.top,
+                                 'left_side': motion_border.left_side,
+                                 'right_side': motion_border.right_side},
                                 indent=2).encode('utf-8'))
 
             trace_group = out_file.create_group('traces')

--- a/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
@@ -21,7 +21,7 @@ from ophys_etl.utils.video_utils import (
 
 from ophys_etl.utils.motion_border import (
     get_max_correction_from_file,
-    MotionBorder)
+    MaxFrameShift)
 
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ class LabelerArtifactGenerator(argschema.ArgSchemaParser):
                                    input_csv=motion_border_path)
         else:
             motion_border_path = None
-            max_shifts = MotionBorder(left=0, right=0, up=0, down=0)
+            max_shifts = MaxFrameShift(left=0, right=0, up=0, down=0)
 
         output_path = pathlib.Path(self.args['artifact_path'])
 

--- a/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
@@ -109,7 +109,7 @@ class LabelerArtifactFileSchema(argschema.ArgSchema):
                     msg += f'you gave {str(file_path.resolve().absolute())}\n'
         file_path = pathlib.Path(data['correlation_path'])
         if file_path.suffix not in ('.pkl', '.png'):
-            msg += 'correlation_path must be either .pkl or .png; '
+            msg += 'correlation_path must have suffix either .pkl or .png; '
             msg += f'you gave {str(file_path.resolve().absolute())}\n'
         if len(msg) > 0:
             raise ValueError(msg)

--- a/src/ophys_etl/modules/roi_cell_classifier/utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, List, Union
+from typing import Tuple, Dict, List, Union, Optional
 import h5py
 import numpy as np
 import pathlib
@@ -124,7 +124,8 @@ def create_metadata_entry(
 def create_metadata(input_args: dict,
                     video_path: pathlib.Path,
                     roi_path: pathlib.Path,
-                    correlation_path: pathlib.Path) -> dict:
+                    correlation_path: pathlib.Path,
+                    motion_csv_path: Optional[pathlib.Path] = None) -> dict:
     """
     Create the metadata dict for an artifact file
 
@@ -142,10 +143,13 @@ def create_metadata(input_args: dict,
     correlation_path: pathlib.Path
         path to the correlation projection data
 
+    motion_csv_path: Optional[pathlib.Path]
+        path to the csv file from which the motion border is read
+
     Returns
     -------
     metadata: dict
-        The complete metadata for the artifac file
+        The complete metadata for the artifact file
     """
     metadata = dict()
     metadata['generator_args'] = copy.deepcopy(input_args)
@@ -153,6 +157,8 @@ def create_metadata(input_args: dict,
     metadata['video'] = create_metadata_entry(video_path)
     metadata['rois'] = create_metadata_entry(roi_path)
     metadata['correlation'] = create_metadata_entry(correlation_path)
+    if motion_csv_path is not None:
+        metadata['motion_csv'] = create_metadata_entry(motion_csv_path)
 
     return metadata
 

--- a/src/ophys_etl/utils/motion_border.py
+++ b/src/ophys_etl/utils/motion_border.py
@@ -20,7 +20,7 @@ def get_max_correction_values(x_series: pd.Series, y_series: pd.Series,
         A series of movements in the y direction
     max_shift: float
         Maximum shift to allow when considering motion correction. Any
-        larger shifts are considered outliers.
+        larger shifts are considered outliers (only absolute value matters).
 
     For deprecated implementation see:
     allensdk.internal.brain_observatory.roi_filter_utils.calculate_max_border

--- a/src/ophys_etl/utils/motion_border.py
+++ b/src/ophys_etl/utils/motion_border.py
@@ -4,11 +4,11 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
-MotionBorder = namedtuple('MotionBorder', ['left', 'right', 'up', 'down'])
+MaxFrameShift = namedtuple('MaxFrameShift', ['left', 'right', 'up', 'down'])
 
 
 def get_max_correction_values(x_series: pd.Series, y_series: pd.Series,
-                              max_shift: float = 30.0) -> MotionBorder:
+                              max_shift: float = 30.0) -> MaxFrameShift:
     """
     Gets the max correction values in the cardinal directions from a series
     of correction values in the x and y directions
@@ -27,7 +27,7 @@ def get_max_correction_values(x_series: pd.Series, y_series: pd.Series,
 
     Returns
     -------
-    MotionBorder
+    MaxFrameShift
         A named tuple containing the maximum correction values found during
         motion correction workflow step. Saved with the following direction
         order [left, right, up, down].
@@ -48,20 +48,20 @@ def get_max_correction_values(x_series: pd.Series, y_series: pd.Series,
     down_shift = np.max(-1 * y_no_outliers.min(), 0)
     up_shift = np.max(y_no_outliers.max(), 0)
 
-    max_border = MotionBorder(left=left_shift, right=right_shift,
+    max_shift = MaxFrameShift(left=left_shift, right=right_shift,
                               up=up_shift, down=down_shift)
 
     # check if all exist
-    if np.any(np.isnan(np.array(max_border))):
-        raise ValueError("One or more motion correction border directions "
-                         "was found to be Nan, max motion border found: "
-                         f"{max_border}, with max_shift {max_shift}")
+    if np.any(np.isnan(np.array(max_shift))):
+        raise ValueError("One or more motion correction shifts "
+                         "was found to be Nan, max shift found: "
+                         f"{max_shift}, with max_shift {max_shift}")
 
-    return max_border
+    return max_shift
 
 
 def get_max_correction_from_file(
-        input_csv: Path, max_shift: float = 30.0) -> MotionBorder:
+        input_csv: Path, max_shift: float = 30.0) -> MaxFrameShift:
     """
 
     Parameters
@@ -78,15 +78,15 @@ def get_max_correction_from_file(
 
     Returns
     -------
-    motion_border
+    max_shift
         A named tuple containing the maximum correction values found during
         motion correction workflow step. Saved with the following direction
         order [left, right, up, down].
 
     """
     motion_correction_df = pd.read_csv(input_csv)
-    motion_border = get_max_correction_values(
+    max_shift = get_max_correction_values(
         x_series=motion_correction_df['x'].astype('float'),
         y_series=motion_correction_df['y'].astype('float'),
         max_shift=max_shift)
-    return motion_border
+    return max_shift

--- a/src/ophys_etl/utils/motion_border.py
+++ b/src/ophys_etl/utils/motion_border.py
@@ -49,10 +49,10 @@ def get_max_correction_values(x_series: pd.Series, y_series: pd.Series,
     y_no_outliers = y_series[(y_series >= -max_shift)
                              & (y_series <= max_shift)]
     # calculate max border shifts
-    right_shift = np.max(-1 * x_no_outliers.min(), 0)
-    left_shift = np.max(x_no_outliers.max(), 0)
-    down_shift = np.max(-1 * y_no_outliers.min(), 0)
-    up_shift = np.max(y_no_outliers.max(), 0)
+    right_shift = -1 * x_no_outliers.min()
+    left_shift = x_no_outliers.max()
+    down_shift = -1 * y_no_outliers.min()
+    up_shift = y_no_outliers.max()
 
     max_shift = MaxFrameShift(left=left_shift, right=right_shift,
                               up=up_shift, down=down_shift)

--- a/src/ophys_etl/utils/motion_border.py
+++ b/src/ophys_etl/utils/motion_border.py
@@ -110,7 +110,7 @@ def motion_border_from_max_shift(
     # a movie in a given direction during motion correction. This could,
     # in principle, be negative (if a movie was only ever shifted up, it's
     # maximum down shift will be negative). MotionBorder is the positive
-    # definite number of pixels to ignore at the edge of a field of view.
+    # (or zero) number of pixels to ignore at the edge of a field of view.
     # In addition to the fact that MotionBorder can only be positive, there
     # is a transposition. If a movie is only ever shifted up, there should
     # be a non-zero motion border at the bottom, since those pixels were

--- a/src/ophys_etl/utils/rois.py
+++ b/src/ophys_etl/utils/rois.py
@@ -6,7 +6,7 @@ import copy
 import networkx
 from scipy.sparse import coo_matrix
 from scipy.spatial.distance import cdist
-from ophys_etl.utils.motion_border import MotionBorder
+from ophys_etl.utils.motion_border import MaxFrameShift
 from ophys_etl.types import DenseROI, ExtractROI, OphysROI
 from skimage.morphology import binary_opening, binary_closing, disk
 
@@ -255,7 +255,7 @@ def crop_roi_mask(roi_mask: coo_matrix) -> coo_matrix:
 
 
 def coo_rois_to_lims_compatible(coo_masks: List[coo_matrix],
-                                max_correction_vals: MotionBorder,
+                                max_correction_vals: MaxFrameShift,
                                 movie_shape: Tuple[int, int],
                                 npixel_threshold: int,
                                 ) -> List[DenseROI]:
@@ -267,7 +267,7 @@ def coo_rois_to_lims_compatible(coo_masks: List[coo_matrix],
     coo_masks: List[coo_matrix]
         A list of scipy coo_matrices representing ROI masks, each element of
         list is a unique ROI.
-    max_correction_vals: MotionBorder
+    max_correction_vals: MaxFrameShift
         Named tuple containing the max motion correction values identified
         in the motion correction step of ophys segmentation pipeline.
         Name tuple has the following names: ['left', 'right', 'up', 'down'].

--- a/tests/modules/classifier_inference/test_classifier_inference_utils.py
+++ b/tests/modules/classifier_inference/test_classifier_inference_utils.py
@@ -32,7 +32,11 @@ def connection(scope="function"):
                 "AttributeName": "timestamp",
                 "AttributeType": "N"
             }
-        ]
+        ],
+        ProvisionedThroughput={
+            "ReadCapacityUnits": 123,
+            "WriteCapacityUnits": 123
+        }
     )
     yield RegistryConnection(table_name)
     mock_dynamo.stop()

--- a/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
+++ b/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
@@ -226,5 +226,5 @@ def test_malformed_corr_file(
     input_data['artifact_path'] = str(output_path)
     input_data['clobber'] = True
 
-    with pytest.raises(RuntimeError, match='.pkl or .png'):
+    with pytest.raises(ValueError, match='.pkl or .png'):
         LabelerArtifactGenerator(input_data=input_data, args=[])

--- a/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
+++ b/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
@@ -30,7 +30,7 @@ from ophys_etl.modules.segmentation.graph_utils.conversion import (
         "with_motion_border",
         product((0.1, 0.2), (0.7, 0.8), (0.1, 0.2), (0.7, 0.8),
                 (True, False), (True, False)))
-def test_with_graph(
+def test_labeler_artifact_generator(
         tmp_path_factory,
         classifier2021_video_fixture,
         classifier2021_video_hash_fixture,
@@ -46,6 +46,9 @@ def test_with_graph(
         projection_upper_quantile,
         use_graph,
         with_motion_border):
+    """
+    Test that LabelerArtifactGenerator runs and produces expected output
+    """
 
     tmpdir = tmp_path_factory.mktemp('full_artifact_generation')
     if with_motion_border:
@@ -235,6 +238,10 @@ def well_made_config_fixture(
         classifier2021_video_fixture,
         suite2p_roi_fixture,
         tmp_path_factory):
+    """
+    A dict representing the input_json for LabelerArtifactGenerator.
+    This one will pass validation.
+    """
 
     tmpdir = tmp_path_factory.mktemp('for_config')
     corr_path = tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1]

--- a/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
+++ b/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
@@ -79,6 +79,10 @@ def test_with_graph(
 
     with h5py.File(output_path, 'r') as artifact_file:
 
+        motion_border = json.loads(
+                          artifact_file['motion_border'][()].decode('utf-8'))
+        assert motion_border == {'up': 0, 'down': 0,
+                                 'left': 0, 'right': 0}
         # test that ROIs were written correctly
         with open(suite2p_roi_fixture, 'rb') as in_file:
             expected_rois = json.load(in_file)

--- a/tests/utils/test_motion_border.py
+++ b/tests/utils/test_motion_border.py
@@ -7,11 +7,11 @@ import pandas as pd
 from ophys_etl.utils.motion_border import (
     get_max_correction_values,
     get_max_correction_from_file,
-    MotionBorder)
+    MaxFrameShift)
 
 
 @pytest.mark.parametrize("motion_correction_data, max_shift,"
-                         "expected_motion_border, x_fail, expected_error",
+                         "expected_max_shift, x_fail, expected_error",
                          [({"x": [None, None],
                             "y": [0.430, 0.321]}, 30.0,
                              None, True, ValueError),
@@ -23,35 +23,35 @@ from ophys_etl.utils.motion_border import (
                              None, True, ValueError),
                           ({"x": [15],
                             "y": [12]}, 30.0,
-                           MotionBorder(left=15, right=-15, up=12, down=-12),
+                           MaxFrameShift(left=15, right=-15, up=12, down=-12),
                            False, None),
                           ({"x": [-15],
                             "y": [-12]}, 30.0,
-                           MotionBorder(left=-15, right=15, up=-12, down=12),
+                           MaxFrameShift(left=-15, right=15, up=-12, down=12),
                            False, None),
                           ({"x": [15],
                             "y": [12]}, -1,
                            None, True, ValueError),
                           ({"x": [15, 12, 0.5, 0.67, -2],
                             "y": [7, 15, 0.56, -2.3, 4]}, 30.0,
-                           MotionBorder(left=15, right=2, up=15, down=2.3),
+                           MaxFrameShift(left=15, right=2, up=15, down=2.3),
                            False, None),
                           ({"x": [0.42, 0.57, 0.36],
                             "y": [0.01, 0.52, 0.21]}, 0.67,
-                           MotionBorder(left=0.57, right=-0.36, up=0.52,
-                                        down=-0.01), False, None),
+                           MaxFrameShift(left=0.57, right=-0.36, up=0.52,
+                                         down=-0.01), False, None),
                           ({"x": [22.0, 42.0, 11.0],
                             "y": [7.0, -4.0, 56.0]}, 30.0,
-                           MotionBorder(left=22.0, right=-11.0,
-                                        up=7.0, down=4.0),
+                           MaxFrameShift(left=22.0, right=-11.0,
+                                         up=7.0, down=4.0),
                            False, None),
                           ({"x": [-22.0, 42.0, 3.0],
                             "y": [7.0, -14.0, 56.0]}, -10.0,
-                           MotionBorder(left=3.0, right=-3.0,
-                                        up=7.0, down=-7.0),
+                           MaxFrameShift(left=3.0, right=-3.0,
+                                         up=7.0, down=-7.0),
                            False, None)])
 def test_get_max_correction_border(motion_correction_data, max_shift,
-                                   expected_motion_border, x_fail,
+                                   expected_max_shift, x_fail,
                                    expected_error):
     """
     Test Cases:
@@ -75,7 +75,7 @@ def test_get_max_correction_border(motion_correction_data, max_shift,
             motion_correction_df["x"],
             motion_correction_df["y"],
             max_shift=max_shift)
-        np.testing.assert_allclose(np.array(expected_motion_border),
+        np.testing.assert_allclose(np.array(expected_max_shift),
                                    np.array(calculated_border))
 
 
@@ -99,15 +99,15 @@ def motion_csv_path_fixture(tmp_path_factory):
 
 @pytest.mark.parametrize(
         'max_shift, expected',
-        [(2, MotionBorder(left=2, right=2, up=2, down=2)),
-         (6, MotionBorder(left=4, right=5, up=2, down=6)),
-         (22, MotionBorder(left=4, right=5, up=2, down=7))])
+        [(2, MaxFrameShift(left=2, right=2, up=2, down=2)),
+         (6, MaxFrameShift(left=4, right=5, up=2, down=6)),
+         (22, MaxFrameShift(left=4, right=5, up=2, down=7))])
 def test_get_max_correction_from_file(
         motion_csv_path_fixture,
         max_shift,
         expected):
     """
-    Test method to read a MotionBorder from a file
+    Test method to read a MaxFrameShift from a file
     """
     actual = get_max_correction_from_file(
                     input_csv=motion_csv_path_fixture,

--- a/tests/utils/test_motion_border.py
+++ b/tests/utils/test_motion_border.py
@@ -36,7 +36,17 @@ from ophys_etl.utils.motion_border import (
                           ({"x": [0.42, 0.57, 0.36],
                             "y": [0.01, 0.52, 0.21]}, 0.67,
                            MotionBorder(left=0.57, right=-0.36, up=0.52,
-                                        down=-0.01), False, None)])
+                                        down=-0.01), False, None),
+                          ({"x": [22.0, 42.0, 11.0],
+                            "y": [7.0, -4.0, 56.0]}, 30.0,
+                           MotionBorder(left=22.0, right=-11.0,
+                                        up=7.0, down=4.0),
+                           False, None),
+                          ({"x": [-22.0, 42.0, 3.0],
+                            "y": [7.0, -14.0, 56.0]}, -10.0,
+                           MotionBorder(left=3.0, right=-3.0,
+                                        up=7.0, down=-7.0),
+                           False, None)])
 def test_get_max_correction_border(motion_correction_data, max_shift,
                                    expected_motion_border, x_fail,
                                    expected_error):

--- a/tests/utils/test_motion_border.py
+++ b/tests/utils/test_motion_border.py
@@ -7,7 +7,9 @@ import pandas as pd
 from ophys_etl.utils.motion_border import (
     get_max_correction_values,
     get_max_correction_from_file,
-    MaxFrameShift)
+    MaxFrameShift,
+    motion_border_from_max_shift,
+    MotionBorder)
 
 
 @pytest.mark.parametrize("motion_correction_data, max_shift,"
@@ -113,4 +115,29 @@ def test_get_max_correction_from_file(
                     input_csv=motion_csv_path_fixture,
                     max_shift=max_shift)
 
+    np.testing.assert_allclose(np.array(actual), np.array(expected))
+
+
+@pytest.mark.parametrize(
+    'max_shift, expected',
+    [(MaxFrameShift(up=0, down=0, left=0, right=0),
+      MotionBorder(top=0, bottom=0, left_side=0, right_side=0)),
+     (MaxFrameShift(up=10, down=0, left=0, right=0),
+      MotionBorder(top=0, bottom=10, left_side=0, right_side=0)),
+     (MaxFrameShift(up=-10, down=0, left=0, right=0),
+      MotionBorder(top=0, bottom=0, left_side=0, right_side=0)),
+     (MaxFrameShift(up=0, down=10, left=0, right=0),
+      MotionBorder(top=10, bottom=0, left_side=0, right_side=0)),
+     (MaxFrameShift(up=0, down=-10, left=0, right=0),
+      MotionBorder(top=0, bottom=0, left_side=0, right_side=0)),
+     (MaxFrameShift(up=0, down=0, left=10, right=0),
+      MotionBorder(top=0, bottom=0, left_side=0, right_side=10)),
+     (MaxFrameShift(up=0, down=0, left=-10, right=0),
+      MotionBorder(top=0, bottom=0, left_side=0, right_side=0)),
+     (MaxFrameShift(up=0, down=0, left=0, right=10),
+      MotionBorder(top=0, bottom=0, left_side=10, right_side=0)),
+     (MaxFrameShift(up=0, down=0, left=0, right=-10),
+      MotionBorder(top=0, bottom=0, left_side=0, right_side=0))])
+def test_motion_border_from_max_shift(max_shift, expected):
+    actual = motion_border_from_max_shift(max_shift)
     np.testing.assert_allclose(np.array(actual), np.array(expected))

--- a/tests/utils/test_rois.py
+++ b/tests/utils/test_rois.py
@@ -6,7 +6,7 @@ from itertools import product
 from scipy.sparse import coo_matrix
 
 from ophys_etl.types import ExtractROI
-from ophys_etl.utils.motion_border import MotionBorder
+from ophys_etl.utils.motion_border import MaxFrameShift
 from ophys_etl.utils import rois as rois_utils
 from ophys_etl.types import DenseROI, OphysROI
 from ophys_etl.schemas import DenseROISchema
@@ -302,83 +302,83 @@ def test_crop_roi_mask(mask, expected):
 
 @pytest.mark.parametrize(
         "dense_mask, max_correction_vals, expected",
-        # MotionBorder in order of: [left, right, up, down]
+        # MaxFrameShift in order of: [left, right, up, down]
         [
-            ([[1]], MotionBorder(0, 0, 0, 0), True),
-            ([[1]], MotionBorder(1, 0, 0, 0), False),
-            ([[1]], MotionBorder(0, 1, 0, 0), False),
-            ([[1]], MotionBorder(0, 0, 1, 0), False),
-            ([[1]], MotionBorder(0, 0, 0, 1), False),
-            ([[1]], MotionBorder(0.2, 0, 0, 0), False),
-            ([[1]], MotionBorder(0, 0.2, 0, 0), False),
-            ([[1]], MotionBorder(0, 0, 0.2, 0), False),
-            ([[1]], MotionBorder(0, 0, 0, 0.2), False),
+            ([[1]], MaxFrameShift(0, 0, 0, 0), True),
+            ([[1]], MaxFrameShift(1, 0, 0, 0), False),
+            ([[1]], MaxFrameShift(0, 1, 0, 0), False),
+            ([[1]], MaxFrameShift(0, 0, 1, 0), False),
+            ([[1]], MaxFrameShift(0, 0, 0, 1), False),
+            ([[1]], MaxFrameShift(0.2, 0, 0, 0), False),
+            ([[1]], MaxFrameShift(0, 0.2, 0, 0), False),
+            ([[1]], MaxFrameShift(0, 0, 0.2, 0), False),
+            ([[1]], MaxFrameShift(0, 0, 0, 0.2), False),
             (
                 [[0, 0, 0],
                  [0, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 1, 1, 1), True),
+                 [0, 0, 0]], MaxFrameShift(1, 1, 1, 1), True),
             (
                 [[0, 1, 0],
                  [0, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 1, 1, 0), True),
+                 [0, 0, 0]], MaxFrameShift(1, 1, 1, 0), True),
             (
                 [[0, 1, 0],
                  [0, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 1, 1, 1), False),
+                 [0, 0, 0]], MaxFrameShift(1, 1, 1, 1), False),
             (
                 [[0, 1, 0],
                  [0, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 1, 1, 0.2), False),
+                 [0, 0, 0]], MaxFrameShift(1, 1, 1, 0.2), False),
             (
                 [[0, 0, 0],
                  [0, 1, 0],
-                 [0, 1, 0]], MotionBorder(1, 1, 0, 1), True),
+                 [0, 1, 0]], MaxFrameShift(1, 1, 0, 1), True),
             (
                 [[0, 0, 0],
                  [0, 1, 0],
-                 [0, 1, 0]], MotionBorder(1, 1, 1, 1), False),
+                 [0, 1, 0]], MaxFrameShift(1, 1, 1, 1), False),
             (
                 [[0, 0, 0],
                  [0, 1, 0],
-                 [0, 1, 0]], MotionBorder(1, 1, 0.2, 1), False),
+                 [0, 1, 0]], MaxFrameShift(1, 1, 0.2, 1), False),
             (
                 [[0, 0, 0],
                  [1, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 0, 1, 1), True),
+                 [0, 0, 0]], MaxFrameShift(1, 0, 1, 1), True),
             (
                 [[0, 0, 0],
                  [1, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 1, 1, 1), False),
+                 [0, 0, 0]], MaxFrameShift(1, 1, 1, 1), False),
             (
                 [[0, 0, 0],
                  [1, 1, 0],
-                 [0, 0, 0]], MotionBorder(1, 0.2, 1, 1), False),
+                 [0, 0, 0]], MaxFrameShift(1, 0.2, 1, 1), False),
             (
                 [[0, 0, 0],
                  [0, 1, 1],
-                 [0, 0, 0]], MotionBorder(0, 1, 1, 1), True),
+                 [0, 0, 0]], MaxFrameShift(0, 1, 1, 1), True),
             (
                 [[0, 0, 0],
                  [0, 1, 1],
-                 [0, 0, 0]], MotionBorder(1, 1, 1, 1), False),
+                 [0, 0, 0]], MaxFrameShift(1, 1, 1, 1), False),
             (
                 [[0, 0, 0],
                  [0, 1, 1],
-                 [0, 0, 0]], MotionBorder(0.2, 1, 1, 1), False),
+                 [0, 0, 0]], MaxFrameShift(0.2, 1, 1, 1), False),
             (
                 [[0, 0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0, 0],
                  [0, 0, 1, 1, 0, 0],
                  [0, 0, 1, 1, 0, 0],
                  [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0]], MotionBorder(2, 2, 2, 2), True),
+                 [0, 0, 0, 0, 0, 0]], MaxFrameShift(2, 2, 2, 2), True),
             (
                 [[0, 0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0, 0],
                  [0, 0, 1, 1, 0, 0],
                  [0, 0, 1, 1, 0, 0],
                  [0, 0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0, 0]], MotionBorder(2, 3, 2, 2), False),
+                 [0, 0, 0, 0, 0, 0]], MaxFrameShift(2, 3, 2, 2), False),
                 ])
 def test_motion_exclusion(dense_mask, max_correction_vals, expected):
     coo = coo_matrix(dense_mask)
@@ -427,7 +427,7 @@ def test_small_size_exclusion(dense_mask, npixel_threshold, expected):
             # this empty one should get filtered away
             coo_matrix([[]])
            ],
-          MotionBorder(2.5, 2.5, 2.5, 2.5), 3,
+          MaxFrameShift(2.5, 2.5, 2.5, 2.5), 3,
           [{'id': 0,
             'x': 0,
             'y': 0,


### PR DESCRIPTION
This PR adds `motion_border` to the datasets contained in the artifact file backing the cell labeling app.

Note, that while the `MotionBorder` named tuple defined in `ophys_et/utils/motion_border.py` actually carries around "the maximum shift that was applied to the movie in each direction", this `motion_border` should represent "the number of pixels to ignore at a given edge of the field of view," i.e. `motion_border.left_side = 7` means "ignore the 7 left most columns of pixels in the field of view.