### PR TITLE
ticket-450: Migrate CircleCI "machine instances"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ commands:
 
 jobs:
   docker:
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run:
@@ -60,19 +61,22 @@ jobs:
             if [ "$CIRCLE_BRANCH" = "main" ]
             then
                 docker tag alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:main
+                docker push alleninstitutepika/ophys_etl_pipelines:main
             else
                 docker tag alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:develop
+                docker push alleninstitutepika/ophys_etl_pipelines:develop
             fi
-            docker push alleninstitutepika/ophys_etl_pipelines
 
   build377:
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - build_and_test:
           python_version: "3.7.7"
 
   build38:
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - build_and_test:
           python_version: "3.8"

--- a/src/ophys_etl/modules/mesoscope_splitting/tiff_splitter.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/tiff_splitter.py
@@ -206,7 +206,7 @@ class ScanImageTiffSplitter(IntFromZMapperMixin):
         The number of pages in this TIFF
         """
         if not hasattr(self, '_n_pages'):
-            with tifffile.TiffFile(self._file_path, 'rb') as tiff_file:
+            with tifffile.TiffFile(self._file_path, mode='rb') as tiff_file:
                 self._n_pages = len(tiff_file.pages)
         return self._n_pages
 
@@ -256,7 +256,7 @@ class ScanImageTiffSplitter(IntFromZMapperMixin):
         offset = self._get_offset(i_roi=i_roi, z_value=z_value)
 
         tiff_data = []
-        with tifffile.TiffFile(self._file_path, 'rb') as tiff_file:
+        with tifffile.TiffFile(self._file_path, mode='rb') as tiff_file:
             for i_page in range(offset, self.n_pages, self.n_valid_zs):
                 arr = tiff_file.pages[i_page].asarray()
                 tiff_data.append(arr)
@@ -299,7 +299,7 @@ class ScanImageTiffSplitter(IntFromZMapperMixin):
 
         if key_pair not in self._frame_shape:
             offset = self._get_offset(i_roi=i_roi, z_value=z_value)
-            with tifffile.TiffFile(self._file_path, 'rb') as tiff_file:
+            with tifffile.TiffFile(self._file_path, mode='rb') as tiff_file:
                 page = tiff_file.pages[offset].asarray()
                 self._frame_shape[key_pair] = page.shape
         return self._frame_shape[key_pair]
@@ -433,7 +433,7 @@ class TimeSeriesSplitter(ScanImageTiffSplitter):
 
         n_frames = np.ceil((self.n_pages-offset)/self.n_valid_zs).astype(int)
 
-        with tifffile.TiffFile(self._file_path, 'rb') as tiff_file:
+        with tifffile.TiffFile(self._file_path, mode='rb') as tiff_file:
             eg_array = tiff_file.pages[0].asarray()
             fov_shape = eg_array.shape
             video_dtype = eg_array.dtype

--- a/src/ophys_etl/modules/mesoscope_splitting/zstack_splitter.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/zstack_splitter.py
@@ -95,7 +95,7 @@ class ZStackSplitter(IntFromZMapperMixin):
 
         self._path_to_pages = dict()
         for tiff_path in self._path_to_metadata.keys():
-            with tifffile.TiffFile(tiff_path, 'rb') as tiff_file:
+            with tifffile.TiffFile(tiff_path, mode='rb') as tiff_file:
                 self._path_to_pages[tiff_path] = len(tiff_file.pages)
 
     @property
@@ -142,7 +142,7 @@ class ZStackSplitter(IntFromZMapperMixin):
         path_z = (tiff_path, self._int_from_z(z_value=z_value))
         z_index = self._path_z_int_to_index[path_z]
 
-        with tifffile.TiffFile(tiff_path, 'rb') as tiff_file:
+        with tifffile.TiffFile(tiff_path, mode='rb') as tiff_file:
             page = tiff_file.pages[z_index].asarray()
         return page.shape
 
@@ -161,7 +161,7 @@ class ZStackSplitter(IntFromZMapperMixin):
         data = []
         n_pages = self._path_to_pages[tiff_path]
         baseline_shape = self.frame_shape(i_roi=i_roi, z_value=z_value)
-        with tifffile.TiffFile(tiff_path, 'rb') as tiff_file:
+        with tifffile.TiffFile(tiff_path, mode='rb') as tiff_file:
             for i_page in range(z_index, n_pages, 2):
                 this_page = tiff_file.pages[i_page].asarray()
                 if this_page.shape != baseline_shape:

--- a/tests/modules/mesoscope_splitting/test_tiff_splitter.py
+++ b/tests/modules/mesoscope_splitting/test_tiff_splitter.py
@@ -172,7 +172,7 @@ def test_depth_splitter(tmp_path_factory,
         splitter.write_output_file(i_roi=i_roi,
                                    z_value=z_value,
                                    output_path=tmp_path)
-        with tifffile.TiffFile(tmp_path, 'rb') as tiff_file:
+        with tifffile.TiffFile(tmp_path, mode='rb') as tiff_file:
             assert len(tiff_file.pages) == 1
             actual = tiff_file.pages[0].asarray()
 
@@ -314,7 +314,7 @@ def test_surface_splitter(tmp_path_factory,
         splitter.write_output_file(i_roi=i_roi,
                                    z_value=z_value,
                                    output_path=tmp_path)
-        with tifffile.TiffFile(tmp_path, 'rb') as tiff_file:
+        with tifffile.TiffFile(tmp_path, mode='rb') as tiff_file:
             assert len(tiff_file.pages) == 1
             actual = tiff_file.pages[0].asarray()
 

--- a/tests/modules/mesoscope_splitting_cli/utils.py
+++ b/tests/modules/mesoscope_splitting_cli/utils.py
@@ -102,23 +102,23 @@ def run_mesoscope_cli_test(
             np.testing.assert_array_equal(actual, expected)
 
             depth_actual = exp_dir / f'{exp_id}_depth.tif'
-            with tifffile.TiffFile(depth_actual, 'rb') as in_file:
+            with tifffile.TiffFile(depth_actual, mode='rb') as in_file:
                 assert len(in_file.pages) == 1
                 actual = in_file.pages[0].asarray()
             depth_expected = depth_data[f'expected_{exp_id}']
-            with tifffile.TiffFile(depth_expected, 'rb') as in_file:
+            with tifffile.TiffFile(depth_expected, mode='rb') as in_file:
                 assert len(in_file.pages) == 1
                 expected = in_file.pages[0].asarray()
             np.testing.assert_array_equal(actual, expected)
 
             surface_actual = exp_dir / f'{exp_id}_surface.tif'
-            with tifffile.TiffFile(surface_actual, 'rb') as in_file:
+            with tifffile.TiffFile(surface_actual, mode='rb') as in_file:
                 assert len(in_file.pages) == 1
                 actual = in_file.pages[0].asarray()
 
             roi_index = exp['roi_index']
             surface_expected = surface_data[f'expected_{roi_index}']
-            with tifffile.TiffFile(surface_expected, 'rb') as in_file:
+            with tifffile.TiffFile(surface_expected, mode='rb') as in_file:
                 assert len(in_file.pages) == 1
                 expected = in_file.pages[0].asarray()
             np.testing.assert_array_equal(actual, expected)

--- a/tests/modules/video/test_video_module_pipeline.py
+++ b/tests/modules/video/test_video_module_pipeline.py
@@ -50,7 +50,7 @@ def test_single_video_downsampling(
     assert output_path.is_file()
 
     if output_path.suffix in ('.tiff', '.tif'):
-        with tifffile.TiffFile(output_path, 'rb') as input_file:
+        with tifffile.TiffFile(output_path, mode='rb') as input_file:
             arr = input_file.pages[0].asarray()
             if video_dtype == 'uint8':
                 assert arr.dtype == np.uint8
@@ -99,7 +99,7 @@ def test_side_by_side_video_downsampling(
     assert output_path.is_file()
 
     if output_path.suffix in ('.tiff', '.tif'):
-        with tifffile.TiffFile(output_path, 'rb') as input_file:
+        with tifffile.TiffFile(output_path, mode='rb') as input_file:
             arr = input_file.pages[0].asarray()
             if video_dtype == 'uint8':
                 assert arr.dtype == np.uint8


### PR DESCRIPTION
Changed the setting for machine image in CircleCI settings following this [post](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/?mkt_tok=NDg1LVpNSC02MjYAAAGD54jNCFTy_9_ZVyMH1jv915_gXepI2hBlANKeJnQ-IWfKfobgo1vgc3LuwswxkOxS4IJXAMBGIR3cS8p01PCbNmSoLZbwIU5b9jXo3CjrReVqSw#changes).

Ran into an issue with `TiffFile` instantiation that required changing `mode` from a positional argument. This wasn't an issue for python3.7 but was when running tests for python3.8.