### PR TITLE
Add neuropil masks output to trace_extraction module

### DIFF
--- a/src/ophys_etl/modules/trace_extraction/schemas.py
+++ b/src/ophys_etl/modules/trace_extraction/schemas.py
@@ -56,6 +56,9 @@ class TraceExtractionOutputSchema(DefaultSchema):
     roi_trace_file = H5FileExists(
         required=True,
         description="path to output h5 file containing roi traces")
+    neuropil_mask_file = H5FileExists(
+        required=True,
+        description="path to output h5 file containing neuropil masks")
     exclusion_labels = Nested(
         ExclusionLabel,
         many=True,

--- a/src/ophys_etl/modules/trace_extraction/schemas.py
+++ b/src/ophys_etl/modules/trace_extraction/schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema
 from argschema.schemas import DefaultSchema
 from argschema.fields import (LogLevel, String, Nested, Float,
-                              OutputDir, InputFile)
+                              OutputDir, InputFile, OutputFile)
 
 from ophys_etl.schemas.fields import H5InputFile
 from ophys_etl.schemas import ExtractROISchema
@@ -56,7 +56,7 @@ class TraceExtractionOutputSchema(DefaultSchema):
     roi_trace_file = H5FileExists(
         required=True,
         description="path to output h5 file containing roi traces")
-    neuropil_mask_file = H5FileExists(
+    neuropil_mask_file = OutputFile(
         required=True,
         description="path to output h5 file containing neuropil masks")
     exclusion_labels = Nested(

--- a/src/ophys_etl/modules/trace_extraction/utils.py
+++ b/src/ophys_etl/modules/trace_extraction/utils.py
@@ -138,22 +138,26 @@ def calculate_roi_and_neuropil_traces(
     return roi_traces, neuropil_traces, neuropil_masks, exclusions
 
 
-def write_trace_file(data, names, path):
+def write_trace_file(data: np.ndarray, names: List[str], path: str):
     logging.debug("Writing {}".format(path))
 
     utf_dtype = h5py.special_dtype(vlen=str)
-    with h5py.File(path, 'w') as fil:
+    with h5py.File(path, "w") as fil:
         fil["data"] = data
-        fil.create_dataset("roi_names",
-                           data=np.array(names).astype(np.string_),
-                           dtype=utf_dtype)
+        fil.create_dataset(
+            "roi_names",
+            data=np.array(names).astype(np.string_),
+            dtype=utf_dtype,
+        )
 
 
-def write_mask_file(mask_objs_list, names, path):
+def write_mask_file(
+    mask_objs_list: List[NeuropilMask], names: List[str], path: str
+):
     logging.debug("Writing {}".format(path))
     names = np.array(names).astype(np.string_)
-    with h5py.File(path, 'w') as fil:
-        group = fil.create_group('masks')
+    with h5py.File(path, "w") as fil:
+        group = fil.create_group("masks")
         for name, mask_obj in zip(names, mask_objs_list):
             group.create_dataset(name, data=mask_obj.mask)
 

--- a/src/ophys_etl/modules/trace_extraction/utils.py
+++ b/src/ophys_etl/modules/trace_extraction/utils.py
@@ -135,7 +135,7 @@ def calculate_roi_and_neuropil_traces(
     roi_traces = traces[:num_rois]
     neuropil_traces = traces[num_rois:]
 
-    return roi_traces, neuropil_traces, exclusions
+    return roi_traces, neuropil_traces, neuropil_masks, exclusions
 
 
 def write_trace_file(data, names, path):
@@ -197,7 +197,7 @@ def extract_traces(motion_corrected_stack: Union[str, Path],
     roi_names = [roi.label for roi in roi_mask_list]
 
     # extract traces
-    roi_traces, neuropil_traces, exclusions = \
+    roi_traces, neuropil_traces, neuropil_masks, exclusions = \
         calculate_roi_and_neuropil_traces(
             motion_corrected_stack, roi_mask_list, border)
 
@@ -207,8 +207,11 @@ def extract_traces(motion_corrected_stack: Union[str, Path],
     np_file = Path(storage_directory) / "neuropil_traces.h5"
     write_trace_file(neuropil_traces, roi_names, np_file)
 
+    np_mask_file = Path(storage_directory) / "neuropil_masks.h5"
+    write_trace_file(neuropil_masks, roi_names, np_mask_file)
     return {
         'neuropil_trace_file': str(np_file),
         'roi_trace_file': str(roi_file),
+        'neuropil_mask_file': str(np_mask_file),
         'exclusion_labels': exclusions
     }

--- a/src/ophys_etl/modules/trace_extraction/utils.py
+++ b/src/ophys_etl/modules/trace_extraction/utils.py
@@ -149,6 +149,15 @@ def write_trace_file(data, names, path):
                            dtype=utf_dtype)
 
 
+def write_mask_file(mask_objs_list, names, path):
+    logging.debug("Writing {}".format(path))
+    names = np.array(names).astype(np.string_)
+    with h5py.File(path, 'w') as fil:
+        group = fil.create_group('masks')
+        for name, mask_obj in zip(names, mask_objs_list):
+            group.create_dataset(name, data=mask_obj.mask)
+
+
 def extract_traces(motion_corrected_stack: Union[str, Path],
                    motion_border: Dict,
                    storage_directory: Union[str, Path],
@@ -208,7 +217,8 @@ def extract_traces(motion_corrected_stack: Union[str, Path],
     write_trace_file(neuropil_traces, roi_names, np_file)
 
     np_mask_file = Path(storage_directory) / "neuropil_masks.h5"
-    write_trace_file(neuropil_masks, roi_names, np_mask_file)
+    write_mask_file(neuropil_masks, roi_names, np_mask_file)
+
     return {
         'neuropil_trace_file': str(np_file),
         'roi_trace_file': str(roi_file),

--- a/tests/modules/trace_extraction/conftest.py
+++ b/tests/modules/trace_extraction/conftest.py
@@ -8,9 +8,7 @@ def roi_list_of_dicts(image_dims, motion_border):
     base_pixels = np.ones((10, 10), dtype=bool).tolist()
     rois = []
     for ii in range(10):
-        rois.append({
-            "x": ii * 10,
-            "y": ii * 10,
-            "id": ii,
-            "mask": base_pixels})
+        rois.append(
+            {"x": ii * 10, "y": ii * 10, "id": ii, "mask": base_pixels}
+        )
     return rois

--- a/tests/modules/trace_extraction/test_trace_extraction.py
+++ b/tests/modules/trace_extraction/test_trace_extraction.py
@@ -42,7 +42,7 @@ def test_TraceExtraction(tmpdir, monkeypatch):
             f.create_dataset("data", data=0)
         np_mask_file = tmpdir / "npmasktraces.h5"
         with h5py.File(np_mask_file, "w") as f:
-            f.create_dataset("data", data=0)
+            f.create_dataset("mask", data=0)
         val = {
                 "neuropil_trace_file": str(npfile),
                 "roi_trace_file": str(tfile),

--- a/tests/modules/trace_extraction/test_trace_extraction.py
+++ b/tests/modules/trace_extraction/test_trace_extraction.py
@@ -1,6 +1,7 @@
 import h5py
+import json
 import numpy as np
-
+from pathlib import Path
 import ophys_etl.modules.trace_extraction.__main__ as temod
 
 
@@ -52,3 +53,10 @@ def test_TraceExtraction(tmpdir, monkeypatch):
     monkeypatch.setattr(temod, "extract_traces", mock_extract_traces)
     te = temod.TraceExtraction(input_data=args, args=[])
     te.run()
+
+    assert Path(outj).is_file()
+    with open(outj, "r") as f:
+        j = json.load(f)
+    assert Path(j['roi_trace_file']).is_file()
+    assert Path(j['neuropil_trace_file']).is_file()
+    assert Path(j['neuropil_mask_file']).is_file()

--- a/tests/modules/trace_extraction/test_trace_extraction.py
+++ b/tests/modules/trace_extraction/test_trace_extraction.py
@@ -1,7 +1,5 @@
 import h5py
-import json
 import numpy as np
-from pathlib import Path
 
 import ophys_etl.modules.trace_extraction.__main__ as temod
 
@@ -9,29 +7,29 @@ import ophys_etl.modules.trace_extraction.__main__ as temod
 def test_TraceExtraction(tmpdir, monkeypatch):
     motion_stack = tmpdir / "input.h5"
     with h5py.File(motion_stack, "w") as f:
-        f.create_dataset("data", data=np.zeros((10, 10, 10), dtype='uint8'))
+        f.create_dataset("data", data=np.zeros((10, 10, 10), dtype="uint8"))
     log0 = tmpdir / "log.txt"
     with open(log0, "w") as f:
         f.write("stuff")
     outj = tmpdir / "output.json"
     args = {
-            "motion_border": {
-                "x0": 0,
-                "x1": 0,
-                "y0": 0,
-                "y1": 0},
-            "storage_directory": str(tmpdir),
-            "motion_corrected_stack": str(motion_stack),
-            "rois": [{
+        "motion_border": {"x0": 0, "x1": 0, "y0": 0, "y1": 0},
+        "storage_directory": str(tmpdir),
+        "motion_corrected_stack": str(motion_stack),
+        "rois": [
+            {
                 "mask": [[True]],
                 "x": 0,
                 "y": 0,
                 "width": 1,
                 "height": 1,
                 "valid": True,
-                "id": 123456}],
-            "log_0": str(log0),
-            "output_json": str(outj)}
+                "id": 123456,
+            }
+        ],
+        "log_0": str(log0),
+        "output_json": str(outj),
+    }
 
     def mock_extract_traces(a, b, c, d):
         tfile = tmpdir / "traces.h5"
@@ -44,11 +42,13 @@ def test_TraceExtraction(tmpdir, monkeypatch):
         with open(np_mask_file, "w") as f:
             f.write("")
         val = {
-                "neuropil_trace_file": str(npfile),
-                "roi_trace_file": str(tfile),
-                "neuropil_mask_file": str(np_mask_file),
-                "exclusion_labels": []}
+            "neuropil_trace_file": str(npfile),
+            "roi_trace_file": str(tfile),
+            "neuropil_mask_file": str(np_mask_file),
+            "exclusion_labels": [],
+        }
         return val
+
     monkeypatch.setattr(temod, "extract_traces", mock_extract_traces)
     te = temod.TraceExtraction(input_data=args, args=[])
     te.run()

--- a/tests/modules/trace_extraction/test_trace_extraction.py
+++ b/tests/modules/trace_extraction/test_trace_extraction.py
@@ -40,9 +40,13 @@ def test_TraceExtraction(tmpdir, monkeypatch):
         npfile = tmpdir / "nptraces.h5"
         with h5py.File(npfile, "w") as f:
             f.create_dataset("data", data=0)
+        np_mask_file = tmpdir / "npmasktraces.h5"
+        with h5py.File(np_mask_file, "w") as f:
+            f.create_dataset("data", data=0)
         val = {
                 "neuropil_trace_file": str(npfile),
                 "roi_trace_file": str(tfile),
+                "neuropil_mask_file": str(np_mask_file),
                 "exclusion_labels": []}
         return val
     monkeypatch.setattr(temod, "extract_traces", mock_extract_traces)
@@ -54,3 +58,4 @@ def test_TraceExtraction(tmpdir, monkeypatch):
         j = json.load(f)
     assert Path(j['roi_trace_file']).is_file()
     assert Path(j['neuropil_trace_file']).is_file()
+    assert Path(j['neuropil_mask_file']).is_file()

--- a/tests/modules/trace_extraction/test_trace_extraction.py
+++ b/tests/modules/trace_extraction/test_trace_extraction.py
@@ -40,9 +40,9 @@ def test_TraceExtraction(tmpdir, monkeypatch):
         npfile = tmpdir / "nptraces.h5"
         with h5py.File(npfile, "w") as f:
             f.create_dataset("data", data=0)
-        np_mask_file = tmpdir / "npmasktraces.h5"
-        with h5py.File(np_mask_file, "w") as f:
-            f.create_dataset("mask", data=0)
+        np_mask_file = tmpdir / "npmask.json"
+        with open(np_mask_file, "w") as f:
+            f.write("")
         val = {
                 "neuropil_trace_file": str(npfile),
                 "roi_trace_file": str(tfile),
@@ -52,10 +52,3 @@ def test_TraceExtraction(tmpdir, monkeypatch):
     monkeypatch.setattr(temod, "extract_traces", mock_extract_traces)
     te = temod.TraceExtraction(input_data=args, args=[])
     te.run()
-
-    assert Path(outj).is_file()
-    with open(outj, "r") as f:
-        j = json.load(f)
-    assert Path(j['roi_trace_file']).is_file()
-    assert Path(j['neuropil_trace_file']).is_file()
-    assert Path(j['neuropil_mask_file']).is_file()

--- a/tests/modules/trace_extraction/test_trace_extraction_utils.py
+++ b/tests/modules/trace_extraction/test_trace_extraction_utils.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import h5py
 import numpy as np
@@ -99,14 +100,15 @@ def test_extract_traces(h5video, roi_list_of_dicts,
     with h5py.File(output["roi_trace_file"], "r") as f:
         r_names = f["roi_names"][()]
         r_traces = f["data"][()]
-    with h5py.File(output["neuropil_mask_file"], "r") as f:
+    with open(output["neuropil_mask_file"], "r") as f:
+        neuropil_dict = json.load(f)
         nm_names = np.array(
-            list(f['masks'].keys()), dtype=np.string_).astype(object)
-        nmasks = [f['masks'][name][()] for name in nm_names]
+            [bytes(neuropil['id'], 'utf-8') for neuropil in neuropil_dict['neuropils']]).astype(object)
+        masks = [neuropil['mask'] for neuropil in neuropil_dict['neuropils']]
 
     np.testing.assert_array_equal(n_names, r_names)
     np.testing.assert_array_equal(nm_names, n_names)
     assert n_traces.shape == r_traces.shape
-    for mask in nmasks:
-        assert isinstance(mask, np.ndarray)
-        assert len(mask.shape) == 2
+    for mask in masks:
+        assert isinstance(mask, list)
+        assert isinstance(mask[0], list)

--- a/tests/modules/trace_extraction/test_trace_extraction_utils.py
+++ b/tests/modules/trace_extraction/test_trace_extraction_utils.py
@@ -6,16 +6,17 @@ import pandas as pd
 from pathlib import Path
 
 from ophys_etl.modules.trace_extraction.utils import (
-        calculate_traces,
-        calculate_roi_and_neuropil_traces,
-        extract_traces)
+    calculate_traces,
+    calculate_roi_and_neuropil_traces,
+    extract_traces,
+)
 
 
 # image_dims fixture from tests/conftest.py
 @pytest.fixture
 def video(image_dims):
     num_frames = 20
-    data = np.ones((num_frames, image_dims['height'], image_dims['width']))
+    data = np.ones((num_frames, image_dims["height"], image_dims["width"]))
     data[:, 50:, 50:] = 2
     return data
 
@@ -32,61 +33,74 @@ def h5video(video, tmpdir):
 def test_calculate_traces(video, roi_mask_list):
     roi_traces, exclusions = calculate_traces(video, roi_mask_list)
 
-    expected_exclusions = pd.DataFrame({
-        'roi_id': ['0', '9'],
-        'exclusion_label_name': ['motion_border', 'motion_border']
-    })
+    expected_exclusions = pd.DataFrame(
+        {
+            "roi_id": ["0", "9"],
+            "exclusion_label_name": ["motion_border", "motion_border"],
+        }
+    )
 
     assert np.all(np.isnan(roi_traces[0, :]))
     assert np.all(roi_traces[4, :] == 1)
     assert np.all(roi_traces[6, :] == 2)
     assert np.all(np.isnan(roi_traces[9, :]))
 
-    pd.testing.assert_frame_equal(expected_exclusions,
-                                  pd.DataFrame(exclusions),
-                                  check_like=True)
+    pd.testing.assert_frame_equal(
+        expected_exclusions, pd.DataFrame(exclusions), check_like=True
+    )
 
 
 # roi_mask_list, motion_border fixture from tests/conftest.py
 def test_calculate_roi_and_neuropil_traces(
-        h5video, roi_mask_list, motion_border):
-    roi_traces, neuropil_traces, neuropil_masks, exclusions = \
-            calculate_roi_and_neuropil_traces(h5video,
-                                              roi_mask_list,
-                                              motion_border)
+    h5video, roi_mask_list, motion_border
+):
+    (
+        roi_traces,
+        neuropil_traces,
+        neuropil_masks,
+        exclusions,
+    ) = calculate_roi_and_neuropil_traces(
+        h5video, roi_mask_list, motion_border
+    )
 
     assert neuropil_traces.shape == roi_traces.shape
     assert np.all(np.isnan(roi_traces[0, :]))
     assert np.all(roi_traces[4, :] == 1)
     assert np.all(roi_traces[6, :] == 2)
     assert np.all(np.isnan(roi_traces[9, :]))
-    expected_exclusions = pd.DataFrame({
-        'roi_id': ['0', '9'],
-        'exclusion_label_name': ['motion_border', 'motion_border']
-    })
-    pd.testing.assert_frame_equal(expected_exclusions,
-                                  pd.DataFrame(exclusions),
-                                  check_like=True)
+    expected_exclusions = pd.DataFrame(
+        {
+            "roi_id": ["0", "9"],
+            "exclusion_label_name": ["motion_border", "motion_border"],
+        }
+    )
+    pd.testing.assert_frame_equal(
+        expected_exclusions, pd.DataFrame(exclusions), check_like=True
+    )
 
 
 # motion_border_dict fixture from tests/conftest.py
 # roi_list_of_dicts from tests/modules/trace_extraction/conftest.py
-def test_extract_traces(h5video, roi_list_of_dicts,
-                        motion_border_dict, tmpdir):
+def test_extract_traces(
+    h5video, roi_list_of_dicts, motion_border_dict, tmpdir
+):
     sdir = Path(tmpdir)
-    output = extract_traces(h5video,
-                            motion_border_dict,
-                            sdir,
-                            roi_list_of_dicts)
+    output = extract_traces(
+        h5video, motion_border_dict, sdir, roi_list_of_dicts
+    )
     assert "exclusion_labels" in output
     assert isinstance(output["exclusion_labels"], list)
-    expected_exclusions = pd.DataFrame({
-        'roi_id': ['0', '9'],
-        'exclusion_label_name': ['motion_border', 'motion_border']
-    })
-    pd.testing.assert_frame_equal(expected_exclusions,
-                                  pd.DataFrame(output["exclusion_labels"]),
-                                  check_like=True)
+    expected_exclusions = pd.DataFrame(
+        {
+            "roi_id": ["0", "9"],
+            "exclusion_label_name": ["motion_border", "motion_border"],
+        }
+    )
+    pd.testing.assert_frame_equal(
+        expected_exclusions,
+        pd.DataFrame(output["exclusion_labels"]),
+        check_like=True,
+    )
 
     for k in ["neuropil_trace_file", "roi_trace_file", "neuropil_mask_file"]:
         assert k in output
@@ -103,8 +117,12 @@ def test_extract_traces(h5video, roi_list_of_dicts,
     with open(output["neuropil_mask_file"], "r") as f:
         neuropil_dict = json.load(f)
         nm_names = np.array(
-            [bytes(neuropil['id'], 'utf-8') for neuropil in neuropil_dict['neuropils']]).astype(object)
-        masks = [neuropil['mask'] for neuropil in neuropil_dict['neuropils']]
+            [
+                bytes(neuropil["id"], "utf-8")
+                for neuropil in neuropil_dict["neuropils"]
+            ]
+        ).astype(object)
+        masks = [neuropil["mask"] for neuropil in neuropil_dict["neuropils"]]
 
     np.testing.assert_array_equal(n_names, r_names)
     np.testing.assert_array_equal(nm_names, n_names)


### PR DESCRIPTION
* Add neuropil masks output as an h5 file. 
* Modify existing tests for the additional output.

https://github.com/AllenInstitute/AllenSDK/issues/2565
Neuropil masks are requested to be stored in the cell_specimens table so the users can access them for provenance/diagnosis of issues.  This is the current work to generate the output file which further work will be needed to modify the AllenSDK to read the file and load into the cell_specimens table. 

Thinking about it more, it might make more sense to modify the AllenSDK to create the neuropil_mask from the roi_mask and store it in the cell_specimens table. This strategy would allow users to access these masks for all existing datasets. 
The logic for creating the mask is fixed with no user-modifiable parameters.

https://github.com/AllenInstitute/ophys_etl_pipelines/blob/3fd19523c1c4ca4de0819d86946901a85b3ab511/src/ophys_etl/utils/roi_masks.py#L330

