### PR TITLE
Ticket/nnnn/video/bug/220314

### DIFF
--- a/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import h5py
 import numbers
+import warnings
 from ophys_etl.types import ExtractROI
 from ophys_etl.utils.video_utils import video_bounds_from_ROI
 import ophys_etl.utils.thumbnail_video_utils as thumbnail_utils
@@ -87,6 +88,12 @@ def get_thumbnail_video_from_artifact_file(
         else:
             valid = np.logical_and(timesteps >= 0,
                                    timesteps < video_shape[0])
+            if valid.sum() < len(timesteps):
+                msg = "You asked for timesteps between "
+                msg += f"[{timesteps.min()}, {timesteps.max()}]; "
+                msg += f"this video has shape {video_shape}; "
+                msg += "automatically clipping timesteps to be valid"
+                warnings.warn(msg)
             timesteps = timesteps[valid]
             video_data = in_file['video_data'][timesteps, y0:y1, x0:x1]
 

--- a/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
@@ -50,6 +50,9 @@ def get_thumbnail_video_from_artifact_file(
         If not None, timesteps to put in the thumbnail
         video. If None, use all timesetps (default: None)
 
+        Note: timesteps will automatically be clipped to be
+        between [0, video_shape[0])
+
     fps: int
         frames per second (default: 31)
 
@@ -67,11 +70,11 @@ def get_thumbnail_video_from_artifact_file(
     """
 
     with h5py.File(artifact_path, 'r') as in_file:
-        fov_shape = in_file['video_data'].shape[1:]
+        video_shape = in_file['video_data'].shape
         (origin,
          window_shape) = video_bounds_from_ROI(
                               roi=roi,
-                              fov_shape=fov_shape,
+                              fov_shape=video_shape[1:],
                               padding=padding)
 
         y0 = origin[0]
@@ -82,6 +85,9 @@ def get_thumbnail_video_from_artifact_file(
         if timesteps is None:
             video_data = in_file['video_data'][:, y0:y1, x0:x1]
         else:
+            valid = np.logical_and(timesteps >= 0,
+                                   timesteps < video_shape[0])
+            timesteps = timesteps[valid]
             video_data = in_file['video_data'][timesteps, y0:y1, x0:x1]
 
     # When users of the cell labeling app try to load a video from

--- a/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
@@ -111,7 +111,8 @@ def get_thumbnail_video_from_artifact_file(
         new_roi_color[roi_id_to_int[roi['id']]] = roi_color[roi['id']]
         if other_roi is not None:
             for o_roi in other_roi:
-                new_roi_color[roi_id_to_int[o_roi['id']]] = roi_color[o_roi['id']]
+                id_as_int = roi_id_to_int[o_roi['id']]
+                new_roi_color[id_as_int] = roi_color[o_roi['id']]
     else:
         new_roi_color = roi_color
 

--- a/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/video_utils.py
@@ -95,7 +95,13 @@ def get_thumbnail_video_from_artifact_file(
                 msg += "automatically clipping timesteps to be valid"
                 warnings.warn(msg)
             timesteps = timesteps[valid]
-            video_data = in_file['video_data'][timesteps, y0:y1, x0:x1]
+            dt = np.unique(np.diff(timesteps))
+            if len(dt) == 1 and int(dt.max()) == 1:
+                tmin = timesteps.min()
+                tmax = timesteps.max()+1
+                video_data = in_file['video_data'][tmin:tmax, y0:y1, x0:x1]
+            else:
+                video_data = in_file['video_data'][timesteps, y0:y1, x0:x1]
 
     # When users of the cell labeling app try to load a video from
     # an arbitrary point, the assigned id is a string, not an int.

--- a/tests/modules/roi_cell_classifier/artifact_videos/test_artifact_video_generation.py
+++ b/tests/modules/roi_cell_classifier/artifact_videos/test_artifact_video_generation.py
@@ -99,3 +99,49 @@ def test_video_gen_for_string_roi_id(
                     tmp_dir=tmp_dir)
 
     assert v1.video_path.is_file()
+
+
+@pytest.mark.parametrize(
+        "safe_timesteps, unsafe_timesteps",
+        [(np.arange(0, 50), np.arange(-40, 50)),
+         (np.arange(60, 100), np.arange(60, 130))])
+def test_timestep_clipping(
+        video_file_fixture,
+        extract_roi_list_fixture,
+        tmp_path_factory,
+        safe_timesteps,
+        unsafe_timesteps):
+    """
+    Test that get_thumbnail_from_artifact_file correctly clips
+    timesteps
+    """
+    tmp_dir = pathlib.Path(tmp_path_factory.mktemp('time_clip'))
+    roi_color = (99, 88, 55)
+    padding = 16
+    other_roi = None
+
+    for ii, roi in enumerate(extract_roi_list_fixture):
+
+        v0 = get_thumbnail_video_from_artifact_file(
+                    artifact_path=video_file_fixture,
+                    roi=roi,
+                    padding=padding,
+                    other_roi=other_roi,
+                    roi_color=roi_color,
+                    timesteps=safe_timesteps,
+                    tmp_dir=tmp_dir)
+
+        v1 = get_thumbnail_video_from_artifact_file(
+                    artifact_path=video_file_fixture,
+                    roi=roi,
+                    padding=padding,
+                    other_roi=other_roi,
+                    roi_color=roi_color,
+                    timesteps=unsafe_timesteps,
+                    tmp_dir=tmp_dir)
+
+        h0 = path_to_hash(v0.video_path)
+        h1 = path_to_hash(v1.video_path)
+        assert h0 == h1
+        del v0
+        del v1

--- a/tests/modules/roi_cell_classifier/conftest.py
+++ b/tests/modules/roi_cell_classifier/conftest.py
@@ -43,6 +43,8 @@ def classifier2021_video_fixture(classifier2021_tmpdir_fixture):
     with h5py.File(video_path, 'w') as out_file:
         out_file.create_dataset('data', data=data)
     yield video_path
+    if video_path.is_file():
+        video_path.unlink()
 
 
 @pytest.fixture(scope='session')
@@ -91,6 +93,8 @@ def suite2p_roi_fixture(classifier2021_tmpdir_fixture):
     with open(roi_path, 'w') as out_file:
         out_file.write(json.dumps(roi_list, indent=2))
     yield roi_path
+    if roi_path.is_file():
+        roi_path.unlink()
 
 
 @pytest.fixture(scope='session')
@@ -123,6 +127,8 @@ def classifier2021_corr_graph_fixture(
                            filtered_hnc_Gaussian=rng.random())
     nx.write_gpickle(graph, graph_path)
     yield graph_path
+    if graph_path.is_file():
+        graph_path.unlink()
 
 
 @pytest.fixture(scope='session')
@@ -148,7 +154,10 @@ def classifier2021_corr_png_fixture(
     img = normalize_array(img)
     img = PIL.Image.fromarray(img)
     img.save(png_path)
-    yield pathlib.Path(png_path)
+    png_path = pathlib.Path(png_path)
+    yield png_path
+    if png_path.is_file():
+        png_path.unlink()
 
 
 @pytest.fixture(scope='session')

--- a/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
+++ b/tests/modules/roi_cell_classifier/test_labeler_artifact_module.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 import copy
 import numpy as np
+import os
 import PIL.Image
 from itertools import product
 
@@ -79,11 +80,14 @@ def test_labeler_artifact_generator(
         corr_fixture = classifier2021_corr_png_fixture
         corr_hash = classifier2021_corr_png_hash_fixture
 
-    output_path = tempfile.mkstemp(dir=tmpdir,
-                                   prefix='artifact_file_',
-                                   suffix='.h5')[1]
+    output_tuple = tempfile.mkstemp(dir=tmpdir,
+                                    prefix='artifact_file_',
+                                    suffix='.h5')
 
-    output_path = pathlib.Path(output_path)
+    # without this, got a "too many files open" error
+    os.close(output_tuple[0])
+
+    output_path = pathlib.Path(output_tuple[1])
 
     # because tempfile.mkstemp actually creates the file
     output_path.unlink()


### PR DESCRIPTION
The classifier app was falling over whenever it asked for videos with timesteps outside of the time domain of the videos. This adds a step to the `get_video` method that automatically clips `timesteps` to be safely in bounds