### PR TITLE
PSB-118 Decrosstalk sensor + pass exclusion labels to demix

### DIFF
--- a/src/ophys_etl/workflows/on_prem/dags/decrosstalk_trigger.py
+++ b/src/ophys_etl/workflows/on_prem/dags/decrosstalk_trigger.py
@@ -12,7 +12,7 @@ from ophys_etl.workflows.utils.lims_utils import LIMSDB
 from ophys_etl.workflows.db import engine
 from sqlmodel import Session
 
-from ophys_etl.workflows.utils.dag_utils import get_most_recent_run
+from ophys_etl.workflows.utils.dag_utils import get_latest_dag_run
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
 from ophys_etl.workflows.workflow_step_runs import get_runs_completed_since, \
     get_completed_ophys_sessions
@@ -66,7 +66,7 @@ def decrosstalk_trigger():
     """
     @task
     def trigger():
-        last_run_datetime = get_most_recent_run(
+        last_run_datetime = get_latest_dag_run(
             dag_id='decrosstalk_trigger')
         if last_run_datetime is None:
             # this DAG hasn't been successfully run before

--- a/src/ophys_etl/workflows/on_prem/dags/ophys_processing.py
+++ b/src/ophys_etl/workflows/on_prem/dags/ophys_processing.py
@@ -10,7 +10,8 @@ from sqlmodel import Session
 from ophys_etl.workflows.app_config.app_config import app_config
 from ophys_etl.workflows.db import engine
 from ophys_etl.workflows.db.schemas import ROIClassifierEnsemble
-from ophys_etl.workflows.on_prem.workflow_utils import run_workflow_step
+from ophys_etl.workflows.on_prem.workflow_utils import run_workflow_step, \
+    submit_job_and_wait_to_finish
 from ophys_etl.workflows.pipeline_modules import roi_classification
 from ophys_etl.workflows.pipeline_modules.denoising.denoising_finetuning import (  # noqa E501
     DenoisingFinetuningModule,
@@ -30,7 +31,8 @@ from ophys_etl.workflows.pipeline_modules.trace_processing.trace_extraction impo
 from ophys_etl.workflows.pipeline_modules.trace_processing.demix_traces import (  # noqa E501
     DemixTracesModule,
 )
-from ophys_etl.workflows.tasks import wait_for_decrosstalk_to_finish
+from ophys_etl.workflows.tasks import wait_for_decrosstalk_to_finish, \
+    save_job_run_to_db
 from ophys_etl.workflows.well_known_file_types import WellKnownFileTypeEnum
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
 from ophys_etl.workflows.workflow_step_runs import get_latest_workflow_step_run
@@ -248,8 +250,6 @@ def ophys_processing():
 
         @task_group
         def demix_traces(motion_corrected_ophys_movie_file, roi_traces_file):
-            wait_for_decrosstalk_to_finish(timeout=app_config.job_timeout)()
-
             run_workflow_step(
                 slurm_config_filename="demix_traces.yml",
                 module=DemixTracesModule,
@@ -260,6 +260,8 @@ def ophys_processing():
                     "motion_corrected_ophys_movie_file": motion_corrected_ophys_movie_file,  # noqa E501
                     "roi_traces_file": roi_traces_file
                 },
+                pre_submit_sensor=wait_for_decrosstalk_to_finish(
+                    timeout=app_config.job_timeout)
             )
 
         roi_traces_file = trace_extraction(

--- a/src/ophys_etl/workflows/on_prem/dags/ophys_processing.py
+++ b/src/ophys_etl/workflows/on_prem/dags/ophys_processing.py
@@ -10,8 +10,7 @@ from sqlmodel import Session
 from ophys_etl.workflows.app_config.app_config import app_config
 from ophys_etl.workflows.db import engine
 from ophys_etl.workflows.db.schemas import ROIClassifierEnsemble
-from ophys_etl.workflows.on_prem.workflow_utils import run_workflow_step, \
-    submit_job_and_wait_to_finish
+from ophys_etl.workflows.on_prem.workflow_utils import run_workflow_step
 from ophys_etl.workflows.pipeline_modules import roi_classification
 from ophys_etl.workflows.pipeline_modules.denoising.denoising_finetuning import (  # noqa E501
     DenoisingFinetuningModule,
@@ -31,8 +30,7 @@ from ophys_etl.workflows.pipeline_modules.trace_processing.trace_extraction impo
 from ophys_etl.workflows.pipeline_modules.trace_processing.demix_traces import (  # noqa E501
     DemixTracesModule,
 )
-from ophys_etl.workflows.tasks import wait_for_decrosstalk_to_finish, \
-    save_job_run_to_db
+from ophys_etl.workflows.tasks import wait_for_decrosstalk_to_finish
 from ophys_etl.workflows.well_known_file_types import WellKnownFileTypeEnum
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
 from ophys_etl.workflows.workflow_step_runs import get_latest_workflow_step_run

--- a/src/ophys_etl/workflows/on_prem/dags/ophys_processing_trigger.py
+++ b/src/ophys_etl/workflows/on_prem/dags/ophys_processing_trigger.py
@@ -7,7 +7,7 @@ from airflow.models.dag import dag
 from airflow.operators.python import get_current_context
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from ophys_etl.workflows.app_config.app_config import app_config
-from ophys_etl.workflows.utils.dag_utils import get_most_recent_run
+from ophys_etl.workflows.utils.dag_utils import get_latest_dag_run
 
 from ophys_etl.workflows.utils.lims_utils import LIMSDB
 
@@ -66,7 +66,7 @@ def ophys_processing_trigger():
 
     @task
     def trigger():
-        last_run_datetime = get_most_recent_run(
+        last_run_datetime = get_latest_dag_run(
             dag_id='ophys_processing_trigger')
         if last_run_datetime is None:
             # this DAG hasn't been successfully run before

--- a/src/ophys_etl/workflows/ophys_experiment.py
+++ b/src/ophys_etl/workflows/ophys_experiment.py
@@ -14,7 +14,7 @@ from ophys_etl.workflows.db.schemas import (
 )
 from ophys_etl.workflows.utils.lims_utils import LIMSDB
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
-from ophys_etl.workflows.workflow_step_runs import get_latest_run
+from ophys_etl.workflows.workflow_step_runs import get_latest_workflow_step_run
 from ophys_etl.workflows.workflow_steps import WorkflowStepEnum
 
 
@@ -195,7 +195,7 @@ class OphysExperiment:
         """
 
         with Session(engine) as session:
-            workflow_step_run_id = get_latest_run(
+            workflow_step_run_id = get_latest_workflow_step_run(
                 session,
                 WorkflowStepEnum.MOTION_CORRECTION,
                 WorkflowNameEnum.OPHYS_PROCESSING,
@@ -225,7 +225,7 @@ class OphysExperiment:
             A list of OphysROI
         """
         with Session(engine) as session:
-            workflow_step_run_id = get_latest_run(
+            workflow_step_run_id = get_latest_workflow_step_run(
                 session,
                 WorkflowStepEnum.SEGMENTATION,
                 WorkflowNameEnum.OPHYS_PROCESSING,

--- a/src/ophys_etl/workflows/pipeline_modules/roi_classification/inference.py
+++ b/src/ophys_etl/workflows/pipeline_modules/roi_classification/inference.py
@@ -26,7 +26,7 @@ from ophys_etl.workflows.pipeline_modules.roi_classification.utils.mlflow_utils 
 )
 from ophys_etl.workflows.well_known_file_types import WellKnownFileTypeEnum
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
-from ophys_etl.workflows.workflow_step_runs import get_latest_run
+from ophys_etl.workflows.workflow_step_runs import get_latest_workflow_step_run
 from ophys_etl.workflows.workflow_steps import WorkflowStepEnum
 
 
@@ -201,7 +201,7 @@ class InferenceModule(PipelineModule):
         ROIs from most recent segmentation run for `self.ophys_experiment.id`
         """
         with Session(engine) as session:
-            segmentation_run_id = get_latest_run(
+            segmentation_run_id = get_latest_workflow_step_run(
                 session=session,
                 workflow_name=WorkflowNameEnum.OPHYS_PROCESSING,
                 workflow_step=WorkflowStepEnum.SEGMENTATION,

--- a/src/ophys_etl/workflows/pipeline_modules/trace_processing/demix_traces.py
+++ b/src/ophys_etl/workflows/pipeline_modules/trace_processing/demix_traces.py
@@ -48,13 +48,13 @@ class DemixTracesModule(PipelineModule):
     @property
     def inputs(self):
         module_args = {
-            "movie_h5": self._motion_corrected_path,
+            "movie_h5": self._motion_corrected_ophys_movie_file,
             "traces_h5": self._roi_trace_file,
             "output_file": str(
                 self.output_path
                 / f"{self._ophys_experiment.id}_demixed_traces.h5"
             ),
-            "rois": self.ophys_experiment.rois,
+            "roi_masks": [x.to_dict() for x in self.ophys_experiment.rois],
         }
         return module_args
 

--- a/src/ophys_etl/workflows/pipeline_modules/trace_processing/demix_traces.py
+++ b/src/ophys_etl/workflows/pipeline_modules/trace_processing/demix_traces.py
@@ -54,7 +54,8 @@ class DemixTracesModule(PipelineModule):
                 self.output_path
                 / f"{self._ophys_experiment.id}_demixed_traces.h5"
             ),
-            "roi_masks": [x.to_dict() for x in self.ophys_experiment.rois],
+            "roi_masks": [x.to_dict(include_exclusion_labels=True)
+                          for x in self.ophys_experiment.rois],
         }
         return module_args
 

--- a/src/ophys_etl/workflows/utils/dag_utils.py
+++ b/src/ophys_etl/workflows/utils/dag_utils.py
@@ -8,13 +8,18 @@ from ophys_etl.workflows.app_config.app_config import app_config
 from ophys_etl.workflows.utils.airflow_utils import get_rest_api_port
 
 
-def get_most_recent_run(dag_id: str) -> Optional[datetime.datetime]:
+def get_latest_dag_run(
+        dag_id: str,
+        state: str = 'success'
+) -> Optional[datetime.datetime]:
     """Gets the most recent run of this DAG, or None if not run before
 
     Parameters
     ----------
     dag_id
         Gets most recent run for this dag id
+    state
+        Filter by dag runs with this state
 
     """
     rest_api_username = \
@@ -29,7 +34,7 @@ def get_most_recent_run(dag_id: str) -> Optional[datetime.datetime]:
         f'dagRuns?'
         'limit=1&'
         'order_by=-execution_date&'
-        'state=success',
+        f'state={state}',
         headers={
             'Authorization': f'Basic {auth.decode()}'
         }

--- a/tests/workflows/test_workflow_step_runs.py
+++ b/tests/workflows/test_workflow_step_runs.py
@@ -9,7 +9,7 @@ from ophys_etl.workflows.output_file import OutputFile
 from ophys_etl.workflows.well_known_file_types import WellKnownFileTypeEnum
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
 from ophys_etl.workflows.workflow_step_runs import (
-    get_latest_run,
+    get_latest_workflow_step_run,
     get_well_known_file_for_latest_run,
 )
 from ophys_etl.workflows.workflow_steps import WorkflowStepEnum
@@ -45,7 +45,7 @@ class TestWorkflowStepRuns(MockSQLiteDB):
                     workflow_name=WorkflowNameEnum.OPHYS_PROCESSING,
                     workflow_step_name=WorkflowStepEnum.MOTION_CORRECTION,
                 )
-                latest_run = get_latest_run(
+                latest_run = get_latest_workflow_step_run(
                     session=session,
                     workflow_name=WorkflowNameEnum.OPHYS_PROCESSING,
                     workflow_step=WorkflowStepEnum.SEGMENTATION,


### PR DESCRIPTION
Follow up to PSB-85

- Adds a sensor that blocks submitting demix job until decrosstalk has run for that experiment
- Passes list of exclusion labels to demix module

Also:
- rename `get_latest_run` -> `get_latest_workflow_step_run`, `get_most_recent_run` -> `get_latest_dag_run` to differentiate them
![Screen Shot 2023-05-16 at 11 17 30 AM](https://github.com/AllenInstitute/ophys_etl_pipelines/assets/5454341/4e719ac2-42f8-4b71-842a-0a75f2de2b7e)
