### PR TITLE
danielsf/debug/zstack/220328

### DIFF
--- a/tests/modules/mesoscope_splitting/test_malformed_zstack.py
+++ b/tests/modules/mesoscope_splitting/test_malformed_zstack.py
@@ -200,3 +200,50 @@ def z_stack_mean_not_int(tmp_path_factory,
         path_to_metadata[tmp_path] = metadata
 
     return path_to_metadata
+
+
+@pytest.fixture(scope='session')
+def z_stack_roi_missing_tiff(tmp_path_factory,
+                             baseline_zstack_metadata):
+    """
+    Create a set of z_stacks in which an ROI is not represented
+    by discretePlaneMode==0 in the stack TIFFs
+    """
+
+    path_to_metadata = dict()
+    tmp_dir = tmp_path_factory.mktemp('z_stack_many')
+    for ii in range(3):
+        tmp_path = tempfile.mkstemp(dir=tmp_dir, suffix='.tiff')[1]
+        metadata = copy.deepcopy(baseline_zstack_metadata)
+        rois = metadata[1]['RoiGroups']['imagingRoiGroup']['rois']
+        if ii == 0 or ii == 1:
+            rois[0]['discretePlaneMode'] = 0
+        else:
+            rois[ii]['discretePlaneMode'] = 0
+
+        path_to_metadata[tmp_path] = metadata
+
+    return path_to_metadata
+
+
+def test_roi_missing_tiff(
+        z_stack_roi_missing_tiff):
+    """
+    Test that an error is raised if an ROI does not have
+    a corresponding z-stack TIFF with discretePlaneMode==0
+    """
+    z_stack_path_to_metadata = z_stack_roi_missing_tiff
+
+    def mock_read_metadata(tiff_path):
+        str_path = str(tiff_path.resolve().absolute())
+        return z_stack_path_to_metadata[str_path]
+
+    tiff_path_list = [pathlib.Path(n)
+                      for n in z_stack_path_to_metadata.keys()]
+
+    to_replace = 'ophys_etl.modules.mesoscope_splitting.'
+    to_replace += 'tiff_metadata._read_metadata'
+    with patch(to_replace, new=mock_read_metadata):
+        with pytest.raises(RuntimeError,
+                           match="are represented in the local z-stack"):
+            ZStackSplitter(tiff_path_list=tiff_path_list)

--- a/tests/modules/mesoscope_splitting/test_malformed_zstack.py
+++ b/tests/modules/mesoscope_splitting/test_malformed_zstack.py
@@ -177,32 +177,6 @@ def test_z_odd_shape(
 
 
 @pytest.fixture(scope='session')
-def z_stack_mean_not_int(tmp_path_factory,
-                         baseline_zstack_metadata):
-    """
-    Create a set of z_stacks in which the mean
-    of each stack's z values is not an integer
-    """
-
-    path_to_metadata = dict()
-    tmp_dir = tmp_path_factory.mktemp('z_stack_none')
-    for ii in range(3):
-        tmp_path = tempfile.mkstemp(dir=tmp_dir, suffix='.tiff')[1]
-        metadata = copy.deepcopy(baseline_zstack_metadata)
-        rois = metadata[1]['RoiGroups']['imagingRoiGroup']['rois']
-        rois[ii]['discretePlaneMode'] = 0
-
-        if ii == 1:
-            key_name = 'SI.hStackManager.zsAllActuators'
-            metadata[0].pop(key_name)
-            metadata[0][key_name] = [[1.1, 2.1], [1.2, 2.2]]
-
-        path_to_metadata[tmp_path] = metadata
-
-    return path_to_metadata
-
-
-@pytest.fixture(scope='session')
 def z_stack_roi_missing_tiff(tmp_path_factory,
                              baseline_zstack_metadata):
     """


### PR DESCRIPTION
There was a failure in the mesoscope file splitting queue over the weekend. The failure was due to a user error (the metadata for the local z-stack TIFFs did not represent all of the ROIs in the ophys session). However, our error message was not as illuminating as it could have been. This PR adds a check for that specific failure case that produces a more helpful error message.

Here is the failed job

http://lims2.corp.alleninstitute.org/job_logs?id=1166657352&utf8=%E2%9C%93

(I am told it was test data, so not actually something to sweat). I have run that data through this PR. It now produces the error

```
RuntimeError: There are 4 ROIs; however, only 3 of them are represented in the local z-stack TIFFS. Here is a mapping from i_roi to TIFF paths
{
  "0": [
    "/Users/scott.daniel/Pika/ophys_etl_2/sfd_sandbox/zstack_failure_220328/data/1166538014_local_z_stack0.tiff",
    "/Users/scott.daniel/Pika/ophys_etl_2/sfd_sandbox/zstack_failure_220328/data/1166538014_local_z_stack1.tiff"
  ],
  "2": [
    "/Users/scott.daniel/Pika/ophys_etl_2/sfd_sandbox/zstack_failure_220328/data/1166538014_local_z_stack2.tiff"
  ],
  "3": [
    "/Users/scott.daniel/Pika/ophys_etl_2/sfd_sandbox/zstack_failure_220328/data/1166538014_local_z_stack3.tiff"
  ]
}

This was determined by scanning the z-stack TIFFs and noting which ROIs were marked with discretePlaneMode==0
```
on instantiation of the `ZStackSplitter`.