### PR TITLE
turn off spike detection

### DIFF
--- a/src/ophys_etl/modules/suite2p_wrapper/schemas.py
+++ b/src/ophys_etl/modules/suite2p_wrapper/schemas.py
@@ -88,6 +88,9 @@ class Suite2PWrapperSchema(argschema.ArgSchema):
                     "refImg to an empty list or array (Default).")
 
     # s2p cell detection settings
+    spikedetect = argschema.fields.Bool(
+            default=False,
+            description=("whether or not to run spike deconvolution"))
     roidetect = argschema.fields.Bool(
             default=True,
             description=("Whether or not to run ROI extraction. This is the "

--- a/tests/modules/suite2p_wrapper/test_suite2p_wrapper.py
+++ b/tests/modules/suite2p_wrapper/test_suite2p_wrapper.py
@@ -86,6 +86,7 @@ def allen_default_args_fixture():
     output['inner_neuropil_radius'] = 2
     output['min_neuropil_pixels'] = 350
     output['allow_overlap'] = True
+    output['spikedetect'] = False
     return output
 
 


### PR DESCRIPTION
I feel very embarrassed writing all of this:

**For some reason**, Suite2P's spike deconvolution was provoking a segmentation fault when I was trying to run segmentation on the SSF dataset over the weekend. This was only happening on the cluster. I could not reproduce on synapse, or on an interactive cluster session in which I installed a fresh conda environment. Probably something about my original conda environment was broken (though that is the conda environment I used to test on synapse).

That being said: we don't use Suite2P's spike deconvolution in our pipeline so, rather than debug this problem, I would like to just turn the option off by default whenever we invoke Suite2P.

Note: running off of this branch solved my problem. The segmentation fault went away.

I am duly embarrassed that this is all I can say about the problem.