### PR TITLE
Fix dff calculation when passed a trace with all 'nan' values

### DIFF
--- a/src/ophys_etl/modules/dff/__main__.py
+++ b/src/ophys_etl/modules/dff/__main__.py
@@ -55,6 +55,9 @@ def compute_dff_trace(corrected_fluorescence_trace: np.ndarray,
         filter) was less than or equal to the estimated noise of the
         `corrected_fluorescence_trace`.
     """
+    valid_trace = corrected_fluorescence_trace[~np.isnan(corrected_fluorescence_trace)]
+    if valid_trace.shape[0] == 0:
+        return corrected_fluorescence_trace, float('nan'), 0
     _check_kernel(long_filter_length, corrected_fluorescence_trace.shape[0])
     _check_kernel(short_filter_length, corrected_fluorescence_trace.shape[0])
     sigma_f = noise_std(corrected_fluorescence_trace, short_filter_length)

--- a/src/ophys_etl/modules/dff/__main__.py
+++ b/src/ophys_etl/modules/dff/__main__.py
@@ -55,8 +55,8 @@ def compute_dff_trace(corrected_fluorescence_trace: np.ndarray,
         filter) was less than or equal to the estimated noise of the
         `corrected_fluorescence_trace`.
     """
-    valid_trace = corrected_fluorescence_trace[~np.isnan(corrected_fluorescence_trace)]
-    if valid_trace.shape[0] == 0:
+    invalid = np.isnan(corrected_fluorescence_trace).all()
+    if invalid:
         return corrected_fluorescence_trace, float('nan'), 0
     _check_kernel(long_filter_length, corrected_fluorescence_trace.shape[0])
     _check_kernel(short_filter_length, corrected_fluorescence_trace.shape[0])

--- a/tests/modules/dff/test_dff.py
+++ b/tests/modules/dff/test_dff.py
@@ -72,3 +72,9 @@ def test_dff_trace(monkeypatch):
     with pytest.raises(ValueError):
         dff_main.compute_dff_trace(
             f_trace, long_filter_length=7, short_filter_length=1)
+
+    f_trace = np.array([np.nan]*10)
+    dff, sigma, small_baseline = dff_main.compute_dff_trace(f_trace, 1, 1)
+    assert 0 == small_baseline
+    assert np.isnan(sigma)
+    np.testing.assert_array_equal(f_trace, dff)

--- a/tests/utils/test_traces.py
+++ b/tests/utils/test_traces.py
@@ -95,15 +95,15 @@ def test_extract_traces(frames, rois, normalize_by_roi_size, expected):
         5,
         median_filter(np.arange(100), 5, mode='reflect'),
     ),
-    # If block of nan values is as large filter size, fill in with previous
-    # value
+    # If block of nan values is as large filter size, fill in with
+    # interpolated value
     (
         np.array([1, 2, 3, np.nan, np.nan, np.nan, 3, 2, 1]),
         3,
         np.array([1, 2, 2.5, 3, 3, 3, 2.5, 2, 1]),
     ),
-    # If block of nan values is as large filter size, fill in with previous
-    # value
+    # If block of nan values is as large filter size, fill in
+    # interpolated value
     (
         np.array([np.nan, np.nan, np.nan, 5, 4, 3, 2, 1]),
         3,


### PR DESCRIPTION
Some corrected_fluorescence traces are all invalidated traces that are all nan values.

If this is passed into `compute_dff_trace`, skip the dff computation and return the nan trace.
