### PR TITLE
try using include statement in coveragerc_file to fix codecov report

### DIFF
--- a/.circleci/coveragerc_file
+++ b/.circleci/coveragerc_file
@@ -3,3 +3,4 @@
 [run]
 branch = True
 concurrency = multiprocessing
+source = ophys_etl


### PR DESCRIPTION
This is ready for review (once everything passes). If you click around in the CodeCov report, you will see that there is now data on the files in src/ophys_etl.