### PR TITLE
PSB-168 Various fixes to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
               --tmpfs /tmp \
               -v $PWD/coverage_outputs_<<parameters.python_version>>:/coverage_outputs_<<parameters.python_version>> \
               alleninstitutepika/ophys_etl_pipelines:<<parameters.docker_tag>> \
-              /repos/ophys_etl/.circleci/scripts/run_and_test.sh "<<parameters.pytest_mark>>" <<parameters.python_version>> <<parameters.conda_env>> <<parameters.test_name>>.xml <<parameters.test_directory>>
+              /repos/ophys_etl/.circleci/scripts/run_and_test.sh "<<parameters.pytest_mark>>" <<parameters.python_version>> <<parameters.conda_env>> <<parameters.test_name>>.xml <<parameters.test_directory>> <<parameters.coverage_executable_path>>
 
 
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
       coverage_executable_path:
         type: string
         # will default to /envs/<conda_env>/bin/coverage in run_and_test.sh
-        default: ""
+        default:
     steps:
       - run:
           name: Run docker image << parameters.test_name >> tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,10 @@ commands:
       test_directory:
         type: string
         default: tests
+      coverage_executable_path:
+        type: string
+        # will default to /envs/<conda_env>/bin/coverage in run_and_test.sh
+        default: ""
     steps:
       - run:
           name: Run docker image << parameters.test_name >> tests
@@ -87,6 +91,7 @@ commands:
           pytest_mark: deepinterpolation_only
           conda_env: ophys_etl
           test_directory: tests/modules/denoising/
+          coverage_executable_path: /usr/local/bin/coverage
       - test:
           test_name: "general"
           python_version: <<parameters.python_version>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,6 @@ commands:
         default: tests
       coverage_executable_path:
         type: string
-        # will default to /envs/<conda_env>/bin/coverage in run_and_test.sh
-        default: ""
     steps:
       - run:
           name: Run docker image << parameters.test_name >> tests
@@ -84,6 +82,7 @@ commands:
           docker_tag: ${CIRCLE_SHA1}
           pytest_mark: "event_detect_only"
           conda_env: event_detection
+          coverage_executable_path: "/envs/event_detection/bin/coverage"
       - test:
           test_name: "deepinterpolation"
           python_version: <<parameters.python_version>>
@@ -98,7 +97,7 @@ commands:
           docker_tag: ${CIRCLE_SHA1}
           pytest_mark: "not event_detect_only and not deepinterpolation_only"
           conda_env: ophys_etl
-
+          coverage_executable_path: "/envs/ophys_etl/bin/coverage"
   smoke_test_and_push:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
       coverage_executable_path:
         type: string
         # will default to /envs/<conda_env>/bin/coverage in run_and_test.sh
-        default:
+        default: ""
     steps:
       - run:
           name: Run docker image << parameters.test_name >> tests
@@ -91,7 +91,7 @@ commands:
           pytest_mark: deepinterpolation_only
           conda_env: ophys_etl
           test_directory: tests/modules/denoising/
-          coverage_executable_path: /usr/local/bin/coverage
+          coverage_executable_path: "/usr/local/bin/coverage"
       - test:
           test_name: "general"
           python_version: <<parameters.python_version>>

--- a/.circleci/scripts/run_and_test.sh
+++ b/.circleci/scripts/run_and_test.sh
@@ -3,7 +3,7 @@ PYTHON_VERSION=${2}
 ENV_SPECIFICATION=${3}  # a name to use for coverage output file
 OUTPUT_XML=${4}    # the name of the coverage xml file (not its full path)
 TEST_DIRECTORY=${5}
-COVERAGE_EXE_PATH=${6:-/envs/${ENV_SPECIFICATION}/bin/coverage}  # path to coverage executable
+COVERAGE_EXE_PATH=${6}  # path to coverage executable
 
 echo "mark: "${PYTEST_MARK}
 echo "version: "${PYTHON_VERSION}

--- a/.circleci/scripts/run_and_test.sh
+++ b/.circleci/scripts/run_and_test.sh
@@ -1,8 +1,9 @@
 PYTEST_MARK=${1}
 PYTHON_VERSION=${2}
-ENV_SPECIFICATION=${3}  # which conda environment to run in
+ENV_SPECIFICATION=${3}  # a name to use for coverage output file
 OUTPUT_XML=${4}    # the name of the coverage xml file (not its full path)
 TEST_DIRECTORY=${5}
+COVERAGE_EXE_PATH=${6:-/envs/${ENV_SPECIFICATION}/bin/coverage}  # path to coverage executable
 
 echo "mark: "${PYTEST_MARK}
 echo "version: "${PYTHON_VERSION}
@@ -14,12 +15,12 @@ set -e
 export COVERAGE_FILE=/tmp/.coverage_${ENV_SPECIFICATION}_${PYTHON_VERSION}
 echo "COVERAGE_FILE set to "${COVERAGE_FILE}
 cd /repos/ophys_etl/
-/envs/${ENV_SPECIFICATION}/bin/coverage run --rcfile .circleci/coveragerc_file --concurrency=multiprocessing -m \
+${COVERAGE_EXE_PATH} run --rcfile .circleci/coveragerc_file --concurrency=multiprocessing -m \
     pytest --verbose \
     -s -m "${PYTEST_MARK}" \
     ${TEST_DIRECTORY}
 
-/envs/${ENV_SPECIFICATION}/bin/coverage combine --data-file=${COVERAGE_FILE} --rcfile .circleci/coveragerc_file
+${COVERAGE_EXE_PATH} combine --data-file=${COVERAGE_FILE} --rcfile .circleci/coveragerc_file
 
 # coverage automatically adds random salt to the end of the
 # coverage file name; need to detect the name of the file
@@ -27,7 +28,3 @@ cd /repos/ophys_etl/
 coverage_file_list=($(ls /tmp/.coverage_${ENV_SPECIFICATION}_${PYTHON_VERSION}*))
 echo "after combining "
 echo ${coverage_file_list[@]}
-
-#/envs/${ENV_SPECIFICATION}/bin/coverage xml --data-file=${COVERAGE_FILE} \
-#-o /coverage_outputs_${PYTHON_VERSION}/${OUTPUT_XML} \
-#--rcfile .circleci/coveragerc_file

--- a/docker/Dockerfile_deepinterpolation
+++ b/docker/Dockerfile_deepinterpolation
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.13.0-gpu
+FROM tensorflow/tensorflow:2.11.0-gpu
 
 LABEL maintainer="pika@alleninstitute.onmicrosoft.com"
 LABEL version=1.0

--- a/docker/Dockerfile_deepinterpolation
+++ b/docker/Dockerfile_deepinterpolation
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.5.1-gpu
+FROM tensorflow/tensorflow:2.13.0-gpu
 
 LABEL maintainer="pika@alleninstitute.onmicrosoft.com"
 LABEL version=1.0

--- a/docker/Dockerfile_deepinterpolation
+++ b/docker/Dockerfile_deepinterpolation
@@ -27,21 +27,12 @@ RUN apt-get -y update --allow-releaseinfo-change
 
 RUN apt-get -y install git
 RUN apt-get -y install wget
-
-# install conda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-RUN bash ~/miniconda.sh -b -p ~/miniconda
-
-# activate conda
-RUN eval "$(~/miniconda/bin/conda shell.bash hook)"
-ENV PATH="~/miniconda/bin:${PATH}"
-ARG PATH="~/miniconda/bin:${PATH}"
-RUN conda init
-
+RUN apt-get -y install "python${PYTHON_VERSION}"
+RUN apt-get -y install python3-pip
+RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3
 
 RUN git clone -b ${OPHYS_ETL_TAG} https://github.com/AllenInstitute/ophys_etl_pipelines ./ophys_etl
-RUN conda create --prefix ${CONDA_ENV} python=${PYTHON_VERSION} && \
-    conda run --prefix ${CONDA_ENV} pip install --no-cache ./ophys_etl[deepinterpolation] && \
-    conda run --prefix ${CONDA_ENV} pip install coverage
+RUN /usr/bin/python3 -m pip install --no-cache ./ophys_etl[deepinterpolation] && \
+    /usr/bin/python3 -m pip install coverage
 
 ENTRYPOINT ["/bin/bash", "-c", "$@", "--"]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
         'deepinterpolation': [
             'tensorflow==2.11.0',
-            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation@refactor'   # noqa E401
+            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation_ai_internal@refactor'   # noqa E401
         ],
         'workflow': workflow_required
     }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             'deepcell @ git+https://github.com/AllenInstitute/DeepCell.git'
         ],
         'deepinterpolation': [
-            'tensorflow==2.13.0'
+            'tensorflow==2.13.0',
             'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation'   # noqa E401
         ],
         'workflow': workflow_required

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             'deepcell @ git+https://github.com/AllenInstitute/DeepCell.git'
         ],
         'deepinterpolation': [
+            'tensorflow==2.13.0'
             'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation'   # noqa E401
         ],
         'workflow': workflow_required

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
         'deepinterpolation': [
             'tensorflow==2.11.0',
-            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation@add_logging'   # noqa E401
+            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation@refactor'   # noqa E401
         ],
         'workflow': workflow_required
     }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             'deepcell @ git+https://github.com/AllenInstitute/DeepCell.git'
         ],
         'deepinterpolation': [
-            'tensorflow==2.13.0',
+            'tensorflow==2.11.0',
             'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation'   # noqa E401
         ],
         'workflow': workflow_required

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
         'deepinterpolation': [
             'tensorflow==2.11.0',
-            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation_ai_internal@refactor'   # noqa E401
+            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation_ai_internal'   # noqa E401
         ],
         'workflow': workflow_required
     }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
         'deepinterpolation': [
             'tensorflow==2.11.0',
-            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation'   # noqa E401
+            'deepinterpolation @ git+https://github.com/AllenInstitute/deepinterpolation@add_logging'   # noqa E401
         ],
         'workflow': workflow_required
     }

--- a/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import argschema
 import h5py
 import json
-from keras import backend as K
 from deepinterpolation.cli.fine_tuning import FineTuning
 
 from ophys_etl.modules.denoising.fine_tuning.schemas import \
@@ -71,9 +70,6 @@ class FinetuningRunner(argschema.ArgSchemaParser):
 
         fine_tuning_runner = FineTuning(input_data=self.args, args=[])
         fine_tuning_runner.run()
-
-        # Manually clean up session due to dangling processes
-        K.clear_session()
 
     def _write_train_val_datasets(
             self,

--- a/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import signal
 import sys
 from pathlib import Path
 
@@ -70,6 +72,9 @@ class FinetuningRunner(argschema.ArgSchemaParser):
 
         fine_tuning_runner = FineTuning(input_data=self.args, args=[])
         fine_tuning_runner.run()
+
+        # Manually killing process due to an issue with hanging processes
+        os.kill(os.getpid(), signal.SIGTERM)
 
     def _write_train_val_datasets(
             self,

--- a/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
@@ -1,12 +1,11 @@
 import logging
-import os
-import signal
 import sys
 from pathlib import Path
 
 import argschema
 import h5py
 import json
+from keras import backend as K
 from deepinterpolation.cli.fine_tuning import FineTuning
 
 from ophys_etl.modules.denoising.fine_tuning.schemas import \
@@ -69,14 +68,12 @@ class FinetuningRunner(argschema.ArgSchemaParser):
         # the schema when `FineTuning` is called below
         del self.args['generator_params']['steps_per_epoch']
         del self.args['test_generator_params']['steps_per_epoch']
-        manually_kill_process = self.args.pop('manually_kill_process')
 
         fine_tuning_runner = FineTuning(input_data=self.args, args=[])
         fine_tuning_runner.run()
 
-        if manually_kill_process:
-            # Manually killing process due to an issue with hanging processes
-            os.kill(os.getpid(), signal.SIGTERM)
+        # Manually clean up session due to dangling processes
+        K.clear_session()
 
     def _write_train_val_datasets(
             self,

--- a/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 
 import argschema
@@ -39,7 +40,8 @@ class FinetuningRunner(argschema.ArgSchemaParser):
         logging.basicConfig(
             format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
             datefmt='%Y-%m-%d %H:%M:%S',
-            level=self.logger.level
+            level=self.logger.level,
+            stream=sys.stdout
         )
         logger = logging.getLogger(type(self).__name__)
         logger.setLevel(level=self.logger.level)

--- a/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/__main__.py
@@ -65,16 +65,18 @@ class FinetuningRunner(argschema.ArgSchemaParser):
 
         del self.args['data_split_params']
 
-        # Removes args added in post_load, since they are not expected in
+        # Removes args added, since they are not expected in
         # the schema when `FineTuning` is called below
         del self.args['generator_params']['steps_per_epoch']
         del self.args['test_generator_params']['steps_per_epoch']
+        manually_kill_process = self.args.pop('manually_kill_process')
 
         fine_tuning_runner = FineTuning(input_data=self.args, args=[])
         fine_tuning_runner.run()
 
-        # Manually killing process due to an issue with hanging processes
-        os.kill(os.getpid(), signal.SIGTERM)
+        if manually_kill_process:
+            # Manually killing process due to an issue with hanging processes
+            os.kill(os.getpid(), signal.SIGTERM)
 
     def _write_train_val_datasets(
             self,

--- a/src/ophys_etl/modules/denoising/fine_tuning/schemas.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/schemas.py
@@ -80,10 +80,3 @@ class FineTuningInputSchemaPreDataSplit(FineTuningInputSchema):
         GeneratorSchemaPreDataSplit, default={})
     test_generator_params = argschema.fields.Nested(
         GeneratorSchemaPreDataSplit, default={})
-    manually_kill_process = argschema.fields.Bool(
-        default=False,
-        description='Whether to manually kill the process.'
-                    'Fixes an issue with hanging processes after the '
-                    'program appeared to have finished. Set to false when '
-                    'running in pytest, since that will kill the test runner.'
-    )

--- a/src/ophys_etl/modules/denoising/fine_tuning/schemas.py
+++ b/src/ophys_etl/modules/denoising/fine_tuning/schemas.py
@@ -80,3 +80,10 @@ class FineTuningInputSchemaPreDataSplit(FineTuningInputSchema):
         GeneratorSchemaPreDataSplit, default={})
     test_generator_params = argschema.fields.Nested(
         GeneratorSchemaPreDataSplit, default={})
+    manually_kill_process = argschema.fields.Bool(
+        default=False,
+        description='Whether to manually kill the process.'
+                    'Fixes an issue with hanging processes after the '
+                    'program appeared to have finished. Set to false when '
+                    'running in pytest, since that will kill the test runner.'
+    )

--- a/src/ophys_etl/workflows/app_config/app_config.py
+++ b/src/ophys_etl/workflows/app_config/app_config.py
@@ -104,7 +104,7 @@ class _DenoisingFineTuning(_PipelineStep):
     slurm_settings = SlurmSettings(
         cpus_per_task=17,
         mem=85,
-        time=480,
+        time=12 * 60,
         gpus=1
     )
 

--- a/src/ophys_etl/workflows/db/db_utils.py
+++ b/src/ophys_etl/workflows/db/db_utils.py
@@ -249,12 +249,3 @@ def _validate_files_exist(output_files: List[OutputFile]):
                 f"Expected {out.well_known_file_type} to "
                 f"exist at {out.path} but it did not"
             )
-        if Path(out.path).is_dir():
-            if len(os.listdir(out.path)) == 0:
-                if app_config.is_debug:
-                    # Skipping in debug mode as it's possible for no files to
-                    #  get written, which is expected
-                    return
-                raise ModuleOutputFileDoesNotExistException(
-                    f"Directory {out.path} is empty"
-                )

--- a/src/ophys_etl/workflows/db/db_utils.py
+++ b/src/ophys_etl/workflows/db/db_utils.py
@@ -1,11 +1,9 @@
 """Database interface"""
 import datetime
 import logging
-import os
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
-from ophys_etl.workflows.app_config.app_config import app_config
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
 

--- a/src/ophys_etl/workflows/on_prem/dags/ophys_processing.py
+++ b/src/ophys_etl/workflows/on_prem/dags/ophys_processing.py
@@ -187,7 +187,8 @@ def ophys_processing():
 
         is_session_complete = \
             ophys_experiment.session.has_completed_workflow_step(
-                workflow_step=WorkflowStepEnum.SEGMENTATION
+                workflow_step=WorkflowStepEnum.SEGMENTATION,
+                passed_or_qc_only=False
             )
 
         return ophys_experiment.is_multiplane and \

--- a/src/ophys_etl/workflows/on_prem/slurm/slurm.py
+++ b/src/ophys_etl/workflows/on_prem/slurm/slurm.py
@@ -233,6 +233,9 @@ class Slurm:
             app_config.singularity.password.get_secret_value()
 
         request_gpu = self._slurm_settings.gpus > 0
+
+        # Note: downloading image to tmprdir and disabling caching due to
+        # cryptic errors, i.e. stale NFS file mount, bus error, etc.
         script = f'''#! /bin/bash
 # Adds mksquashfs (needed for singularity) to $PATH
 source /etc/profile
@@ -240,7 +243,10 @@ source /etc/profile
 export SINGULARITY_DOCKER_USERNAME={singularity_username}
 export SINGULARITY_DOCKER_PASSWORD={singularity_password}
 
-SINGULARITY_TMPDIR=/scratch/fast/${{SLURM_JOB_ID}} singularity run \
+SINGULARITY_TMPDIR=/scratch/fast/${{SLURM_JOB_ID}} \
+SINGULARITY_PULLFOLDER=/scratch/fast/${{SLURM_JOB_ID}} \
+SINGULARITY_DISABLE_CACHE=True \
+singularity run \
     --bind /allen:/allen,/scratch/fast/${{SLURM_JOB_ID}}:/tmp \
     {"--nv" if request_gpu else ""} \
     docker://alleninstitutepika/\

--- a/src/ophys_etl/workflows/on_prem/slurm/slurm.py
+++ b/src/ophys_etl/workflows/on_prem/slurm/slurm.py
@@ -123,10 +123,7 @@ class SlurmJob:
             return cls(
                 id=job_id
             )
-        elif len(response['jobs']) > 1:
-            raise RuntimeError(f'Expected 1 job to be returned but '
-                               f'{len(response["jobs"])} were returned)')
-        job = response['jobs'][0]
+        job = response['jobs'][-1]
 
         # slurm records datetimes in local time (Pacific). Convert to UTC
         start = datetime.fromtimestamp(job['time']['start'],

--- a/src/ophys_etl/workflows/ophys_experiment.py
+++ b/src/ophys_etl/workflows/ophys_experiment.py
@@ -45,7 +45,8 @@ class OphysExperimentGroup(abc.ABC):
 
     def has_completed_workflow_step(
         self,
-        workflow_step: WorkflowStepEnum
+        workflow_step: WorkflowStepEnum,
+        passed_or_qc_only: bool = True
     ) -> bool:
         """
         Returns whether the ophys experiment group has completed
@@ -54,6 +55,8 @@ class OphysExperimentGroup(abc.ABC):
         Parameters
         ----------
         workflow_step
+        passed_or_qc_only
+            See this argument in `get_ophys_experiment_ids`
 
         Returns
         -------
@@ -61,7 +64,8 @@ class OphysExperimentGroup(abc.ABC):
             whether the ophys experiment group has completed
             `workflow_step` (all experiments in group have run)
         """
-        all_ophys_experiment_ids = self.get_ophys_experiment_ids()
+        all_ophys_experiment_ids = self.get_ophys_experiment_ids(
+            passed_or_qc_only=passed_or_qc_only)
         with Session(engine) as session:
             step = get_workflow_step_by_name(
                 name=workflow_step,

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/_denoising.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/_denoising.py
@@ -26,5 +26,6 @@ class _DenoisingModule(PipelineModule, ABC):
         ]
         self._motion_corrected_path = str(motion_corrected_ophys_movie.path)
 
+    @property
     def python_interpreter_path(self) -> str:
         return '/usr/bin/python3'

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/_denoising.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/_denoising.py
@@ -25,3 +25,6 @@ class _DenoisingModule(PipelineModule, ABC):
             "motion_corrected_ophys_movie_file"
         ]
         self._motion_corrected_path = str(motion_corrected_ophys_movie.path)
+
+    def python_interpreter_path(self) -> str:
+        return '/usr/bin/python3'

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
@@ -75,8 +75,7 @@ class DenoisingFinetuningModule(_DenoisingModule):
                 "pre_post_omission": 0,
                 "seed": 1234
             },
-            "run_uid": str(self.ophys_experiment.id),
-            "manually_kill_process": True
+            "run_uid": str(self.ophys_experiment.id)
         }
 
     @property

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
@@ -55,6 +55,8 @@ class DenoisingFinetuningModule(_DenoisingModule):
                 "output_dir": str(self.output_path),
                 "period_save": 1,
                 "steps_per_epoch": 20,
+                # Disabling multiprocessing since issue with zombie processes
+                "use_multiprocessing": False,
                 "verbose": 2
             },
             "generator_params": {

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
@@ -55,6 +55,7 @@ class DenoisingFinetuningModule(_DenoisingModule):
                 "output_dir": str(self.output_path),
                 "period_save": 1,
                 "steps_per_epoch": 20,
+                "verbose": 2
             },
             "generator_params": {
                 "batch_size": app_config.pipeline_steps.denoising.batch_size,

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
@@ -76,6 +76,7 @@ class DenoisingFinetuningModule(_DenoisingModule):
                 "seed": 1234
             },
             "run_uid": str(self.ophys_experiment.id),
+            "manually_kill_process": True
         }
 
     @property

--- a/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
+++ b/src/ophys_etl/workflows/pipeline_modules/denoising/denoising_finetuning.py
@@ -51,7 +51,7 @@ class DenoisingFinetuningModule(_DenoisingModule):
                 "multi_gpus": False,
                 "name": "transfer_trainer",
                 "nb_times_through_data": 1,
-                "nb_workers": 15,
+                "nb_workers": 1,
                 "output_dir": str(self.output_path),
                 "period_save": 1,
                 "steps_per_epoch": 20,

--- a/tests/workflows/db/test_db_utils.py
+++ b/tests/workflows/db/test_db_utils.py
@@ -85,7 +85,6 @@ class TestDBUtils:
             path = self._tmp_dir / "foo.txt"
         else:
             path = self._tmp_dir / "foo"
-            os.makedirs(path)
         files = [
             OutputFile(
                 path=path,

--- a/tests/workflows/db/test_db_utils.py
+++ b/tests/workflows/db/test_db_utils.py
@@ -100,6 +100,7 @@ class TestDBUtils:
             with open(path, "w") as f:
                 f.write("")
         else:
+            os.makedirs(path)
             with open(path / "foo.txt", "w") as f:
                 f.write("")
 

--- a/tests/workflows/on_prem/slurm/test_data/expected_job.json
+++ b/tests/workflows/on_prem/slurm/test_data/expected_job.json
@@ -16,5 +16,5 @@
       "LD_LIBRARY_PATH": "/lib/:/lib64/:/usr/local/lib"
     }
   },
-  "script": "#! /bin/bash\n# Adds mksquashfs (needed for singularity) to $PATH\nsource /etc/profile\n\nexport SINGULARITY_DOCKER_USERNAME=foo\nexport SINGULARITY_DOCKER_PASSWORD=bar\n\nSINGULARITY_TMPDIR=/scratch/fast/${SLURM_JOB_ID} singularity run     --bind /allen:/allen,/scratch/fast/${SLURM_JOB_ID}:/tmp          docker://alleninstitutepika/ophys_etl_pipelines:main     /envs/ophys_etl/bin/python -m ophys_etl.modules.suite2p_registration  --input_json input.json --output_json output.json"
+  "script": "#! /bin/bash\n# Adds mksquashfs (needed for singularity) to $PATH\nsource /etc/profile\n\nexport SINGULARITY_DOCKER_USERNAME=foo\nexport SINGULARITY_DOCKER_PASSWORD=bar\n\nSINGULARITY_TMPDIR=/scratch/fast/${SLURM_JOB_ID} SINGULARITY_PULLFOLDER=/scratch/fast/${SLURM_JOB_ID} SINGULARITY_DISABLE_CACHE=True singularity run     --bind /allen:/allen,/scratch/fast/${SLURM_JOB_ID}:/tmp          docker://alleninstitutepika/ophys_etl_pipelines:main     /envs/ophys_etl/bin/python -m ophys_etl.modules.suite2p_registration  --input_json input.json --output_json output.json"
 }


### PR DESCRIPTION
This PR fixes various issues found while testing pipeline.

- Use python outside virtual env. to fix an issue with conda inside denoising image
- Pin tensorflow version to 2.11.0 since deepinterpolation is unpinned
- Speeds up movie stats calculation (by a significant amount) by not indexing into arbitrary indices in hdf5 file
- add logging and timestamps
- Fix issue when there are 0 rois (we don't expect there to be any thumbnail images for classification)
- increase default timeout for finetuning to 12 hrs
- use `verbosity=2` for tensorflow, which is meant for production logging, rather than interactive
- Fix issue with decrosstalk. Wait for all experiments, rather than only passed/qc
- Disable singularity caching and pull docker image into tmp directory rather than isilon to avoid singularity issues