### PR TITLE
Pin pytorch requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ tifffile
 scikit-image
 networkx<=2.8.8
 suite2p==0.10.2
+torch==1.13.1
 deepinterpolation @ git+https://github.com/danielsf/deepinterpolation@staging/cleaner/ophys_etl


### PR DESCRIPTION
Pin torch to 1.13.1.

The version of suite2p we are using grabs torch version >=1.7.1. There is a more recent version that seems to be causing the issue. Subsequent suite2p releases (latest is 0.14 ours is 0.10.2) pin the version of torch to a similar value. Attempted to update suite2p to 0.14 and 0.11 but found failures in testing one of which is non trivial. Suggest deploying this for now and creating a ticket to bump the suite2p version to 0.14 so we can unpin in our requirements.