### PR TITLE
PSB-239 bugfix: Superclass constructor not called before self.output_path

### DIFF
--- a/src/ophys_etl/workflows/pipeline_modules/roi_classification/inference.py
+++ b/src/ophys_etl/workflows/pipeline_modules/roi_classification/inference.py
@@ -48,14 +48,21 @@ class InferenceModule(PipelineModule):
             ensemble_id=kwargs["ensemble_id"]
         )
 
-        self._model_inputs_path = self._write_model_inputs_to_disk(
-            thumbnails_dir=thumbnails_dir.path
-        )
         super().__init__(
             ophys_experiment=ophys_experiment,
             prevent_file_overwrites=prevent_file_overwrites,
+            # Passing False here since self._model_inputs_path needs to be set
+            # but in order to set that, the superclass constructor needs to be
+            # called. `self.validate_input_args()` is called afterwards
+            validate_input_args=False,
             **kwargs,
         )
+
+        self._model_inputs_path = self._write_model_inputs_to_disk(
+            thumbnails_dir=thumbnails_dir.path
+        )
+
+        self.validate_input_args()
 
     @property
     def queue_name(self) -> WorkflowStepEnum:

--- a/tests/workflows/pipeline_modules/roi_classification/test_inference.py
+++ b/tests/workflows/pipeline_modules/roi_classification/test_inference.py
@@ -2,6 +2,9 @@ import datetime
 import json
 import os
 import pickle
+
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 import random
 import shutil
@@ -9,6 +12,8 @@ from pathlib import Path
 from unittest.mock import patch, PropertyMock
 
 import pandas as pd
+from deepcell.datasets.channel import channel_filename_prefix_map
+
 from ophys_etl.workflows.pipeline_modules.motion_correction import \
     MotionCorrectionModule
 
@@ -127,39 +132,62 @@ class TestInference(MockSQLiteDB):
         ).to_csv(self._preds_path, index=False)
         self._insert_model()
 
+        self._thumbnails_dir = self._write_dummy_thumbnails()
+
+    def _write_dummy_thumbnails(self):
+        rois_path = Path(__file__).parent.parent / "resources" / "rois.json"
+        thumbnails_dir = self._tmp_dir / 'thumbnails'
+        os.makedirs(thumbnails_dir, exist_ok=True)
+
+        with open(rois_path) as f:
+            rois = json.load(f)
+
+        for roi in rois:
+            roi_id = roi["id"]
+            for channel in (
+                    app_config.pipeline_steps.roi_classification.
+                    input_channels):
+                filename = (
+                    f'{channel_filename_prefix_map[channel]}_'
+                    f'{self._ophys_experiment_id}_{roi_id}.png')
+                path = thumbnails_dir / filename
+                plt.imsave(path, np.random.random((10, 10)))
+
+        return OutputFile(
+            path=thumbnails_dir,
+            well_known_file_type=(
+                WellKnownFileTypeEnum.ROI_CLASSIFICATION_THUMBNAIL_IMAGES)
+        )
+
     @classmethod
     def teardown_class(cls):
         shutil.rmtree(cls._tmp_dir)
 
-    @pytest.mark.skip(reason="TODO: handle _get_mlflow_model_params")
-    @patch.object(OphysSession, "output_dir", new_callable=PropertyMock)
-    @patch.object(
-        InferenceModule, "output_path", new_callable=PropertyMock
-    )
-    @patch.object(
-        InferenceModule, "_write_model_inputs_to_disk"
-    )
+    @patch.object(InferenceModule, "_get_mlflow_model_params")
     def test_inputs(
-        self, mock_write_module_inputs_to_disk,
-        mock_output_path, mock_output_dir,
-        mock_ophys_experiment, mock_thumbnails_dir, temp_dir
+        self,
+        mock_get_mlflow_model_params,
+        mock_ophys_experiment
     ):
         """Test that inputs are correctly formatted
         for input into the module.
         """
-        mock_write_module_inputs_to_disk.return_value = temp_dir / 'model_inputs.json' # noqa E501
-        with open(temp_dir/'model_inputs.json', 'w') as f:
+        mock_get_mlflow_model_params.return_value = {
+            'use_pretrained_model': True,
+            'model_architecture': 'foo',
+            'truncate_to_layer': None
+        }
+        with open(self._tmp_dir / 'model_inputs.json', 'w') as f:
             f.write(json.dumps([{'foo': 'bar'}]))
 
-        mock_output_path.return_value = temp_dir
-        mock_output_dir.return_value = temp_dir
         with patch('ophys_etl.workflows.pipeline_modules.roi_classification.'
                    'inference.engine', new=self._engine):
             mod = InferenceModule(
                 docker_tag="main",
                 ophys_experiment=mock_ophys_experiment,
-                thumbnails_dir=mock_thumbnails_dir,
+                thumbnails_dir=self._thumbnails_dir,
                 ensemble_id=1,
+                prevent_file_overwrites=False
             )
         mod.inputs
 

--- a/tests/workflows/pipeline_modules/roi_classification/test_inference.py
+++ b/tests/workflows/pipeline_modules/roi_classification/test_inference.py
@@ -5,11 +5,10 @@ import pickle
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pytest
 import random
 import shutil
 from pathlib import Path
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
 
 import pandas as pd
 from deepcell.datasets.channel import channel_filename_prefix_map


### PR DESCRIPTION
Fixes bug introduced in https://github.com/AllenInstitute/ophys_etl_pipelines/pull/596

Removes mocking in `TestInference.test_inputs` so that this issue would be caught. 