### PR TITLE
Ticket/nnn/video/from/artifacts

### DIFF
--- a/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
@@ -16,9 +16,54 @@ def get_thumbnail_video_from_artifact_file(
                           Tuple[int, int, int],
                           Dict[int, Tuple[int, int, int]]] = None,
          timesteps: Optional[np.ndarray] = None,
-         quality: int = 5,
          fps: int = 31,
-         tmp_dir: Optional[pathlib.Path] = None):
+         quality: int = 5,
+         tmp_dir: Optional[pathlib.Path] = None
+         ) -> thumbnail_utils.ThumbnailVideo:
+    """
+    Get a ThumbnailVideo from an ROI and a labeler artifact file
+
+    Parameters
+    ----------
+    artifact_path: pathlib.Path
+        Path to the labeler artifact file from which to read the video
+
+    roi: ExtractROI
+
+    padding: int
+        The number of pixels to either side of the ROI to
+        include in the field of view (if possible; default=0)
+
+    other_roi: Union[None, List[ExtractROI]]
+        Other ROI to display
+
+    roi_color: Union[None,
+                     Tuple[int, int, int],
+                     Dict[int, Tuple[int, int, int]]]
+        If not None, the RGB color in which to plot the ROI's
+        contour (or dict mapping ROI ID to RGB color).
+        If None, ROI is not plotted in thumbnail.
+        (default: None)
+
+    timesteps: Optional[np.ndarray]
+        If not None, timesteps to put in the thumbnail
+        video. If None, use all timesetps (default: None)
+
+    fps: int
+        frames per second (default: 31)
+
+    quality: int
+        quality parameter passed to imageio. Max is 10.
+        (default: 5)
+
+    tmp_dir: Optional[pathlib.Path]
+        temporary directory where thumbnail video will
+        be written
+
+    Returns
+    -------
+    thumbnail_utils.ThumbnailVideo
+    """
 
     with h5py.File(artifact_path, 'r') as in_file:
         fov_shape = in_file['video_data'].shape[1:]

--- a/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
@@ -1,0 +1,76 @@
+from typing import Optional, List, Tuple, Dict, Union
+import pathlib
+import numpy as np
+import h5py
+from ophys_etl.types import ExtractROI
+from ophys_etl.utils.video_utils import video_bounds_from_ROI
+import ophys_etl.utils.thumbnail_video_utils as thumbnail_utils
+
+
+def get_thumbnail_video_from_artifact_file(
+         artifact_path: pathlib.Path,
+         roi: ExtractROI,
+         padding: int = 0,
+         other_roi: Union[None, List[ExtractROI]] = None,
+         roi_color: Union[None,
+                          Tuple[int, int, int],
+                          Dict[int, Tuple[int, int, int]]] = None,
+         timesteps: Optional[np.ndarray] = None,
+         quality: int = 5,
+         fps: int = 31,
+         tmp_dir: Optional[pathlib.Path] = None):
+
+    with h5py.File(artifact_path, 'r') as in_file:
+        fov_shape = in_file['video_data'].shape[1:]
+        (origin,
+         window_shape) = video_bounds_from_ROI(
+                              roi=roi,
+                              fov_shape=fov_shape,
+                              padding=padding)
+
+        y0 = origin[0]
+        y1 = origin[0]+window_shape[0]
+        x0 = origin[1]
+        x1 = origin[1]+window_shape[1]
+
+        if timesteps is None:
+            video_data = in_file['video_data'][:, y0:y1, x0:x1]
+        else:
+            video_data = in_file['video_data'][timesteps, y0:y1, x0:x1]
+
+    new_roi = ExtractROI(
+                   id=int(roi['id']),
+                   y=int(roi['y']-y0),
+                   x=int(roi['x']-x0),
+                   width=int(roi['width']),
+                   height=int(roi['height']),
+                   mask=roi['mask'],
+                   valid=True)
+    if other_roi is None:
+        new_other_roi = None
+    else:
+        new_other_roi = []
+        for o_roi in other_roi:
+            new_o_roi = ExtractROI(
+                           id=int(o_roi['id']),
+                           y=int(o_roi['y']-y0),
+                           x=int(o_roi['x']-x0),
+                           width=int(o_roi['width']),
+                           height=int(o_roi['height']),
+                           mask=o_roi['mask'],
+                           valid=True)
+            new_other_roi.append(new_o_roi)
+
+    thumbnail = thumbnail_utils.thumbnail_video_from_ROI(
+                    video=video_data,
+                    roi=new_roi,
+                    padding=padding,
+                    roi_color=roi_color,
+                    other_roi=new_other_roi,
+                    timesteps=None,
+                    tmp_dir=tmp_dir,
+                    quality=quality,
+                    min_max=None,
+                    fps=fps)
+
+    return thumbnail

--- a/tests/modules/roi_cell_classifier/artifact_videos/conftest.py
+++ b/tests/modules/roi_cell_classifier/artifact_videos/conftest.py
@@ -1,0 +1,69 @@
+import pytest
+import pathlib
+import numpy as np
+import tempfile
+import h5py
+from ophys_etl.types import ExtractROI
+
+
+@pytest.fixture(scope='session')
+def video_file_fixture(tmp_path_factory):
+    """
+    Create an HDF5 file with 'video_data'.
+    Yield the path to that file.
+    """
+    tmp_dir = pathlib.Path(tmp_path_factory.mktemp('artifact_video'))
+    rng = np.random.default_rng(7213)
+    video_path = tempfile.mkstemp(dir=tmp_dir, suffix='.h5')[1]
+    video_path = pathlib.Path(video_path)
+    with h5py.File(video_path, 'w') as out_file:
+        out_file.create_dataset(
+                'video_data',
+                data=rng.integers(0, 255, (100, 64, 64)).astype(np.uint8),
+                chunks=(10, 16, 16))
+    yield video_path
+    if video_path.is_file():
+        video_path.unlink()
+
+
+@pytest.fixture(scope='session')
+def extract_roi_list_fixture():
+    """
+    Return a list of ExtractROIs
+    """
+    rng = np.random.default_rng(5321)
+    roi_list = []
+
+    mask = rng.integers(0, 2, (10, 10)).astype(bool)
+    roi_list.append(ExtractROI(id=0,
+                               x=4, y=3,
+                               width=mask.shape[1],
+                               height=mask.shape[0],
+                               valid=True,
+                               mask=[list(v) for v in mask]))
+
+    mask = rng.integers(0, 2, (7, 12)).astype(bool)
+    roi_list.append(ExtractROI(id=1,
+                               x=10, y=3,
+                               width=mask.shape[1],
+                               height=mask.shape[0],
+                               valid=True,
+                               mask=[list(v) for v in mask]))
+
+    mask = rng.integers(0, 2, (7, 12)).astype(bool)
+    roi_list.append(ExtractROI(id=2,
+                               x=1, y=1,
+                               width=mask.shape[1],
+                               height=mask.shape[0],
+                               valid=True,
+                               mask=[list(v) for v in mask]))
+
+    mask = rng.integers(0, 2, (7, 12)).astype(bool)
+    roi_list.append(ExtractROI(id=3,
+                               x=12, y=4,
+                               width=mask.shape[1],
+                               height=mask.shape[0],
+                               valid=True,
+                               mask=[list(v) for v in mask]))
+
+    return roi_list

--- a/tests/modules/roi_cell_classifier/artifact_videos/test_artifact_video_generation.py
+++ b/tests/modules/roi_cell_classifier/artifact_videos/test_artifact_video_generation.py
@@ -12,6 +12,9 @@ from ophys_etl.modules.roi_cell_classifier.video_utils import (
 
 
 def path_to_hash(this_path):
+    """
+    Return the md5 checksum of a file specified by a path
+    """
     hasher = hashlib.md5()
     with open(this_path, 'rb') as in_file:
         chunk = in_file.read(10000)
@@ -26,7 +29,7 @@ def path_to_hash(this_path):
     product((0, 5), (True, False),
             (None, (122, 11, 6)),
             (None, np.arange(6, 36, dtype=int))))
-def test_roundtrip(
+def test_video_gen(
         video_file_fixture,
         extract_roi_list_fixture,
         tmp_path_factory,
@@ -34,7 +37,10 @@ def test_roundtrip(
         use_other_roi,
         roi_color,
         timesteps):
-
+    """
+    Test that get_thumbnail_video_from_artifact_file returns
+    the same results as VideoGenerator.get_thumbnail_video_from_roi
+    """
     tmp_dir = pathlib.Path(tmp_path_factory.mktemp('roundtrip'))
     alt_tmp_dir = pathlib.Path(tmp_path_factory.mktemp('by_hand'))
 

--- a/tests/modules/roi_cell_classifier/artifact_videos/test_artifact_video_generation.py
+++ b/tests/modules/roi_cell_classifier/artifact_videos/test_artifact_video_generation.py
@@ -1,0 +1,73 @@
+import pytest
+import h5py
+import pathlib
+import hashlib
+import numpy as np
+import copy
+from itertools import product
+from ophys_etl.utils.thumbnail_video_generator import (
+    VideoGenerator)
+from ophys_etl.modules.roi_cell_classifier.video_utils import (
+    get_thumbnail_video_from_artifact_file)
+
+
+def path_to_hash(this_path):
+    hasher = hashlib.md5()
+    with open(this_path, 'rb') as in_file:
+        chunk = in_file.read(10000)
+        while len(chunk) > 0:
+            hasher.update(chunk)
+            chunk = in_file.read(100000)
+    return hasher.hexdigest()
+
+
+@pytest.mark.parametrize(
+    "padding, use_other_roi, roi_color, timesteps",
+    product((0, 5), (True, False),
+            (None, (122, 11, 6)),
+            (None, np.arange(6, 36, dtype=int))))
+def test_roundtrip(
+        video_file_fixture,
+        extract_roi_list_fixture,
+        tmp_path_factory,
+        padding,
+        use_other_roi,
+        roi_color,
+        timesteps):
+
+    tmp_dir = pathlib.Path(tmp_path_factory.mktemp('roundtrip'))
+    alt_tmp_dir = pathlib.Path(tmp_path_factory.mktemp('by_hand'))
+
+    with h5py.File(video_file_fixture, 'r') as in_file:
+        data_arr = in_file['video_data'][()]
+    gen0 = VideoGenerator(video_data=data_arr,
+                          tmp_dir=tmp_dir)
+
+    for ii, roi in enumerate(extract_roi_list_fixture):
+        if use_other_roi:
+            other_roi = copy.deepcopy(extract_roi_list_fixture)
+            other_roi.pop(ii)
+        else:
+            other_roi = None
+
+        v0 = gen0.get_thumbnail_video_from_roi(
+                                   roi=roi,
+                                   padding=padding,
+                                   other_roi=other_roi,
+                                   roi_color=roi_color,
+                                   timesteps=timesteps)
+
+        v1 = get_thumbnail_video_from_artifact_file(
+                    artifact_path=video_file_fixture,
+                    roi=roi,
+                    padding=padding,
+                    other_roi=other_roi,
+                    roi_color=roi_color,
+                    timesteps=timesteps,
+                    tmp_dir=alt_tmp_dir)
+
+        h0 = path_to_hash(v0.video_path)
+        h1 = path_to_hash(v1.video_path)
+        assert h0 == h1
+        del v0
+        del v1


### PR DESCRIPTION
This adds a utility function that can create a thumbnail video from a labeler artifact file, using the fact that the labeler artifact files should be chunked to more rapidly load the video data.