### PR TITLE
Ticket/nnn/fix/tiff/splitting/json

### DIFF
--- a/src/ophys_etl/modules/mesoscope_splitting/__main__.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/__main__.py
@@ -17,6 +17,9 @@ from ophys_etl.modules.mesoscope_splitting.zstack_splitter import (
 from ophys_etl.modules.mesoscope_splitting.tiff_metadata import (
     ScanImageMetadata)
 
+from ophys_etl.modules.mesoscope_splitting.output_json_sanitizer import (
+    get_sanitized_json_data)
+
 
 def get_valid_roi_centers(
         timeseries_splitter: TimeSeriesSplitter) -> List[Tuple[float, float]]:
@@ -223,7 +226,7 @@ class TiffSplitterCLI(ArgSchemaParser):
             file_metadata.append(this_metadata)
         output["file_metadata"] = file_metadata
 
-        self.output(output, indent=1)
+        self.output(get_sanitized_json_data(output), indent=1)
         duration = time.time()-t0
         self.logger.info(f"that took {duration:.2e} seconds")
 

--- a/src/ophys_etl/modules/mesoscope_splitting/output_json_sanitizer.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/output_json_sanitizer.py
@@ -7,7 +7,6 @@
 # to the output.json.
 
 from typing import Union
-import json
 import numbers
 import numpy as np
 
@@ -64,9 +63,4 @@ def get_sanitized_json_data(
         A version of output_json_data that is fit to be written to
         the output.json and ingested by LIMS
     """
-
-    # round trip the data through JSON so that any sets get converted
-    # into lists, etc.
-    reconstituted = json.loads(json.dumps(output_json_data))
-    json_data = _sanitize_data(data=reconstituted)
-    return json_data
+    return _sanitize_data(data=output_json_data)

--- a/src/ophys_etl/modules/mesoscope_splitting/output_json_sanitizer.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/output_json_sanitizer.py
@@ -12,7 +12,7 @@ import numbers
 import numpy as np
 
 
-def _sanitize_element(element: numbers.Number) -> Union[str, float]:
+def _sanitize_element(element: numbers.Number) -> Union[str, numbers.Number]:
     """
     If element is NaN or +/-inf, convert to a
     string; otherwise, return element as-si
@@ -27,7 +27,8 @@ def _sanitize_element(element: numbers.Number) -> Union[str, float]:
 
 
 def _sanitize_data(
-        data: Union[list, dict, float]) -> Union[list, dict, float]:
+        data: Union[list, dict, numbers.Number, str]
+        ) -> Union[list, dict, numbers.Number, str]:
     """
     Iteratively sanitize a data structure so that there are no NaNs
     or infinities in the output.json returned by this module

--- a/src/ophys_etl/modules/mesoscope_splitting/output_json_sanitizer.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/output_json_sanitizer.py
@@ -1,0 +1,71 @@
+# The ruby code that runs the LIMS strategies reads in the output.json
+# produced by each module and uses it to set attributes in the LIMS
+# database. The JSON parser in that code does not handle NaNs or Infs.
+# Unfortunately, the ScanImage metadata prepended to the Mesoscope
+# TIFF files includes several values that are set to Inf. This module
+# provides some methods to sanitize the output data before it is written
+# to the output.json.
+
+from typing import Union
+import json
+import numbers
+import numpy as np
+
+
+def _sanitize_element(element: numbers.Number) -> Union[str, float]:
+    """
+    If element is NaN or +/-inf, convert to a
+    string; otherwise, return element as-si
+    """
+    if np.isfinite(element):
+        return element
+    if np.isnan(element):
+        return "_NaN_"
+    if element > 0:
+        return "_Inf_"
+    return "_-Inf_"
+
+
+def _sanitize_data(
+        data: Union[list, dict, float]) -> Union[list, dict, float]:
+    """
+    Iteratively sanitize a data structure so that there are no NaNs
+    or infinities in the output.json returned by this module
+
+    Return the sanitized version of data.
+    """
+    if isinstance(data, numbers.Number):
+        return _sanitize_element(element=data)
+    elif isinstance(data, list):
+        for ii in range(len(data)):
+            data[ii] = _sanitize_data(data=data[ii])
+    elif isinstance(data, dict):
+        key_list = list(data.keys())
+        for key in key_list:
+            data[key] = _sanitize_data(data=data[key])
+    return data
+
+
+def get_sanitized_json_data(
+        output_json_data: Union[dict, list]) -> Union[list, dict]:
+    """
+    Take the data that is supposed to be written to the output.json
+    and sanitize it so that there are no NaNs or infs.
+
+    Parameters
+    ----------
+    output_json_data: Union[dict, list]
+        The data this meant to be written to the output.json file
+
+    Returns
+    -------
+    sanitized_output_json_data: Union[dict, list]
+        A version of output_json_data that is fit to be written to
+        the output.json and ingested by LIMS
+    """
+
+    # round trip the data through JSON so that any sets get converted
+    # into lists, etc.
+    reconstituted = json.loads(json.dumps(output_json_data))
+    json_data = _sanitize_data(data=reconstituted)
+    return json_data

--- a/tests/modules/mesoscope_splitting/test_output_sanitization.py
+++ b/tests/modules/mesoscope_splitting/test_output_sanitization.py
@@ -1,0 +1,103 @@
+import pytest
+import numpy as np
+from ophys_etl.modules.mesoscope_splitting.output_json_sanitizer import (
+    _sanitize_element,
+    _sanitize_data,
+    get_sanitized_json_data)
+
+
+def test_sanitize_element():
+    """
+    test that _sanitize_element fixes what it is supposed
+    to fix and passes through what it is supposed to pass through
+    """
+    assert _sanitize_element(2) == 2
+    np.testing.assert_allclose(_sanitize_element(2.1), 2.1)
+    assert _sanitize_element(float('Infinity')) == "_Inf_"
+    assert _sanitize_element(-float('Infinity')) == "_-Inf_"
+    assert _sanitize_element(np.inf) == "_Inf_"
+    assert _sanitize_element(-np.inf) == "_-Inf_"
+    assert _sanitize_element(np.nan) == "_NaN_"
+
+
+@pytest.mark.parametrize(
+        "data, expected",
+        [({'a': 'b', 'c': 1, 'd': np.inf},
+          {'a': 'b', 'c': 1, 'd': '_Inf_'}),
+         ([1, 2, -np.inf, 3, np.nan],
+          [1, 2, '_-Inf_', 3, '_NaN_']),
+         ({'a': 'b', 'c': [1, np.nan, 3], 'd': np.inf},
+          {'a': 'b', 'c': [1, '_NaN_', 3], 'd': '_Inf_'}),
+         ({'a': {'b': np.nan, 'c': [1, -np.inf, 2]},
+           'b': 2, 'c': 3, 'd': [1, np.inf], 'e': np.nan},
+          {'a': {'b': '_NaN_', 'c': [1, '_-Inf_', 2]},
+           'b': 2, 'c': 3, 'd': [1, '_Inf_'], 'e': '_NaN_'}),
+         ([1, 'b', {'a': np.nan, 'b': [1, 2, np.inf]}, 'c', -np.inf],
+          [1, 'b', {'a': '_NaN_', 'b': [1, 2, '_Inf_']}, 'c', '_-Inf_'])
+         ])
+def test_sanitize_data(data, expected):
+    """
+    test that _sanitize_data properly sanitizes iterable data elements
+    """
+    assert _sanitize_data(data=data) == expected
+
+
+@pytest.fixture
+def json_data_fixture0():
+    """
+    Returns an input json_data and an expected result
+    of sanitization
+    """
+    json_data = {'a': np.inf,
+                 'b': [1, 2, -np.inf],
+                 'c': {'d': [np.inf, -np.inf, 3],
+                       'e': '/path/to/a/file.txt'}}
+
+    expected = {'a': '_Inf_',
+                'b': [1, 2, '_-Inf_'],
+                'c': {'d': ['_Inf_', '_-Inf_', 3],
+                      'e': '/path/to/a/file.txt'}}
+
+    return (json_data, expected)
+
+
+@pytest.fixture
+def json_data_fixture1():
+    """
+    Returns an input json_data and an expected result
+    of sanitization
+    """
+
+    json_data = [{'a': '/path/to/file.txt',
+                  'b': [np.inf, 2, np.nan]},
+                 [-np.inf, 'c', 'd'],
+                 4]
+
+    expected = [{'a': '/path/to/file.txt',
+                 'b': ['_Inf_', 2, '_NaN_']},
+                ['_-Inf_', 'c', 'd'],
+                4]
+
+    return(json_data, expected)
+
+
+@pytest.fixture
+def json_data_fixture_list(json_data_fixture0,
+                           json_data_fixture1):
+    """
+    Returns a list of (input_data, expected_result) pairs
+    """
+    output = []
+    output.append(json_data_fixture0)
+    output.append(json_data_fixture1)
+    return output
+
+
+def test_sanitized_json_data(json_data_fixture_list):
+    """
+    Test that get_sanitized_json_data returns the expected result
+    """
+
+    for (input_data, expected_result) in json_data_fixture_list:
+        actual_result = get_sanitized_json_data(input_data)
+        assert actual_result == expected_result


### PR DESCRIPTION
The updated mesoscope tiff splitter is failing on LIMS because it writes an output.json with the naive JSON serializations of `np.inf` and `np.nan`, which the LIMS ruby code cannot properly ingest. This PR adds methods to sanitize the output JSON file by casting infs and nans into strings (the legacy code accomplished this with a method called `SI_stringify_floats`.

I have run this code on real input data and verified that following ruby script
```
require 'json'
f = File.read('better_output.json')
p = JSON.parse(f)
```
can ingest and parse the output JSON file (prior to this PR, this ruby script would have thrown a very noisy error).