### PR TITLE
PSB-132 Tag image with unique tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,17 +117,17 @@ commands:
             echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
             if [ "$CIRCLE_BRANCH" = "main" ]
             then
-                docker tag alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:main
-                docker push alleninstitutepika/ophys_etl_pipelines:main
+                docker tag alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:main_${CIRCLE_SHA1}
+                docker push alleninstitutepika/ophys_etl_pipelines:main_${CIRCLE_SHA1}
 
-                docker tag alleninstitutepika/ophys_etl_pipelines:deepinterpolation_${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:deepinterpolation_main
-                docker push alleninstitutepika/ophys_etl_pipelines:deepinterpolation_main
+                docker tag alleninstitutepika/ophys_etl_pipelines:deepinterpolation_${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:deepinterpolation_main_${CIRCLE_SHA1}
+                docker push alleninstitutepika/ophys_etl_pipelines:deepinterpolation_main_${CIRCLE_SHA1}
             else
-                docker tag alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:develop
-                docker push alleninstitutepika/ophys_etl_pipelines:develop
+                docker tag alleninstitutepika/ophys_etl_pipelines:${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:develop_${CIRCLE_SHA1}
+                docker push alleninstitutepika/ophys_etl_pipelines:develop_${CIRCLE_SHA1}
 
-                docker tag alleninstitutepika/ophys_etl_pipelines:deepinterpolation_${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:deepinterpolation_develop
-                docker push alleninstitutepika/ophys_etl_pipelines:deepinterpolation_develop
+                docker tag alleninstitutepika/ophys_etl_pipelines:deepinterpolation_${CIRCLE_SHA1} alleninstitutepika/ophys_etl_pipelines:deepinterpolation_develop_${CIRCLE_SHA1}
+                docker push alleninstitutepika/ophys_etl_pipelines:deepinterpolation_develop_${CIRCLE_SHA1}
             fi
         
 jobs:


### PR DESCRIPTION
Upload image to dockerhub and tag with unique tag.

If we use the same tag when we upload, it could easily get overwritten. It also allows for tracking of what image was pulled.

# Testing

images have been tagged with git commit sha on dockerhub https://hub.docker.com/layers/alleninstitutepika/ophys_etl_pipelines/develop_03d2272c5f9696d25e325527f98f199656ff2d26/images/sha256-50c2ebf27954b06a73ba1eab6c7eec4d37701e665e79ac2dd35965d18f938931?context=repo