### PR TITLE
Danielsf/make/ff/optional

### DIFF
--- a/src/ophys_etl/modules/mesoscope_splitting/__main__.py
+++ b/src/ophys_etl/modules/mesoscope_splitting/__main__.py
@@ -307,7 +307,6 @@ class TiffSplitterCLI(ArgSchemaParser):
                                    zstack_splitter),
                                   (scanfield_z,
                                    None,
-                                   scanfield_z,
                                    scanfield_z),
                                   (f"{experiment_id}_depth.tif",
                                    f"{experiment_id}_surface.tif",

--- a/src/ophys_etl/test_utils/full_field_tiff_utils.py
+++ b/src/ophys_etl/test_utils/full_field_tiff_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import tifffile
 import pathlib
-import tempfile
+from ophys_etl.utils.tempfile_util import mkstemp_clean
 
 
 def _create_full_field_tiff(
@@ -52,9 +52,9 @@ def _create_full_field_tiff(
     avg_img = data.mean(axis=0)
     tiff_pages = [data[ii, :, :] for ii in range(data.shape[0])]
     tiff_path = pathlib.Path(
-            tempfile.mkstemp(dir=output_dir,
-                             prefix='full_field_',
-                             suffix='.tiff')[1])
+            mkstemp_clean(dir=output_dir,
+                          prefix='full_field_',
+                          suffix='.tiff'))
     tifffile.imwrite(tiff_path, tiff_pages)
     metadata = [{'SI.hStackManager.actualNumVolumes': numVolumes,
                  'SI.hStackManager.actualNumSlices': numSlices}]

--- a/tests/modules/mesoscope_splitting_cli/conftest.py
+++ b/tests/modules/mesoscope_splitting_cli/conftest.py
@@ -484,11 +484,20 @@ def full_field_2p_tiff_fixture(
 
     if request.param is 'upload', but the file in
     upload_directory_fixture
+
+    if request.param is 'corrupt', alter the metadata
+    so that full field tiff generation will fail (so
+    we can test to see if the rest of the TIFF splitting
+    job passed, anyway)
     """
+    corrupt_metadata = False
     if request.param == 'storage':
         output_dir = storage_directory_fixture
     elif request.param == 'upload':
         output_dir = upload_directory_fixture
+    elif request.param == 'corrupt':
+        output_dir = storage_directory_fixture
+        corrupt_metadata = True
     else:
         raise RuntimeError(
             "not sure how to handle request.param "
@@ -511,6 +520,12 @@ def full_field_2p_tiff_fixture(
         output_dir=output_dir,
         nrows=nrows,
         ncols=ncols)
+
+    if corrupt_metadata:
+        metadata[0]['SI.hStackManager.actualNumVolumes'] = 13
+        metadata[0]['is_corrupt'] = True
+    else:
+        metadata[0]['is_corrupt'] = False
 
     roi_metadata = _create_roi_metadata(
             nrois=nrois,

--- a/tests/modules/mesoscope_splitting_cli/test_mesoscope_splitter.py
+++ b/tests/modules/mesoscope_splitting_cli/test_mesoscope_splitter.py
@@ -192,7 +192,7 @@ def expected_count(flavor):
         product((True, False, None),
                 (True, False, None),
                 (True, False),
-                ('upload', 'storage'),
+                ('upload', 'storage', 'corrupt'),
                 ('1x6', '4x2', '4x2_floats',
                  '2x4_repeats', '2x4',
                  '4x2_repeats')),
@@ -231,6 +231,11 @@ def test_splitter_cli(upload_directory_fixture,
                                  'rb'))
         if 'fullfield_2p_image' not in platform_data:
             expect_full_field = False
+
+    # Full field image generation should fail, but the
+    # overarching TIFF splitting job should pass
+    if full_field_2p_tiff_fixture['metadata'][0]['is_corrupt']:
+        expect_full_field = False
 
     # remove upload_data_dir from input_json, if specified
     if use_data_upload_dir is None:


### PR DESCRIPTION
Full field image generation has been stumbling over some edge cases in the data. Our users do not want a failure in this last step of TIFF splitting to fail an entire TIFF splitting job. This PR wraps the full field image generation step in a try/except block such that failure of that step does not fail the whole job. However, the traceback resulting from full field image failure will be written to the log, so that we can double back and debug the failure, should we so choose.