### PR TITLE
Find/fullfield/tiff

### DIFF
--- a/src/ophys_etl/modules/mesoscope_splitting/tiff_splitter.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/tiff_splitter.py
@@ -458,9 +458,9 @@ class AvgImageTiffSplitter(TiffSplitterBase):
 
         metadata = {'scanimage_metadata': self.raw_metadata}
 
-        tifffile.imsave(output_path,
-                        avg_img,
-                        metadata=metadata)
+        tifffile.imwrite(output_path,
+                         avg_img,
+                         metadata=metadata)
         return None
 
 

--- a/src/ophys_etl/test_utils/full_field_tiff_utils.py
+++ b/src/ophys_etl/test_utils/full_field_tiff_utils.py
@@ -55,7 +55,7 @@ def _create_full_field_tiff(
             tempfile.mkstemp(dir=output_dir,
                              prefix='full_field_',
                              suffix='.tiff')[1])
-    tifffile.imsave(tiff_path, tiff_pages)
+    tifffile.imwrite(tiff_path, tiff_pages)
     metadata = [{'SI.hStackManager.actualNumVolumes': numVolumes,
                  'SI.hStackManager.actualNumSlices': numSlices}]
 

--- a/tests/modules/mesoscope_splitting/test_roi_insertion.py
+++ b/tests/modules/mesoscope_splitting/test_roi_insertion.py
@@ -83,7 +83,7 @@ def _create_avg_surface_tiff(
         for i_page in range(i_roi, n_pages_per_roi*n_rois, n_rois):
             data[i_page, :, :] = this_data[i_page//n_rois, :, :]
 
-    tifffile.imsave(tiff_path, data)
+    tifffile.imwrite(tiff_path, data)
 
     metadata[0][
         'SI.hStackManager.zsAllActuators'] = [[i_roi, 0]

--- a/tests/modules/mesoscope_splitting/test_tiff_splitter.py
+++ b/tests/modules/mesoscope_splitting/test_tiff_splitter.py
@@ -73,7 +73,7 @@ def _create_image_tiff(
             tiff_pages.append(page)
             page_lookup[(i_roi, z_value)].append(page)
     tmp_path = pathlib.Path(mkstemp_clean(dir=tmp_dir, suffix='tiff'))
-    tifffile.imsave(tmp_path, tiff_pages)
+    tifffile.imwrite(tmp_path, tiff_pages)
 
     tiff_pages = np.array(tiff_pages)
 
@@ -601,7 +601,7 @@ def _create_z_stack_tiffs(
                     tiff_pages_lookup[(i_roi, this_z)].append(page)
                     this_tiff.append(page)
 
-        tifffile.imsave(stack_path, this_tiff)
+        tifffile.imwrite(stack_path, this_tiff)
 
     return (z_stack_path_to_metadata,
             tiff_pages_lookup,

--- a/tests/modules/mesoscope_splitting/test_timeseries_utils.py
+++ b/tests/modules/mesoscope_splitting/test_timeseries_utils.py
@@ -41,7 +41,7 @@ def timeseries_tiff_fixture(
                 all_data.append(timeseries_fixtures[offset][ii, :, :])
 
     all_data = np.stack(all_data)
-    tifffile.imsave(tiff_path, all_data)
+    tifffile.imwrite(tiff_path, all_data)
 
     yield tiff_path
 

--- a/tests/modules/mesoscope_splitting_cli/conftest.py
+++ b/tests/modules/mesoscope_splitting_cli/conftest.py
@@ -55,6 +55,34 @@ def _roi_index_to_centerxy(roi_index):
 
 
 @pytest.fixture
+def upload_directory_fixture(
+       tmp_path_factory,
+       helper_functions):
+    """
+    The 'data_upload_dir' key in the mesoscope splitter
+    input_json
+    """
+    output_tmp_dir = tmp_path_factory.mktemp('splitter_cli_upload')
+    output_tmp_dir = pathlib.Path(output_tmp_dir)
+    yield output_tmp_dir
+    helper_functions.clean_up_dir(output_tmp_dir)
+
+
+@pytest.fixture
+def storage_directory_fixture(
+       tmp_path_factory,
+       helper_functions):
+    """
+    The 'storage_directory' key in the mesoscope splitter
+    input_json
+    """
+    output_tmp_dir = tmp_path_factory.mktemp('splitter_cli_output')
+    output_tmp_dir = pathlib.Path(output_tmp_dir)
+    yield output_tmp_dir
+    helper_functions.clean_up_dir(output_tmp_dir)
+
+
+@pytest.fixture
 def full_field_roi_size_fixture():
     """
     Return a tuple representing the size of the ROIs that make up
@@ -88,13 +116,13 @@ def surface_roi_sizexy_fixture():
 
 
 @pytest.fixture
-def z_to_stack_path_fixture(splitter_tmp_dir_fixture,
+def z_to_stack_path_fixture(upload_directory_fixture,
                             z_list_fixture):
     """
     Return a dict mapping a tuple of z-values to the path
     to local_z_stack.tiff corresponding to those z-values
     """
-    tmp_dir = splitter_tmp_dir_fixture
+    tmp_dir = upload_directory_fixture
     result = dict()
     for pair in z_list_fixture:
         path = mkstemp_clean(dir=tmp_dir,
@@ -173,8 +201,7 @@ def surface_metadata_fixture(image_metadata_fixture,
 
 
 @pytest.fixture
-def zstack_metadata_fixture(splitter_tmp_dir_fixture,
-                            image_metadata_fixture,
+def zstack_metadata_fixture(image_metadata_fixture,
                             z_to_stack_path_fixture,
                             z_to_roi_index_fixture,
                             roi_index_to_z_fixture):
@@ -213,7 +240,7 @@ def zstack_metadata_fixture(splitter_tmp_dir_fixture,
 @pytest.fixture
 def zstack_fixture(zstack_metadata_fixture,
                    z_to_exp_id_fixture,
-                   splitter_tmp_dir_fixture,
+                   upload_directory_fixture,
                    float_resolution_fixture):
     """
     Create z-stack tiff files at paths specified in
@@ -225,7 +252,7 @@ def zstack_fixture(zstack_metadata_fixture,
     """
 
     rng = np.random.default_rng(7123412)
-    tmp_dir = splitter_tmp_dir_fixture
+    tmp_dir = upload_directory_fixture
     n_pages = 10
 
     # make it not a square so we can catch
@@ -276,7 +303,7 @@ def zstack_fixture(zstack_metadata_fixture,
 
 
 @pytest.fixture
-def surface_fixture(splitter_tmp_dir_fixture,
+def surface_fixture(upload_directory_fixture,
                     roi_index_to_z_fixture,
                     surface_roi_resolutionxy_fixture):
     """
@@ -290,7 +317,7 @@ def surface_fixture(splitter_tmp_dir_fixture,
     for an individual experiment
     """
     n_rois = len(roi_index_to_z_fixture)
-    tmp_dir = splitter_tmp_dir_fixture
+    tmp_dir = upload_directory_fixture
     raw_tiff_path = mkstemp_clean(dir=tmp_dir,
                                   suffix='_surface.tiff')
     expected_path_list = []
@@ -333,7 +360,7 @@ def surface_fixture(splitter_tmp_dir_fixture,
 
 
 @pytest.fixture
-def timeseries_fixture(splitter_tmp_dir_fixture,
+def timeseries_fixture(upload_directory_fixture,
                        image_metadata_fixture,
                        z_to_exp_id_fixture):
     """
@@ -347,7 +374,7 @@ def timeseries_fixture(splitter_tmp_dir_fixture,
     experiment
     """
     rng = np.random.default_rng(6123512)
-    tmp_dir = splitter_tmp_dir_fixture
+    tmp_dir = upload_directory_fixture
     z_list = image_metadata_fixture[0]['SI.hStackManager.zsAllActuators']
     z_to_data = dict()
     n_pages = 13
@@ -385,7 +412,7 @@ def timeseries_fixture(splitter_tmp_dir_fixture,
 
 
 @pytest.fixture
-def depth_fixture(splitter_tmp_dir_fixture,
+def depth_fixture(upload_directory_fixture,
                   image_metadata_fixture,
                   z_to_exp_id_fixture):
     """
@@ -399,7 +426,7 @@ def depth_fixture(splitter_tmp_dir_fixture,
     for an individual experiment
     """
     rng = np.random.default_rng(334422)
-    tmp_dir = splitter_tmp_dir_fixture
+    tmp_dir = upload_directory_fixture
     z_list = image_metadata_fixture[0]['SI.hStackManager.zsAllActuators']
     z_to_data = dict()
     n_pages = 11
@@ -439,9 +466,11 @@ def depth_fixture(splitter_tmp_dir_fixture,
 
 @pytest.fixture
 def full_field_2p_tiff_fixture(
-        splitter_tmp_dir_fixture,
+        upload_directory_fixture,
+        storage_directory_fixture,
         surface_roi_sizexy_fixture,
-        full_field_roi_size_fixture):
+        full_field_roi_size_fixture,
+        request):
     """
     Create a test full field TIFF image
 
@@ -449,7 +478,22 @@ def full_field_2p_tiff_fixture(
     Return a dict with
     'raw' -> the path to the raw tiff image
     'metadata' -> the metadata dict that goes with this file
+
+    if request.param is 'storage', put the file in
+    storage_directory_fixture
+
+    if request.param is 'upload', but the file in
+    upload_directory_fixture
     """
+    if request.param == 'storage':
+        output_dir = storage_directory_fixture
+    elif request.param == 'upload':
+        output_dir = upload_directory_fixture
+    else:
+        raise RuntimeError(
+            "not sure how to handle request.param "
+            f"{request.param}")
+
     gap = 1
     nrois = 3
     roix = 24
@@ -464,7 +508,7 @@ def full_field_2p_tiff_fixture(
         numVolumes=4,
         numSlices=3,
         seed=1123,
-        output_dir=splitter_tmp_dir_fixture,
+        output_dir=output_dir,
         nrows=nrows,
         ncols=ncols)
 
@@ -488,7 +532,7 @@ def full_field_2p_tiff_fixture(
 
 @pytest.fixture
 def platform_json_fixture(
-        splitter_tmp_dir_fixture,
+        upload_directory_fixture,
         full_field_2p_tiff_fixture,
         request):
     """
@@ -497,7 +541,7 @@ def platform_json_fixture(
     If request.param is True, include the fullfield_2p_image path
     in the input json. If not, do not.
     """
-    platform_path = splitter_tmp_dir_fixture / 'platform.json'
+    platform_path = upload_directory_fixture / 'platform.json'
 
     if request.param:
         str_path = full_field_2p_tiff_fixture['raw']
@@ -516,6 +560,8 @@ def platform_json_fixture(
 
 @pytest.fixture
 def input_json_fixture(
+        storage_directory_fixture,
+        upload_directory_fixture,
         depth_fixture,
         surface_fixture,
         timeseries_fixture,
@@ -524,7 +570,6 @@ def input_json_fixture(
         z_to_exp_id_fixture,
         z_to_stack_path_fixture,
         roi_index_to_z_fixture,
-        splitter_tmp_dir_fixture,
         tmp_path_factory,
         z_to_roi_index_fixture,
         zstack_fixture,
@@ -533,8 +578,6 @@ def input_json_fixture(
     """
     Return dict of input data for Mesoscope TIFF splitting CLI
     """
-    output_tmp_dir = tmp_path_factory.mktemp('splitter_cli_output')
-    output_tmp_dir = pathlib.Path(output_tmp_dir)
     timeseries_tmp_dir = pathlib.Path(
             tmp_path_factory.mktemp('splitter_timeseries_temps'))
     params = dict()
@@ -542,12 +585,13 @@ def input_json_fixture(
     params['depths_tif'] = depth_fixture['raw']
     params['surface_tif'] = surface_fixture['raw']
     params['timeseries_tif'] = timeseries_fixture['raw']
-    params['storage_directory'] = str(output_tmp_dir.resolve().absolute())
+    params['storage_directory'] = str(
+            storage_directory_fixture.resolve().absolute())
     params['tmp_dir'] = str(timeseries_tmp_dir.resolve().absolute())
     params['platform_json_path'] = str(
             platform_json_fixture.resolve().absolute())
     params['data_upload_dir'] = str(
-            splitter_tmp_dir_fixture.resolve().absolute())
+            upload_directory_fixture.resolve().absolute())
 
     plane_groups = []
     for z_pair in z_to_stack_path_fixture:
@@ -559,7 +603,7 @@ def input_json_fixture(
         for zz in z_pair:
             this_experiment = dict()
             exp_id = z_to_exp_id_fixture[z_pair][zz]
-            exp_dir = output_tmp_dir / f'{exp_id}_dir'
+            exp_dir = storage_directory_fixture / f'{exp_id}_dir'
             if not exp_dir.exists():
                 exp_dir.mkdir()
             exp_dir = str(exp_dir.resolve().absolute())
@@ -602,4 +646,3 @@ def input_json_fixture(
                         this_path.unlink()
 
     helper_functions.clean_up_dir(timeseries_tmp_dir)
-    helper_functions.clean_up_dir(output_tmp_dir)

--- a/tests/modules/mesoscope_splitting_cli/conftest.py
+++ b/tests/modules/mesoscope_splitting_cli/conftest.py
@@ -501,7 +501,7 @@ def platform_json_fixture(
 
     if request.param:
         str_path = full_field_2p_tiff_fixture['raw']
-        json_data = {'fullfield_2p_image': str_path}
+        json_data = {'fullfield_2p_image': pathlib.Path(str_path).name}
     else:
         json_data = {'nonsense': 1}
 

--- a/tests/modules/mesoscope_splitting_cli/conftest.py
+++ b/tests/modules/mesoscope_splitting_cli/conftest.py
@@ -489,13 +489,22 @@ def full_field_2p_tiff_fixture(
 @pytest.fixture
 def platform_json_fixture(
         splitter_tmp_dir_fixture,
-        full_field_2p_tiff_fixture):
+        full_field_2p_tiff_fixture,
+        request):
     """
     Write out a platform.json file; return the path to it
+
+    If request.param is True, include the fullfield_2p_image path
+    in the input json. If not, do not.
     """
     platform_path = splitter_tmp_dir_fixture / 'platform.json'
-    str_path = full_field_2p_tiff_fixture['raw']
-    json_data = {'fullfield_2p_image': str_path}
+
+    if request.param:
+        str_path = full_field_2p_tiff_fixture['raw']
+        json_data = {'fullfield_2p_image': str_path}
+    else:
+        json_data = {'nonsense': 1}
+
     with open(platform_path, 'w') as out_file:
         out_file.write(json.dumps(json_data))
 

--- a/tests/modules/mesoscope_splitting_cli/conftest.py
+++ b/tests/modules/mesoscope_splitting_cli/conftest.py
@@ -292,7 +292,7 @@ def zstack_fixture(zstack_metadata_fixture,
                     zz = np.round(zz, decimals=float_resolution_fixture)
                 tiff_data.append(raw_data[zz][i_page, :, :])
 
-        tifffile.imsave(tmp_dir / tiff_path, tiff_data)
+        tifffile.imwrite(tmp_dir / tiff_path, tiff_data)
 
     yield exp_id_to_expected
 
@@ -346,10 +346,10 @@ def surface_fixture(upload_directory_fixture,
         for ii in range(n_rois):
             tiff_data.append(data_list[ii][i_page, :, :])
 
-    tifffile.imsave(raw_tiff_path, tiff_data)
+    tifffile.imwrite(raw_tiff_path, tiff_data)
     for expected_path, expected_img in zip(expected_path_list,
                                            expected_img_list):
-        tifffile.imsave(expected_path, expected_img)
+        tifffile.imwrite(expected_path, expected_img)
 
     result = dict()
     result['raw'] = raw_tiff_path
@@ -396,7 +396,7 @@ def timeseries_fixture(upload_directory_fixture,
             for zz in z_pair:
                 tiff_data.append(z_to_data[z_pair][zz][i_page, :, :])
     raw_path = mkstemp_clean(dir=tmp_dir, suffix='_timeseries.tiff')
-    tifffile.imsave(raw_path, tiff_data)
+    tifffile.imwrite(raw_path, tiff_data)
     result = dict()
     result['raw'] = raw_path
     for z_pair in z_list:
@@ -443,7 +443,7 @@ def depth_fixture(upload_directory_fixture,
             for zz in z_pair:
                 tiff_data.append(z_to_data[z_pair][zz][i_page, :, :])
     raw_path = mkstemp_clean(dir=tmp_dir, suffix='_depth.tiff')
-    tifffile.imsave(raw_path, tiff_data)
+    tifffile.imwrite(raw_path, tiff_data)
     result = dict()
     result['raw'] = raw_path
     for z_pair in z_list:
@@ -453,7 +453,7 @@ def depth_fixture(upload_directory_fixture,
             expected_path = tmp_dir / f'expected_{exp_id}_depth.tiff'
             expected_data = np.mean(z_to_data[z_pair][zz], axis=0)
             expected_data = normalize_array(array=expected_data)
-            tifffile.imsave(expected_path, expected_data)
+            tifffile.imwrite(expected_path, expected_data)
             str_path = str(expected_path.resolve().absolute())
             result[f'expected_{exp_id}'] = str_path
     yield result

--- a/tests/modules/mesoscope_splitting_cli/test_cli_utils.py
+++ b/tests/modules/mesoscope_splitting_cli/test_cli_utils.py
@@ -1,0 +1,145 @@
+import pytest
+import warnings
+import json
+import pathlib
+
+from ophys_etl.utils.tempfile_util import (
+    mkstemp_clean)
+
+from ophys_etl.modules.mesoscope_splitting.__main__ import (
+    get_full_field_path)
+
+
+class DummyLogger(object):
+
+    def warning(self, msg):
+        warnings.warn(msg)
+
+    def info(self, msg):
+        print(msg)
+
+
+def test_missing_platform_file():
+    """
+    Test that warning is logged when platform_json_path is
+    missing from args
+    """
+    with pytest.warns(UserWarning,
+                      match="platform_json_path not specified"):
+        val = get_full_field_path(runner_args={}, logger=DummyLogger())
+    assert val is None
+
+
+def test_missing_ff_key():
+    """
+    Test that warning is logged when fullfield_2p_image is missing
+    from platform_json
+    """
+    json_path = mkstemp_clean(suffix='.json')
+    with open(json_path, 'w') as out_file:
+        out_file.write(json.dumps({'nonsense': 2}))
+    these_args = {'platform_json_path': str(json_path)}
+    with pytest.warns(UserWarning,
+                      match="fullfield_2p_image not present"):
+        val = get_full_field_path(
+                runner_args=these_args,
+                logger=DummyLogger())
+    assert val is None
+    json_path = pathlib.Path(json_path)
+    json_path.unlink()
+
+
+@pytest.mark.parametrize("upload", (True, False, None))
+def test_missing_file(upload):
+    """
+    Test that warning is logged when fullfield_2p_image is not
+    actually a file
+
+    if upload is False, do not list an upload directory
+
+    if upload is None, set upload directory to None
+    """
+    json_path = mkstemp_clean(suffix='.json')
+    with open(json_path, 'w') as out_file:
+        out_file.write(
+            json.dumps({'fullfield_2p_image': 'silly.txt'}))
+
+    these_args = {'storage_directory': 'nonsense',
+                  'data_upload_dir': 'more_nonsense',
+                  'platform_json_path': json_path}
+
+    if upload is None:
+        these_args['data_upload_dir'] = None
+    elif not upload:
+        these_args.pop('data_upload_dir')
+
+    with pytest.warns(UserWarning,
+                      match="full field image file does not exist"):
+        val = get_full_field_path(
+                runner_args=these_args,
+                logger=DummyLogger())
+
+    assert val is None
+    json_path = pathlib.Path(json_path)
+    json_path.unlink()
+
+
+@pytest.mark.parametrize(
+        "where_tiff, specify_upload",
+        [("storage", True),
+         ("storage", False),
+         ("storage", None),
+         ("upload", True)])
+def test_file_exists(
+        tmp_path_factory,
+        where_tiff,
+        specify_upload,
+        helper_functions):
+    """
+    Test that the correct file path is returned when
+    fullfield_2p_image exists and is well specified
+
+    where_tiff controls which directory (storage or data_upload)
+    contains the fullfield_2p_image
+
+    specify_upload controls whether or not data_upload_dir is actually
+    in runner_args
+    """
+    storage_dir = tmp_path_factory.mktemp('storage_')
+    upload_dir = tmp_path_factory.mktemp('upload_')
+
+    if where_tiff == 'storage':
+        ff_path = mkstemp_clean(dir=storage_dir, suffix='.tiff')
+    elif where_tiff == 'upload':
+        ff_path = mkstemp_clean(dir=upload_dir, suffix='.tiff')
+
+    with open(ff_path, 'w') as out_file:
+        out_file.write('ta dah!')
+
+    platform_json_path = mkstemp_clean(
+            dir=upload_dir,
+            suffix='.json')
+
+    with open(platform_json_path, 'w') as out_file:
+        out_file.write(
+            json.dumps(
+                {'fullfield_2p_image': pathlib.Path(ff_path).name}))
+
+    these_args = {'storage_directory': str(storage_dir),
+                  'data_upload_dir': str(upload_dir),
+                  'platform_json_path': platform_json_path}
+
+    if specify_upload is None:
+        these_args['data_upload_dir'] = None
+    elif not specify_upload:
+        these_args.pop('data_upload_dir')
+
+    val = get_full_field_path(
+            runner_args=these_args,
+            logger=DummyLogger())
+
+    assert val is not None
+    assert str(val.resolve().absolute()) == ff_path
+
+    helper_functions.clean_up_dir(storage_dir)
+    helper_functions.clean_up_dir(upload_dir)

--- a/tests/modules/mesoscope_splitting_cli/test_mesoscope_splitter.py
+++ b/tests/modules/mesoscope_splitting_cli/test_mesoscope_splitter.py
@@ -10,6 +10,7 @@
 
 import pytest
 import pathlib
+import json
 import copy
 from itertools import product
 from utils import run_mesoscope_cli_test
@@ -185,13 +186,15 @@ def expected_count(flavor):
 
 
 @pytest.mark.parametrize(
-        'use_platform_json, use_data_upload_dir, flavor',
+        'use_platform_json, use_data_upload_dir, '
+        'platform_json_fixture, flavor',
         product((True, False, None),
                 (True, False, None),
+                (True, False),
                 ('1x6', '4x2', '4x2_floats',
                  '2x4_repeats', '2x4',
                  '4x2_repeats')),
-        indirect=['flavor'])
+        indirect=['flavor', 'platform_json_fixture'])
 def test_splitter_cli(input_json_fixture,
                       tmp_path_factory,
                       zstack_metadata_fixture,
@@ -216,6 +219,10 @@ def test_splitter_cli(input_json_fixture,
     elif not use_platform_json:
         input_json_data.pop('platform_json_path')
         expect_full_field = False
+    else:
+        data = json.load(open(input_json_data['platform_json_path'], 'rb'))
+        if 'fullfield_2p_image' not in data:
+            expect_full_field = False
 
     if use_data_upload_dir is None:
         input_json_data['data_upload_dir'] = None


### PR DESCRIPTION
This PR should finally get us to resolve #535 by updating the mesoscope TIFF splitter to look for the fullfield 2p image both in the data upload directory and in the session's storage directory (where the file can end up due to the mesoscope uploading pipeline)