### PR TITLE
PSB-210 Block ophys_processing dag from completing until other dags complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
           build_name: "General+suite2p"
           python_version: <<parameters.python_version>>
           tag: ${CIRCLE_SHA1}
-          dockerfile_name: "Dockerfile_no_deepinterpolation"
+          dockerfile_name: "Dockerfile"
       - build_docker:
           build_name: "DeepInterpolation only"
           python_version: <<parameters.python_version>>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN conda create --prefix ${OPHYS_ETL_ENV} python=${PYTHON_VERSION} && \
     # if requirements.txt specifies a different version, these will get overwritten
     # and some other BLAS backend will be used - speed will decrease
     conda run --prefix ${OPHYS_ETL_ENV} conda install scipy && \
-    conda run --prefix ${OPHYS_ETL_ENV} pip install --no-cache ./ophys_etl[workflow,pytorch_deps] && \
+    conda run --prefix ${OPHYS_ETL_ENV} pip install --no-cache ./ophys_etl[workflow,pytorch_deps,deepinterpolation] && \
     conda run --prefix ${OPHYS_ETL_ENV} pip install coverage && \
     echo "use for ophys_etl "$(conda run --prefix ${OPHYS_ETL_ENV} which python)
 

--- a/requirements-workflow.txt
+++ b/requirements-workflow.txt
@@ -1,3 +1,4 @@
+apache-airflow==2.6.3
 sqlmodel
 PyYaml
 paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy<=1.23.3
 scipy
 imageio-ffmpeg
 pytest
-argschema==2.0.2
+argschema
 h5py
 matplotlib
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy<=1.23.3
 scipy
 imageio-ffmpeg
 pytest
-argschema
+argschema==3.0.4
 h5py
 matplotlib
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy<=1.23.3
 scipy
 imageio-ffmpeg
 pytest
-argschema==3.0.4
+argschema
 h5py
 matplotlib
 pandas

--- a/src/ophys_etl/workflows/tasks.py
+++ b/src/ophys_etl/workflows/tasks.py
@@ -4,11 +4,12 @@ import datetime
 import json
 import logging
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Literal
 
 from airflow.decorators import task
 from airflow.operators.python import get_current_context
 from airflow.sensors.base import PokeReturnValue
+from ophys_etl.workflows.app_config.app_config import app_config
 from sqlalchemy.exc import NoResultFound
 
 from ophys_etl.workflows.utils.dag_utils import get_latest_dag_run
@@ -125,9 +126,14 @@ def save_job_run_to_db(
     }
 
 
-def wait_for_decrosstalk_to_finish(timeout: float) -> Callable:
+def wait_for_dag_to_finish(
+    dag_id: str,
+    workflow_step: WorkflowStepEnum,
+    level: Literal['experiment', 'session', 'container'] = None,
+    timeout: float = app_config.job_timeout
+) -> Callable:
     """
-    Returns function which waits for decrosstalk job to finish
+    Returns function which waits for `dag_id` to finish
 
     Notes
     ------
@@ -135,45 +141,77 @@ def wait_for_decrosstalk_to_finish(timeout: float) -> Callable:
 
     Parameters
     ----------
+    dag_id
+        dag_id to wait for
     timeout
         Timeout in seconds
+    workflow_step
+        WorkflowStepEnum associated with `dag_id`
+    level
+        What level the dag runs at. 'experiment', 'session', or 'container'
+        None if it doesn't apply
 
     Returns
     -------
     Callable decorated with `task.sensor`
     """
 
-    @task.sensor(mode="reschedule", timeout=timeout)
-    def wait_for_decrosstalk_to_finish():
+    @task.sensor(
+        mode="reschedule",
+        timeout=timeout,
+        task_id=f'wait_for_{dag_id}_to_finish')
+    def wait_for_dag_to_finish():
         context = get_current_context()
         ophys_experiment_id = context['params']['ophys_experiment_id']
         ophys_experiment = OphysExperiment.from_id(id=ophys_experiment_id)
-        if not ophys_experiment.is_multiplane:
-            logger.info(f'Experiment {ophys_experiment.id} is not multiplane. '
-                        f'Equipment type: {ophys_experiment.equipment_name}. '
-                        f'Decrosstalk does not need to run')
-            return PokeReturnValue(is_done=True)
+
+        if dag_id == 'decrosstalk':
+            if not ophys_experiment.is_multiplane:
+                logger.info(
+                    f'Experiment {ophys_experiment.id} is not multiplane. '
+                    f'Equipment type: {ophys_experiment.equipment_name}. '
+                    f'Decrosstalk does not need to run')
+                return PokeReturnValue(is_done=True)
+
+        if level == 'experiment':
+            kwargs = {
+                'ophys_experiment_id': ophys_experiment.id
+            }
+        elif level == 'session':
+            kwargs = {
+                'ophys_session_id': ophys_experiment.session.id
+            }
+        elif level == 'container':
+            kwargs = {
+                'ophys_container_id': ophys_experiment.container.id
+            }
+        else:
+            if level is not None:
+                raise ValueError(f'Invalid level {level}. Only "experiment", '
+                                 f'"session", "container" supported')
+            else:
+                kwargs = {}
 
         with Session(engine) as session:
             try:
                 get_latest_workflow_step_run(
                     session=session,
-                    ophys_session_id=ophys_experiment.session.id,
-                    workflow_step=WorkflowStepEnum.DECROSSTALK,
-                    workflow_name=WorkflowNameEnum.OPHYS_PROCESSING
+                    workflow_step=workflow_step,
+                    workflow_name=WorkflowNameEnum.OPHYS_PROCESSING,
+                    **kwargs
                 )
                 is_done = True
             except NoResultFound:
                 is_done = False
 
-        # Checking if decrosstalk is running to prevent a situation where
-        # decrosstalk was rerun. We don't want to pull the old decrosstalk
+        # Checking if `dag_id` is running to prevent a situation where
+        # `dag_id` was rerun. We don't want to pull the old `dag_id`
         # values. So we are waiting for the running dag to finish
         is_running = get_latest_dag_run(
-            dag_id='decrosstalk',
+            dag_id=dag_id,
             states=['running']
         ) is not None
 
         return PokeReturnValue(is_done=is_done and not is_running)
 
-    return wait_for_decrosstalk_to_finish
+    return wait_for_dag_to_finish

--- a/tests/workflows/airflow_test.py
+++ b/tests/workflows/airflow_test.py
@@ -1,0 +1,16 @@
+import os
+import tempfile
+
+
+class AirflowTest:
+    @classmethod
+    def setup_class(cls):
+        cls._tmpdir = tempfile.TemporaryDirectory()
+
+        # IMPORTANT -- make sure all airflow imports happen after setup_class
+        # gets called
+        os.environ['AIRFLOW_HOME'] = cls._tmpdir.name
+
+    @classmethod
+    def teardown_class(cls):
+        cls._tmpdir.cleanup()

--- a/tests/workflows/on_prem/dags/test_dags.py
+++ b/tests/workflows/on_prem/dags/test_dags.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from airflow.models import DagBag
+
+from ophys_etl.workflows import on_prem
+
+
+class TestDags:
+    @classmethod
+    def setup_class(cls):
+        airflow_home = Path(on_prem.__file__).parent
+
+        cls._dag_bag = DagBag(
+            dag_folder=str(airflow_home / 'dags'),
+            include_examples=False
+        )
+
+    def test_dags_load(self):
+        """Test that all dags load successfully"""
+        for dag_path, traceback in self._dag_bag.import_errors.items():
+            raise Exception(f'{dag_path} failed to load\n {traceback}')

--- a/tests/workflows/on_prem/dags/test_dags.py
+++ b/tests/workflows/on_prem/dags/test_dags.py
@@ -1,17 +1,16 @@
-import os
 from pathlib import Path
 
 from ophys_etl.workflows import on_prem
-os.environ['AIRFLOW_HOME'] = str(Path(on_prem.__file__).parent)
-
-from airflow.models import DagBag
+from tests.workflows.airflow_test import AirflowTest
 
 
-class TestDags:
+class TestDags(AirflowTest):
     @classmethod
     def setup_class(cls):
+        super().setup_class()
+        from airflow.models import DagBag
         cls._dag_bag = DagBag(
-            dag_folder=str(Path(os.environ['AIRFLOW_HOME']) / 'dags'),
+            dag_folder=str(Path(on_prem.__file__).parent / 'dags'),
             include_examples=False
         )
 

--- a/tests/workflows/on_prem/dags/test_dags.py
+++ b/tests/workflows/on_prem/dags/test_dags.py
@@ -1,17 +1,17 @@
+import os
 from pathlib import Path
 
-from airflow.models import DagBag
-
 from ophys_etl.workflows import on_prem
+os.environ['AIRFLOW_HOME'] = str(Path(on_prem.__file__).parent)
+
+from airflow.models import DagBag
 
 
 class TestDags:
     @classmethod
     def setup_class(cls):
-        airflow_home = Path(on_prem.__file__).parent
-
         cls._dag_bag = DagBag(
-            dag_folder=str(airflow_home / 'dags'),
+            dag_folder=str(Path(os.environ['AIRFLOW_HOME']) / 'dags'),
             include_examples=False
         )
 

--- a/tests/workflows/test_tasks.py
+++ b/tests/workflows/test_tasks.py
@@ -1,0 +1,123 @@
+import datetime
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from airflow.sensors.base import PokeReturnValue
+from ophys_etl.workflows.workflow_names import WorkflowNameEnum
+from sqlmodel import Session
+
+from ophys_etl.workflows.db.db_utils import save_job_run_to_db
+
+from ophys_etl.workflows.ophys_experiment import OphysExperiment, \
+    OphysContainer, Specimen, OphysSession
+
+from ophys_etl.workflows.workflow_steps import WorkflowStepEnum
+
+from ophys_etl.workflows.tasks import wait_for_dag_to_finish
+from tests.workflows.conftest import MockSQLiteDB
+
+
+class TestTasks(MockSQLiteDB):
+    @mock.patch('ophys_etl.workflows.tasks.get_current_context')
+    @mock.patch.object(OphysExperiment, 'from_id')
+    @mock.patch('ophys_etl.workflows.tasks.get_latest_dag_run')
+    @pytest.mark.parametrize(
+        'dag_id, workflow_step, level',
+        [
+            pytest.param(
+                # dag_id
+                'decrosstalk',
+                # workflow_step,
+                WorkflowStepEnum.DECROSSTALK,
+                # level
+                'session'
+            ),
+            pytest.param(
+                # dag_id
+                'cell_classifier_inference',
+                # workflow_step,
+                WorkflowStepEnum.ROI_CLASSIFICATION_INFERENCE,
+                # level
+                'experiment'
+            ),
+            pytest.param(
+                # dag_id
+                'nway_cell_matching',
+                # workflow_step,
+                WorkflowStepEnum.NWAY_CELL_MATCHING,
+                # level
+                'container'
+            )
+        ]
+    )
+    def test_wait_for_dag_to_finish(
+        self,
+        mock_get_running_dag_run,
+        mock_ophys_experiment,
+        _,
+        dag_id,
+        workflow_step,
+        level
+    ):
+        mock_get_running_dag_run.return_value = None
+        mock_ophys_experiment.return_value = OphysExperiment(
+            id=1,
+            container=OphysContainer(id=1, specimen=Specimen(id='1')),
+            session=OphysSession(id=1, specimen=Specimen(id='1')),
+            equipment_name='MESO.1',
+            full_genotype='',
+            movie_frame_rate_hz=1,
+            raw_movie_filename=Path(''),
+            specimen=Specimen(id='1'),
+            storage_directory=Path('')
+        )
+
+        # 1. First run we expect is_done to be False since it hasn't run yet
+        with mock.patch('ophys_etl.workflows.tasks.engine', new=self._engine):
+            res: PokeReturnValue = wait_for_dag_to_finish(
+                    dag_id=dag_id,
+                    workflow_step=workflow_step,
+                    level=level
+                ).function()
+            assert not res.is_done
+
+        # 2. Now we run the dag and we expect is_done to be True
+        if level == 'experiment':
+            kwargs = {
+                'ophys_experiment_id':
+                    mock_ophys_experiment.return_value.id
+            }
+        elif level == 'session':
+            kwargs = {
+                'ophys_session_id':
+                    mock_ophys_experiment.return_value.session.id
+            }
+        elif level == 'container':
+            kwargs = {
+                'ophys_container_id':
+                    mock_ophys_experiment.return_value.container.id
+            }
+        else:
+            raise ValueError(f'invalid level {level}')
+
+        with Session(self._engine) as session:
+            save_job_run_to_db(
+                start=datetime.datetime.now(),
+                end=datetime.datetime.now(),
+                module_outputs=[],
+                sqlalchemy_session=session,
+                storage_directory="foo",
+                log_path="foo",
+                workflow_name=WorkflowNameEnum.OPHYS_PROCESSING,
+                workflow_step_name=workflow_step,
+                **kwargs
+            )
+
+        with mock.patch('ophys_etl.workflows.tasks.engine', new=self._engine):
+            res: PokeReturnValue = wait_for_dag_to_finish(
+                    dag_id=dag_id,
+                    workflow_step=workflow_step,
+                    level=level
+                ).function()
+            assert res.is_done

--- a/tests/workflows/test_tasks.py
+++ b/tests/workflows/test_tasks.py
@@ -1,14 +1,9 @@
-import os
 from pathlib import Path
-
-from ophys_etl.workflows import on_prem
-os.environ['AIRFLOW_HOME'] = str(Path(on_prem.__file__).parent)
 
 import datetime
 from unittest import mock
 
 import pytest
-from airflow.sensors.base import PokeReturnValue
 from ophys_etl.workflows.workflow_names import WorkflowNameEnum
 from sqlmodel import Session
 
@@ -20,10 +15,11 @@ from ophys_etl.workflows.ophys_experiment import OphysExperiment, \
 from ophys_etl.workflows.workflow_steps import WorkflowStepEnum
 
 from ophys_etl.workflows.tasks import wait_for_dag_to_finish
+from tests.workflows.airflow_test import AirflowTest
 from tests.workflows.conftest import MockSQLiteDB
 
 
-class TestTasks(MockSQLiteDB):
+class TestTasks(MockSQLiteDB, AirflowTest):
     @mock.patch('ophys_etl.workflows.tasks.get_current_context')
     @mock.patch.object(OphysExperiment, 'from_id')
     @mock.patch('ophys_etl.workflows.tasks.get_latest_dag_run')
@@ -65,6 +61,8 @@ class TestTasks(MockSQLiteDB):
         workflow_step,
         level
     ):
+        from airflow.sensors.base import PokeReturnValue
+
         mock_get_running_dag_run.return_value = None
         mock_ophys_experiment.return_value = OphysExperiment(
             id=1,

--- a/tests/workflows/test_tasks.py
+++ b/tests/workflows/test_tasks.py
@@ -1,5 +1,10 @@
-import datetime
+import os
 from pathlib import Path
+
+from ophys_etl.workflows import on_prem
+os.environ['AIRFLOW_HOME'] = str(Path(on_prem.__file__).parent)
+
+import datetime
 from unittest import mock
 
 import pytest

--- a/tests/workflows/test_tasks.py
+++ b/tests/workflows/test_tasks.py
@@ -14,7 +14,6 @@ from ophys_etl.workflows.ophys_experiment import OphysExperiment, \
 
 from ophys_etl.workflows.workflow_steps import WorkflowStepEnum
 
-from ophys_etl.workflows.tasks import wait_for_dag_to_finish
 from tests.workflows.airflow_test import AirflowTest
 from tests.workflows.conftest import MockSQLiteDB
 
@@ -62,6 +61,7 @@ class TestTasks(MockSQLiteDB, AirflowTest):
         level
     ):
         from airflow.sensors.base import PokeReturnValue
+        from ophys_etl.workflows.tasks import wait_for_dag_to_finish
 
         mock_get_running_dag_run.return_value = None
         mock_ophys_experiment.return_value = OphysExperiment(


### PR DESCRIPTION
The `ophys_processing` dag runs the `nway_cell_matching` and `cell_classifier_inference` dags , but currently does not track whether those completed successfully. This PR adds a task call to check whether they've completed.

- Generalize `wait_for_decrosstalk_to_finish` to support any dag/workflow step

# Testing
Added new tests that test `wait_for_dag_to_finish`. Also added a test that tests that all dags can load successfully. 

# Other
- needed to install deepinterpolation in `Dockerfile` since the `test_dags_load` imports it, and because it now imports it, renamed `Dockerfile_no_deepinterpolation` -> `Dockerfile`. 
- Updated argschema version since had a conflict with airflow