### PR TITLE
PSB-223 bugfix: get motion border for experiment

### DIFF
--- a/src/ophys_etl/workflows/ophys_experiment.py
+++ b/src/ophys_etl/workflows/ophys_experiment.py
@@ -374,9 +374,10 @@ class OphysExperiment:
 
         with Session(engine) as session:
             workflow_step_run_id = get_latest_workflow_step_run(
-                session,
-                WorkflowStepEnum.MOTION_CORRECTION,
-                WorkflowNameEnum.OPHYS_PROCESSING,
+                session=session,
+                workflow_step=WorkflowStepEnum.MOTION_CORRECTION,
+                workflow_name=WorkflowNameEnum.OPHYS_PROCESSING,
+                ophys_experiment_id=self.id
             )
             query = select(MotionCorrectionRun,).where(
                 MotionCorrectionRun.workflow_step_run_id

--- a/tests/workflows/test_ophys_experiment.py
+++ b/tests/workflows/test_ophys_experiment.py
@@ -36,7 +36,8 @@ class TestOphysExperiment(MockSQLiteDB):
                 workflow=WorkflowNameEnum.OPHYS_PROCESSING.value,
                 name=WorkflowStepEnum.MOTION_CORRECTION.value,
             )
-            motion_correction_run = WorkflowStepRun(
+
+            motion_correction_run1 = WorkflowStepRun(
                 ophys_experiment_id=ophys_experiment_id,
                 workflow_step_id=motion_correction_workflow_step.id,
                 log_path="log_path",
@@ -44,7 +45,17 @@ class TestOphysExperiment(MockSQLiteDB):
                 start="2023-04-01 00:00:00",
                 end="2023-04-01 01:00:00",
             )
-            session.add(motion_correction_run)
+            session.add(motion_correction_run1)
+
+            motion_correction_run2 = WorkflowStepRun(
+                ophys_experiment_id="2",
+                workflow_step_id=motion_correction_workflow_step.id,
+                log_path="log_path",
+                storage_directory="storage_directory",
+                start="2023-05-01 00:00:00",
+                end="2023-05-01 01:00:00",
+            )
+            session.add(motion_correction_run2)
 
             # add segmentation run
             segmentation_workflow_step = get_workflow_step_by_name(
@@ -64,11 +75,20 @@ class TestOphysExperiment(MockSQLiteDB):
 
             session.flush()
             motion_correction = MotionCorrectionRun(
-                workflow_step_run_id=motion_correction_run.id,
+                workflow_step_run_id=motion_correction_run1.id,
                 max_correction_left=10,
                 max_correction_right=20,
                 max_correction_up=30,
                 max_correction_down=40,
+            )
+            session.add(motion_correction)
+
+            motion_correction = MotionCorrectionRun(
+                workflow_step_run_id=motion_correction_run2.id,
+                max_correction_left=100,
+                max_correction_right=200,
+                max_correction_up=300,
+                max_correction_down=400,
             )
             session.add(motion_correction)
 


### PR DESCRIPTION
Previously the most recently added motion border was being pulled. We need to pull the most recently added motion border _for a specific experiment id_