### PR TITLE
pull deepinterpolation from main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             'deepcell @ git+https://github.com/AllenInstitute/DeepCell.git'
         ],
         'deepinterpolation': [
-            'deepinterpolation @ git+https://github.com/danielsf/deepinterpolation@staging/ophys_etl'   # noqa E401
+            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation'   # noqa E401
         ],
         'workflow': workflow_required
     }

--- a/src/ophys_etl/workflows/app_config/app_config.py
+++ b/src/ophys_etl/workflows/app_config/app_config.py
@@ -94,6 +94,21 @@ class _Denoising(_PipelineStep):
         "I.e. a downsample frac of 0.1 would randomly sample 10% "
         "of the data",
     )
+    batch_size: StrictInt = Field(
+        default=8,
+        description="Batch size of the generator for fine tuning"
+        "and inference. Set equal to number of workers for multiprocessing"
+    )
+    normalize_cache: bool = Field(
+        default=True,
+        description="Whether to normalize the cache data."
+        "Generally disable if RAM is less than 128GB"
+    )
+    gpu_cache_full: bool = Field(
+        default=False,
+        description="Whether to use GPU for caching. Enable if GPU"
+        "has more RAM than the size of the movie, e.g. A100 48GB"
+    )
 
 
 class _MotionCorrection(_PipelineStep):

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
@@ -55,7 +55,7 @@ class DenoisingFinetuningModule(_DenoisingModule):
                 "steps_per_epoch": 20,
             },
             "generator_params": {
-                "batch_size": 5,
+                "batch_size": app_config.pipeline_steps.denoising.batch_size,
                 "name": "MovieJSONGenerator",
                 "post_frame": 30,
                 "pre_frame": 30,

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_inference.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_inference.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 from ophys_etl.modules.denoising import inference
 from ophys_etl.workflows.ophys_experiment import OphysExperiment
+from ophys_etl.workflows.app_config.app_config import app_config
 from ophys_etl.workflows.output_file import OutputFile
 from ophys_etl.workflows.pipeline_modules.denoising._denoising import (
     _DenoisingModule,
@@ -38,17 +39,19 @@ class DenoisingInferenceModule(_DenoisingModule):
     def inputs(self) -> Dict:
         return {
             "generator_params": {
-                "batch_size": 8,
+                "batch_size": app_config.pipeline_steps.denoising.batch_size,
                 "name": "InferenceOphysGenerator",
                 "start_frame": 0,
                 "cache_data": True,
+                "normalize_cache": app_config.pipeline_steps.denoising.normalize_cache, # noqa E501
+                "gpu_cache_full": app_config.pipeline_steps.denoising.gpu_cache_full, # noqa E501
                 "data_path": self._motion_corrected_path,
             },
             "inference_params": {
                 "model_source": {"local_path": self._trained_model_path},
                 "rescale": True,
                 "save_raw": False,
-                "output_padding": False,
+                "output_padding": True,
                 "output_file": (
                     str(
                         self.output_path

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_inference.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_inference.py
@@ -38,16 +38,17 @@ class DenoisingInferenceModule(_DenoisingModule):
     def inputs(self) -> Dict:
         return {
             "generator_params": {
-                "batch_size": 5,
-                "name": "OphysGenerator",
+                "batch_size": 8,
+                "name": "InferenceOphysGenerator",
                 "start_frame": 0,
+                "cache_data": True,
                 "data_path": self._motion_corrected_path,
             },
             "inference_params": {
                 "model_source": {"local_path": self._trained_model_path},
-                "n_parallel_workers": 85,
                 "rescale": True,
                 "save_raw": False,
+                "output_padding": False,
                 "output_file": (
                     str(
                         self.output_path


### PR DESCRIPTION
Changing deepinterpolation to the main branch after optimizations were merged into it. 
Changed associated params.

1. The generator for inference switched to `InferenceOphysGenerator` which is an optimized version of the `OphysGenerator` for inference. 
2. Removed params associated with multiprocessing in the inference_params since InferenceOphysGenerator does not use them. 

Questions for other pika members:
1. Should we use output_padding?
2. What kind of compute resources should we set the default params to? Larger batch sizes can be faster if the GPU has a lot of memory. If the A100 GPU with 48GB VRAM is used, gpu_cache can be enabled. 
