### PR TITLE
chunk videos saved to artifact file

### DIFF
--- a/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_labeler_artifacts.py
@@ -189,6 +189,14 @@ class LabelerArtifactGenerator(argschema.ArgSchemaParser):
 
         logger.info("Created scaled video")
 
+        # determine chunks in which to save the video data
+        ntime = scaled_video.shape[0]
+        nrows = scaled_video.shape[1]
+        ncols = scaled_video.shape[2]
+        video_chunks = (max(1, ntime//10),
+                        max(1, nrows//16),
+                        max(1, ncols//16))
+
         with h5py.File(output_path, 'a') as out_file:
             out_file.create_dataset(
                 'metadata',
@@ -210,7 +218,8 @@ class LabelerArtifactGenerator(argschema.ArgSchemaParser):
                 data=correlation_img_data)
             out_file.create_dataset(
                 'video_data',
-                data=scaled_video)
+                data=scaled_video,
+                chunks=video_chunks)
 
             # note the transposition below;
             # if you shift up, the suspect pixels are those that wrap

--- a/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
+++ b/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
@@ -139,6 +139,7 @@ def test_labeler_artifact_generator(
                     artifact_file[f'traces/{roi_id}'][()])
 
         # test that the scaled video data was written correctly
+        assert artifact_file['video_data'].chunks is not None
         scaled_video = artifact_file['video_data'][()]
 
         with h5py.File(classifier2021_video_fixture, 'r') as raw_file:


### PR DESCRIPTION
Should speed up trace extraction

running

```
import h5py
import time
import numpy as np

def read_trace(file_path, row, col):
    with h5py.File(file_path, 'r') as in_file:
        return in_file['data'][:, row, col]

def create_movie(file_path, chunks=None, rng=None):
    data = rng.integers(0, 255, (10000, 512, 512), dtype=np.uint8)
    with h5py.File(file_path, 'w') as out_file:
        out_file.create_dataset('data', data=data, chunks=chunks)

def run(chunks=None, rng=None):
    file_path = 'junk.h5'
    create_movie(file_path, chunks=chunks, rng=rng)
    t0 = time.time()
    for ii in range(100):
        row, col = rng.integers(0, 512, size=2)
        t = read_trace(file_path, row, col)
    duration = time.time()-t0
    print(f'chunks: {chunks}; duration {duration:.2e} seconds')

if __name__ == "__main__":
    my_rng = np.random.default_rng(71243)
    run(chunks=None, rng=my_rng)
    run(chunks=(1000,32,32), rng=my_rng)
```
gives
```
chunks: None; duration 9.20e+00 seconds
chunks: (1000, 32, 32); duration 2.11e-01 seconds
```