### PR TITLE
Ticket/psb-183: Remove start/end frame, motion correction reset.

### DIFF
--- a/src/ophys_etl/modules/suite2p_registration/utils.py
+++ b/src/ophys_etl/modules/suite2p_registration/utils.py
@@ -104,7 +104,7 @@ def find_movie_start_end_empty_frames(
                           np.arange(0, lowside, dtype=start_idxs.dtype)):
         lowside = 0
         if logger is not None:
-            logger(f"{n_sigma} sigma discrepant frames found outside the "
+            logger(f"{n_sigma} sigma discrepant frames found outside of the "
                    "beginning of the movie. Please inspect the movie for data "
                    "quality. Not trimming frames from the movie beginning.")
     if not np.array_equal(end_idxs,
@@ -113,9 +113,9 @@ def find_movie_start_end_empty_frames(
                                     dtype=end_idxs.dtype)):
         highside = 0
         if logger is not None:
-            logger(f"{n_sigma} sigma discrepant frames found outside the end "
-                   "of the movie. Please inspect the movie for data quality. "
-                   "Not trimming frames from the movie end.")
+            logger(f"{n_sigma} sigma discrepant frames found outside of the "
+                   "end of the movie. Please inspect the movie for data "
+                   "quality. Not trimming frames from the movie end.")
 
     return (lowside, highside)
 

--- a/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
+++ b/tests/modules/suite2p_registration/test_suite2p_registration_pipeline.py
@@ -137,7 +137,7 @@ def test_suite2p_motion_correction(
         "x_pre_clip",
         "y_pre_clip",
         "correlation",
-        "is_valid",
+        "is_low_intensity_start_end_frame",
     ]
     if nonrigid:
         expected_cols.extend(["nonrigid_x", "nonrigid_y", "nonrigid_corr"])


### PR DESCRIPTION
Experiments were found that, while they don't have empty data for there initial ophys movie frames (as was the case for some experiments in SSF where the shutter was closed for the initial N frames), they have a different/low enough intensity to trigger the code to detect shutter closed frames. Reworked the code to throw a warning rather than resetting frames that are detected in this way. Reworked/worded log output to warn when these cases, remove them from consideration when computing a reference image, and mark the frames in the output CSV file.