### PR TITLE
add gpt commit summarizer

### DIFF
--- a/.github/workflows/gpt-commit-summarizer.yml
+++ b/.github/workflows/gpt-commit-summarizer.yml
@@ -1,0 +1,16 @@
+name: GPT Commits summarizer
+# Summary: This action will write a comment about every commit in a pull request, as well as generate a summary for every file that was modified and add it to the review page, compile a PR summary from all commit summaries and file diff summaries, and delete outdated code review comments
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: KanHarI/gpt-commit-summarizer@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
This is a github action that uses GPT to summarize commits based on the git diff of each commit. 

This github action requires an OpenAI key, which I used mine. 