### PR TITLE
turn exception into warning

### DIFF
--- a/src/ophys_etl/modules/roi_cell_classifier/compute_classifier_artifacts.py
+++ b/src/ophys_etl/modules/roi_cell_classifier/compute_classifier_artifacts.py
@@ -187,7 +187,7 @@ class ClassifierArtifactsGenerator(ArgSchemaParser):
         roi_id = ophys_roi.roi_id
         if mask_thumbnail.sum() <= 0:
             msg = f"{exp_id}_{roi_id} has bad mask {mask_thumbnail.shape}"
-            raise RuntimeError(msg)
+            self.logger.warn(msg)
         for img, name in zip((max_thumbnail, avg_thumbnail,
                               corr_thumbnail, mask_thumbnail),
                              (f"max_{exp_id}_{roi_id}.png",


### PR DESCRIPTION
There is a scenario in which the mask doesn't fit in the 128x128 window and so the sum is 0. This prevents artifacts from being generated for the entire experiment