### PR TITLE
psb-66 psb-67 Inputs outputs in sync

### DIFF
--- a/src/ophys_etl/workflows/db/db_utils.py
+++ b/src/ophys_etl/workflows/db/db_utils.py
@@ -31,6 +31,7 @@ def save_job_run_to_db(
         module_outputs: List[OutputFile],
         sqlalchemy_session: Session,
         storage_directory: Union[Path, str],
+        log_path: Union[Path, str],
         ophys_experiment_id: Optional[str] = None,
         validate_files_exist: bool = True,
         additional_steps: Optional[Callable] = None,
@@ -61,6 +62,8 @@ def save_job_run_to_db(
         Session to use for inserting into DB
     storage_directory
         Where `ophys_experiment_id` is saving data to
+    log_path
+        Path where logs for this run are saved
     additional_steps
         A function which inserts additional data into the database
         Needs to have signature:
@@ -89,6 +92,7 @@ def save_job_run_to_db(
     workflow_step_run = WorkflowStepRun(
         workflow_step_id=workflow_step.id,
         storage_directory=str(storage_directory),
+        log_path=str(log_path),
         ophys_experiment_id=ophys_experiment_id,
         start=start,
         end=end

--- a/src/ophys_etl/workflows/db/schemas.py
+++ b/src/ophys_etl/workflows/db/schemas.py
@@ -50,6 +50,7 @@ class WorkflowStepRun(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     ophys_experiment_id: Optional[str] = Field(index=True)
     workflow_step_id: int = Field(foreign_key='workflow_step.id')
+    log_path: str
     storage_directory: str
     start: datetime.datetime
     end: datetime.datetime

--- a/src/ophys_etl/workflows/on_prem/workflow_utils.py
+++ b/src/ophys_etl/workflows/on_prem/workflow_utils.py
@@ -115,6 +115,7 @@ def submit_job_and_wait_to_finish(
     )(
         job_id=job_submit_res['job_id'],
         storage_directory=job_submit_res['storage_directory'],
+        log_path=job_submit_res['log_path'],
         module_outputs=(
             job_submit_res['module_outputs'])
     )

--- a/src/ophys_etl/workflows/pipeline_module.py
+++ b/src/ophys_etl/workflows/pipeline_module.py
@@ -1,5 +1,6 @@
 """Pipeline module"""
 import abc
+import datetime
 import logging
 import os
 from dataclasses import dataclass
@@ -60,6 +61,7 @@ class PipelineModule:
         self._ophys_experiment = ophys_experiment
         self._docker_tag = docker_tag if docker_tag is not None else \
             app_config.pipeline_steps.default_docker_tag
+        self._now = datetime.datetime.now()
 
         os.makedirs(self.output_path, exist_ok=True)
 
@@ -132,9 +134,7 @@ class PipelineModule:
         else:
             path = self._ophys_experiment.output_dir / self.queue_name.value
 
-        # TODO add timestamp to path
-        # path = path / datetime.datetime.now().
-        # strftime('%Y-%m-%d_%H:%m:%S-%f')
+        path = path / self._now.strftime('%Y-%m-%d_%H-%m-%S-%f')
 
         return path
 

--- a/src/ophys_etl/workflows/tasks.py
+++ b/src/ophys_etl/workflows/tasks.py
@@ -45,6 +45,8 @@ def save_job_run_to_db(
                 Maps well known file type name to path
             - storage_directory
                 Root dir where all files for this job run are written
+            - log_path
+                Path where logs for this run are saved
             - start
                 When did this step of the workflow run start. Uses encoding
                 %Y-%m-%d %H:%M:%S
@@ -91,6 +93,7 @@ def save_job_run_to_db(
             ophys_experiment_id=ophys_experiment_id,
             sqlalchemy_session=session,
             storage_directory=job_finish_res['storage_directory'],
+            log_path=job_finish_res['log_path'],
             validate_files_exist=not app_config.is_debug,
             additional_steps=additional_steps,
             additional_steps_kwargs=additional_steps_kwargs

--- a/tests/workflows/db/test_db_utils.py
+++ b/tests/workflows/db/test_db_utils.py
@@ -131,6 +131,7 @@ class TestDBUtils:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 workflow_name=WorkflowName.OPHYS_PROCESSING
             )
 

--- a/tests/workflows/pipeline_modules/roi_classification/test_inference.py
+++ b/tests/workflows/pipeline_modules/roi_classification/test_inference.py
@@ -110,6 +110,7 @@ class TestInference:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 additional_steps=InferenceModule.save_predictions_to_db,
                 additional_steps_kwargs={
                     # only 1 inserted, so we can assume id is 1
@@ -138,6 +139,7 @@ class TestInference:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 additional_steps=SegmentationModule.save_rois_to_db,
                 workflow_name=WorkflowName.OPHYS_PROCESSING
             )
@@ -165,6 +167,7 @@ class TestInference:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 additional_steps=TrainingModule.save_trained_model_to_db,
                 additional_steps_kwargs={
                   'mlflow_parent_run_name': cls._mlflow_parent_run_name

--- a/tests/workflows/pipeline_modules/roi_classification/test_training.py
+++ b/tests/workflows/pipeline_modules/roi_classification/test_training.py
@@ -91,6 +91,7 @@ class TestTraining:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 additional_steps=TrainingModule.save_trained_model_to_db,
                 additional_steps_kwargs={
                   'mlflow_parent_run_name': mlflow_parent_run_name

--- a/tests/workflows/pipeline_modules/test_motion_correction.py
+++ b/tests/workflows/pipeline_modules/test_motion_correction.py
@@ -62,6 +62,7 @@ class TestMotionCorrectionModule:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 additional_steps=MotionCorrectionModule.save_metadata_to_db,
                 workflow_name=WorkflowName.OPHYS_PROCESSING
             )

--- a/tests/workflows/pipeline_modules/test_segmentation.py
+++ b/tests/workflows/pipeline_modules/test_segmentation.py
@@ -63,6 +63,7 @@ class TestSegmentation:
                 ophys_experiment_id='1',
                 sqlalchemy_session=session,
                 storage_directory='/foo',
+                log_path='/foo',
                 additional_steps=SegmentationModule.save_rois_to_db,
                 workflow_name=WorkflowName.OPHYS_PROCESSING
             )

--- a/tests/workflows/test_workflow_step_runs.py
+++ b/tests/workflows/test_workflow_step_runs.py
@@ -65,6 +65,7 @@ class TestWorkflowStepRuns:
                     sqlalchemy_session=session,
                     ophys_experiment_id=ophys_experiment_id,
                     storage_directory='foo',
+                    log_path='foo',
                     workflow_name=workflow_name,
                     workflow_step_name=workflow_step_name
                 )
@@ -101,6 +102,7 @@ class TestWorkflowStepRuns:
                     sqlalchemy_session=session,
                     ophys_experiment_id=ophys_experiment_id,
                     storage_directory='foo',
+                    log_path='foo',
                     workflow_name=workflow_name,
                     workflow_step_name=workflow_step_name
                 )


### PR DESCRIPTION
This PR makes sure that the inputs and outputs are in sync for a successful workflow step run.

- When we run a workflow step (e.g segmentation, motion correction), a unique path with a timestamp is created rather than writing to a single path for that ophys experiment. This means that data is always stored separately for each run.
- For writing logs, we are using the airflow dynamic log path. It is given in the airflow.cfg file as `log_filename_template = dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{%% if ti.map_index >= 0 %%}map_index={{ ti.map_index }}/{%% endif %%}attempt={{ try_number }}.log`. I am keeping this template, but saving the log path to the DB so that for a successful run, we can always look up the logs for that run.